### PR TITLE
fix: 消息监听器空消息解引用致 Error in event handler (0.3.1)

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -10,8 +10,10 @@ import { route } from '~/src/engines/router';
 export default defineBackground(() => {
   console.log('[PT] Background service worker started');
 
-  // 首次加载设置并注册变更监听，保持内存副本与 sync 同步
-  settingsReady();
+  // 首次加载设置并注册变更监听，保持内存副本与 sync 同步。
+  // 这里必须吃掉 rejection —— 监听器里逃出去的异常会被 Chrome 记成
+  // 「Error in event handler」，且没有可用堆栈。
+  settingsReady().catch((e) => console.error('[PT] 设置加载失败:', e));
   onSettingsChanged(() => {});
 
   // 暴露给 DevTools Console 用于 DoD 验证
@@ -25,14 +27,22 @@ export default defineBackground(() => {
 
   // Content script 无法直接 fetch 跨域翻译端点，统一在此代理
   chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
-    if (msg.type !== 'pt:translate') return;
+    // msg 可能是 null / 非对象（其它扩展、页面脚本、WXT 自身的内部消息都会
+    // 进到这里）。直接 msg.type 解引用会抛 TypeError，异常逃出监听器后
+    // Chrome 只记一条「Error in event handler」，堆栈是 :0 匿名函数。
+    if (msg?.type !== 'pt:translate') return;
 
-    // SW 休眠后重新唤醒时模块重新求值，await settingsReady()
-    // 保证每次唤醒后的第一条消息也拿到真实设置
-    settingsReady()
-      .then(() => route(msg.payload))
-      .then((r) => sendResponse({ ok: true, data: r }))
-      .catch((e) => sendResponse({ ok: false, error: String(e) }));
+    try {
+      // SW 休眠后重新唤醒时模块重新求值，await settingsReady()
+      // 保证每次唤醒后的第一条消息也拿到真实设置
+      settingsReady()
+        .then(() => route(msg.payload))
+        .then((r) => sendResponse({ ok: true, data: r }))
+        .catch((e) => sendResponse({ ok: false, error: String(e) }));
+    } catch (e) {
+      // 同步抛错也要回给调用方，否则通道悬空到超时
+      sendResponse({ ok: false, error: String(e) });
+    }
 
     return true; // 保持通道开启，否则 sendResponse 静默失效
   });

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -54,27 +54,37 @@ export default defineContentScript({
     }
 
     function showError(el: Element, msg: string): void {
-      // 在页面上给出可见提示，而非静默失败
+      // 在页面上给出可见提示，而非静默失败。
+      // 宿主可能是 XML / SVG 文档，或 body 尚未就绪 —— 取不到挂载点就退回
+      // documentElement，绝不让这里抛错。
+      const host = document.body ?? document.documentElement;
+      if (!host) return;
       const div = document.createElement('div');
       div.textContent = `⚠ Parallel-Translation: ${msg}`;
       div.style.cssText =
         'position:fixed;top:12px;right:12px;' +
         'background:#c0392b;color:#fff;' +
         'padding:8px 14px;border-radius:6px;font-size:13px;z-index:2147483647;';
-      document.body.appendChild(div);
+      host.appendChild(div);
       setTimeout(() => div.remove(), 5000);
     }
 
     // 监听来自 popup 的 toggle 消息
     chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
-      if (msg.type !== 'pt:toggle-translate') return;
+      // msg 可能是 null / 非对象 —— 直接解引用会把 TypeError 抛出监听器，
+      // Chrome 记为「Error in event handler」（堆栈 :0 匿名函数）。
+      if (msg?.type !== 'pt:toggle-translate') return;
 
-      const willTranslate = !translated;
-      (willTranslate
-        ? doTranslate()
-        : Promise.resolve().then(() => doRestore()).then(() => 'restored'))
-        .then((status) => sendResponse({ ok: true, status }))
-        .catch((e: Error) => sendResponse({ ok: false, error: String(e) }));
+      try {
+        const willTranslate = !translated;
+        (willTranslate
+          ? doTranslate()
+          : Promise.resolve().then(() => doRestore()).then(() => 'restored'))
+          .then((status) => sendResponse({ ok: true, status }))
+          .catch((e: Error) => sendResponse({ ok: false, error: String(e) }));
+      } catch (e) {
+        sendResponse({ ok: false, error: String(e) });
+      }
 
       return true; // 保持通道开启
     });

--- a/entrypoints/options/main.ts
+++ b/entrypoints/options/main.ts
@@ -24,4 +24,9 @@ async function init(): Promise<void> {
   onSettingsChanged(() => render());
 }
 
-document.addEventListener('DOMContentLoaded', init);
+document.addEventListener('DOMContentLoaded', () => {
+  init().catch((e) => {
+    console.error('[PT] options 初始化失败:', e);
+    statusDiv.textContent = '设置加载失败，请刷新页面';
+  });
+});

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -65,7 +65,7 @@
     <div id="pt-hint" class="pt-hint" style="display:none"></div>
 
     <footer class="pt-footer">
-      <span>v0.3.0</span>
+      <span>v0.3.1</span>
       <button class="pt-settings-btn" id="pt-settings-btn">设置</button>
     </footer>
   </div>

--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -69,17 +69,25 @@ function syncUI(): void {
 
 // ---- Event handlers ----
 
+/** 写设置失败（配额、sync 不可用）不应变成未处理拒绝。 */
+function savePatch(patch: Parameters<typeof patchSettings>[0]): void {
+  patchSettings(patch).catch((e) => {
+    console.error('[PT] 设置写入失败:', e);
+    showHint('设置保存失败');
+  });
+}
+
 function onToggleClick(): void {
   const s = getSettings();
-  patchSettings({ enabled: !s.enabled });
+  savePatch({ enabled: !s.enabled });
 }
 
 async function onTranslatePageClick(): Promise<void> {
-  const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-  const tabId = tabs[0]?.id;
-  if (tabId == null) return;
-
   try {
+    const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+    const tabId = tabs[0]?.id;
+    if (tabId == null) return;
+
     const resp = await chrome.tabs.sendMessage(tabId, {
       type: 'pt:toggle-translate',
     });
@@ -89,7 +97,10 @@ async function onTranslatePageClick(): Promise<void> {
       showHint('本页没有可翻译的内容');
     }
   } catch {
-    // 页面可能不支持内容脚本（如 chrome:// 页），静默忽略
+    // 页面可能不支持内容脚本（如 chrome:// 页）。
+    // tabs.query 也要罩在里面 —— 它抛出的 rejection 会变成 popup 里的
+    // 未处理拒绝，同样被记成事件处理器错误。
+    showHint('当前页面无法翻译');
   }
 }
 
@@ -113,19 +124,19 @@ function onEngineChange(): void {
     engine,
     ...prev.filter((e) => e !== engine),
   ];
-  patchSettings({ enginePriority: updated });
+  savePatch({ enginePriority: updated });
 }
 
 function onFromChange(): void {
-  patchSettings({ from: fromSelect.value });
+  savePatch({ from: fromSelect.value });
 }
 
 function onToChange(): void {
-  patchSettings({ to: toSelect.value });
+  savePatch({ to: toSelect.value });
 }
 
 function onModeChange(): void {
-  patchSettings({ displayMode: modeSelect.value as 'bilingual' | 'translation-only' });
+  savePatch({ displayMode: modeSelect.value as 'bilingual' | 'translation-only' });
 }
 
 // ---- Init ----
@@ -154,4 +165,9 @@ async function init(): Promise<void> {
   });
 }
 
