### PR TITLE
fix: 段落内换行归一化 —— 词组不再被硬换行切断，OpenAI 批量编号不再错位 (v0.6.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 对照式网页翻译浏览器扩展。原文与译文并排呈现，让阅读外语内容不必在两个界面之间来回切换。
 
-Chrome / Edge / Firefox，Manifest V3，当前 v0.6.2。
+Chrome / Edge / Firefox，Manifest V3，当前 v0.6.3。
 
 ## 特性
 

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -7,6 +7,7 @@
 import '~/src/styles/tokens.css';
 import '~/src/styles/presets.css';
 import { collect } from '~/src/dom/walker';
+import { normalizeText } from '~/src/dom/normalize';
 import { startObserver } from '~/src/dom/observer';
 import { render, unrender, applyMode, applyStyle } from '~/src/dom/renderer';
 import { applyCustomCss } from '~/src/styles/custom';
@@ -123,7 +124,8 @@ export default defineContentScript({
       const targets = elements ?? collect();
       if (targets.length === 0) return 'no-elements';
 
-      const texts = targets.map((el) => el.textContent?.trim() ?? '');
+      // 归一化内部空白：硬换行切词、撑破 OpenAI 编号结构都源于未折叠的 \n
+      const texts = targets.map((el) => normalizeText(el.textContent ?? ''));
 
       const resp = await chrome.runtime.sendMessage({
         type: 'pt:translate',
@@ -228,7 +230,7 @@ export default defineContentScript({
       const ns = getSettings();
       if (!ns.enabled) return;
 
-      const text = el.textContent?.trim() ?? '';
+      const text = normalizeText(el.textContent ?? '');
       if (!text) return;
 
       const resp = await chrome.runtime.sendMessage({
@@ -246,6 +248,8 @@ export default defineContentScript({
 
     // ── 翻译选区 ──
     async function translateSelection(text: string): Promise<void> {
+      // 跨行划词时选区文本天然带 \n，入口归一化
+      text = normalizeText(text);
       const ns = getSettings();
       if (!ns.enabled) return;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/compat.ts
+++ b/src/dom/compat.ts
@@ -4,6 +4,8 @@
 //
 // 补丁只做两件事：跳过(skip)、改指(take)。不在此处写翻译逻辑或 DOM 操作。
 
+import { normalizeText } from './normalize';
+
 type CompatResult =
   | { skip: true }
   | { take: Element }
@@ -55,7 +57,7 @@ const HANDLERS: Record<string, CompatHandler> = {
     }
     // 独立的行内 code 在非 pre 上下文中通常是变量名/hash
     if (el.tagName === 'CODE' && !el.closest('pre, .blob-code')) {
-      const text = el.textContent?.trim() ?? '';
+      const text = normalizeText(el.textContent ?? '');
       // 短 hash / 变量名 / 数字 不翻
       if (/^[a-f0-9]{7,40}$/.test(text) || /^[._a-zA-Z]\w*$/.test(text) || /^\d+$/.test(text)) {
         return { skip: true };

--- a/src/dom/normalize.ts
+++ b/src/dom/normalize.ts
@@ -1,0 +1,14 @@
+// Phase 9 — 取文本前的空白归一化（纯函数，无 DOM 依赖）。
+//
+// Markdown 段落内的软换行会原样保留为文本节点里的 \n（GitHub README 等
+// 源文件硬换行的页面最典型）。直接把 \n 送进引擎有两个后果：
+// - Google 引擎在 \n 处切句，跨换行的词组被拆开各自翻译（"atomic
+//   replacement" → "原子" + "替换"），join 后 \n 原样保留进 DOM，
+//   HTML 空白折叠渲染成多余空格
+// - OpenAI 引擎用换行分隔编号条目，文本自带的 \n 会把编号结构撑破，
+//   续行无编号，LLM 重编号后 parseNumbered 回填错位
+//
+// 统一在取文本处折叠空白：\s+ → 单个空格，再 trim 首尾。
+export function normalizeText(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}

--- a/src/engines/openai.ts
+++ b/src/engines/openai.ts
@@ -4,6 +4,7 @@
 
 import { getKey } from '~/src/storage/keys';
 import { getSettings } from '~/src/storage/settings';
+import { normalizeText } from '~/src/dom/normalize';
 import { EngineError } from './types';
 import type { TranslateEngine } from './types';
 
@@ -35,7 +36,11 @@ export const openai: TranslateEngine = {
 
     const model = getSettings().models?.openai ?? 'gpt-4o-mini';
 
-    const numbered = texts.map((t, i) => `${i + 1}. ${t}`).join('\n');
+    // 纵深防御：编号结构靠 \n 分隔，文本自带的换行会把编号撑破导致错位。
+    // 即便入口采集漏了归一化，这里也必须兜住，拼 prompt 前再压一次。
+    const numbered = texts
+      .map((t, i) => `${i + 1}. ${normalizeText(t)}`)
+      .join('\n');
     const prompt =
       `将以下编号文本翻译成${to}${from === 'auto' ? '' : `（源语言：${from}）`}。` +
       `严格保持编号与行数一致，只输出译文，不要解释。\n\n${numbered}`;


### PR DESCRIPTION
修复 #16

## 变更

新增共用函数 `normalizeText`（`src/dom/normalize.ts`）：`\s+ → 单空格 + trim`。统一覆盖四处取文本入口：

- **整页翻译** `doTranslate`（`entrypoints/content.ts`）—— 核心修复点，此前只有 `trim()`，段落中间的 `\n` 原样送进引擎
- **单段翻译** `translateOne` —— 另一条只 `trim()` 的路径
- **跨行划词** `translateSelection` —— 选区文本天然带 `\n`
- **compat CODE 判定** —— 与其余三处统一走同一函数

纵深防御：`openai.ts` 拼 prompt 前对每条 text 再兜底归一化一次，防止将来新增取文本路径再漏。

## 验证

- `pnpm typecheck` 通过
- 复现 issue 错位场景实证：修复前 `parseNumbered('1. …原子\n2. 替换…3. …', 2)` 返回第 1 段下半句给第 2 段；归一化后编号结构完整（每行都有编号），LLM 回译逐段对应
- `normalizeText(' uses atomic\nreplacement, and\r\n restores state. ')` → `"uses atomic replacement, and restores state."`

## 已知取舍

- **缓存键**：归一化前后同一段文本 key 变化，老缓存条目一次性 miss，接受
- **`<pre>`/`<code>`**：在 `SKIP_SET` 内不参与翻译，归一化不影响代码缩进

## 真机验证建议

- 打开任意源文件硬换行的 GitHub README，确认译文不再出现词组中间的空格（`atomic replacement` 作为整体翻译）
- 切 OpenAI 引擎翻译长页面，确认译文与段落一一对应
- 跨行划词翻译确认正常