-document.addEventListener('DOMContentLoaded', init);
+document.addEventListener('DOMContentLoaded', () => {
+  init().catch((e) => {
+    console.error('[PT] popup 初始化失败:', e);
+    showHint('初始化失败，请重新打开');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/storage/settings.ts
+++ b/src/storage/settings.ts
@@ -40,10 +40,19 @@ function merge(stored: Partial<Settings> | undefined): Settings {
  */
 export function settingsReady(): Promise<Settings> {
   if (!ready) {
-    ready = chrome.storage.sync.get(KEY).then((r) => {
-      current = merge(r[KEY]);
-      return current;
-    });
+    ready = chrome.storage.sync
+      .get(KEY)
+      .then((r) => {
+        current = merge(r[KEY]);
+        return current;
+      })
+      .catch((e) => {
+        // 失败的 Promise 不能留在缓存里 —— 否则首次读取一旦失败，
+        // 之后每次 settingsReady() 都拿到同一个 rejected Promise，
+        // 翻译在整个上下文生命周期内永久不可用。
+        ready = null;
+        throw e;
+      });
   }
   return ready;
 }


### PR DESCRIPTION
## 症状

`chrome://extensions` 的错误页报 **Error in event handler**，上下文「未知」，堆栈只有 `:0（匿名函数）`。这是异常逃出扩展事件监听器时 Chrome 的固定记法——它拿不到调用点，所以看不出是谁抛的。

## 成因

两个 `onMessage` 监听器都直接解引用 `msg.type`：

```ts
// background.ts
if (msg.type !== 'pt:translate') return;
// content.ts
if (msg.type !== 'pt:toggle-translate') return;
```

消息为 `null` 或非对象时抛 `TypeError`，异常逃出监听器 → Chrome 记一条 Error in event handler。同一 profile 下的其它扩展、页面脚本、以及 WXT 自身的内部消息（产物里可见 `wxt:content-script-started`、`wxt:locationchange`）都会进到这两个监听器，`msg` 的形状不受我们控制。

## 改动

- **两处监听器**：`msg?.type` + 处理体包 `try/catch`；同步抛错也回 `sendResponse`，不让消息通道悬空到超时
- **`settings.ts`**：首次读取失败不再把 rejected Promise 留在缓存里。原实现一旦首读失败，整个上下文生命周期内 `settingsReady()` 都返回同一个 rejected Promise，翻译永久不可用
- **`content.ts` `showError`**：`document.body` 取不到时退回 `documentElement`（XML / SVG 文档场景）
- **popup**：`patchSettings` 统一走 `savePatch` 捕获拒绝；`tabs.query` 移进 `try`；`init()` 加 `catch`，失败时给可见提示而非静默白屏
- **options**：`init()` 同样加 `catch`

版本号 0.3.0 → 0.3.1（`package.json` 与 popup 页脚同步）。

## 验证

```
pnpm typecheck                  → 0 error
pnpm build                      → 48.7 kB，manifest "version":"0.3.1"，仍无 host_permissions
桩测试 34 条 x 2 组参数           → 全通过
闸门专项 8 条                    → 全通过
settings 专项 3 条（新增）        → 全通过
  S1 首次读取失败如实抛出
  S2 失败后重试能成功（未缓存 rejected Promise）
  S3 重试后内存副本已更新
实网两端点                       → google / bing 均正常
```

产物中两处监听器已是 `(e==null?void 0:e.type)==="pt:translate"` 形态。

## 说明

**这是按症状定位的修复，不是复现后的修复。** 错误卡片没有堆栈，我无法把它对应到具体某一行；上面列的是代码里真实存在、且会产生这一现象的路径。如果装上 0.3.1 后仍然复现，请点错误卡片的「在开发者工具中查看」把堆栈贴出来——有调用点就能直接定位。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
