### PR TITLE
fix: 整卡点击覆盖层（stretched link）下段落按钮兜底浮出 (v0.6.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 对照式网页翻译浏览器扩展。原文与译文并排呈现，让阅读外语内容不必在两个界面之间来回切换。
 
-Chrome / Edge / Firefox，Manifest V3，当前 v0.6.3。
+Chrome / Edge / Firefox，Manifest V3，当前 v0.6.4。
 
 ## 特性
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/ui/paragraph-btn.ts
+++ b/src/ui/paragraph-btn.ts
@@ -36,6 +36,9 @@ const GAP = 4;
 /** 钳制到视口内时留的边距 */
 const MARGIN = 4;
 
+/** 段落按钮的可翻译标签（与 DIRECT_SET 的块级正文一致，不含表格单元格） */
+const DIRECT = 'p,li,dd,blockquote,h1,h2,h3,h4,h5,h6';
+
 export function createParaBtn(translateOne: TranslateOneFn): () => void {
   const shadow = mountIsolated('para-btn');
   const btn = document.createElement('button');
@@ -47,8 +50,6 @@ export function createParaBtn(translateOne: TranslateOneFn): () => void {
   let target: Element | null = null;
   let hideTimer: number | undefined;
   let showTimer: number | undefined;
-
-  const DIRECT = 'p,li,dd,blockquote,h1,h2,h3,h4,h5,h6';
 
   const isOurUi = (n: EventTarget | null): boolean =>
     n instanceof Element && !!n.closest?.('[data-pt-ui="1"]');
@@ -85,8 +86,37 @@ export function createParaBtn(translateOne: TranslateOneFn): () => void {
   };
 
   const onMouseOver = (e: MouseEvent) => {
-    const el = (e.target as Element)?.closest?.(DIRECT);
-    if (!el || el.closest('[data-pt-ui="1"]')) return;
+    const hit = (e.target as Element)?.closest?.(DIRECT);
+    if (hit) {
+      scheduleShow(hit);
+      return;
+    }
+
+    // 整卡点击覆盖层（stretched link）的兜底：命中测试落在铺满卡片的
+    // 伪元素上，而伪元素算到产生它的祖先 <a> —— closest() 只向上找，
+    // 够不到被盖住的后代段落（h2/p）。
+    //
+    // elementsFromPoint() 会强制同步布局，所以不在这里直接跑，而是
+    // 设进 SHOW_DELAY 的悬停意图计时器：鼠标划过空白区时计时器每次
+    // 都被重置，只有真正停住才会执行 —— 划过的路上零布局成本。
+    const x = e.clientX;
+    const y = e.clientY;
+    clearTimeout(showTimer);
+    showTimer = self.setTimeout(() => {
+      const el = findUnderOverlay(x, y);
+      if (!el) return;
+      clearTimeout(hideTimer);
+      show(el);
+    }, SHOW_DELAY);
+  };
+
+  /**
+   * 命中段落 → 计划浮出按钮（停住 SHOW_DELAY 才真正浮出）。
+   * 路过时后一次 mouseover 会把前一段的计时重置掉，于是一路划过去
+   * 一次都不弹。
+   */
+  const scheduleShow = (el: Element) => {
+    if (el.closest('[data-pt-ui="1"]')) return;
     if (el.getAttribute('data-pt') === 'done') return;
 
     clearTimeout(hideTimer);
@@ -94,8 +124,6 @@ export function createParaBtn(translateOne: TranslateOneFn): () => void {
     // 已经停在这一段上了 —— 段落内部换子元素不重定位，省掉无谓的强制布局
     if (el === target && isVisible()) return;
 
-    // 悬停意图：停住 SHOW_DELAY 才浮出。路过时后一次 mouseover 会把
-    // 前一段的计时重置掉，于是一路划过去一次都不弹。
     clearTimeout(showTimer);
     showTimer = self.setTimeout(() => show(el), SHOW_DELAY);
   };
@@ -140,6 +168,25 @@ export function createParaBtn(translateOne: TranslateOneFn): () => void {
     window.removeEventListener('resize', onReflow);
     unmountIsolated('para-btn');
   };
+}
+
+/**
+ * 沿 elementsFromPoint 的命中栈找被覆盖层遮住的段落（stretched link 兜底）。
+ * 命中栈按 z 序从顶层元素排到 <html>，被伪元素盖住的后代段落也在栈里 ——
+ * 对每层做 closest(DIRECT)，即可捞到覆盖层下方的 h2/p。
+ *
+ * 只取前 8 层：覆盖层 → 卡片容器 → 标题包裹层 → 段落的典型结构在
+ * 3~5 层内，更深处在深层嵌套页面上会捞到远处无关元素。
+ */
+function findUnderOverlay(x: number, y: number): Element | null {
+  const stack = document.elementsFromPoint(x, y);
+  for (const n of stack.slice(0, 8)) {
+    const el = n.closest?.(DIRECT);
+    if (!el || el.closest('[data-pt-ui="1"]')) continue;
+    if (el.getAttribute('data-pt') === 'done') continue;
+    return el;
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
修复 #17

## 变更

`src/ui/paragraph-btn.ts`：`closest(DIRECT)` 未命中时，走 `elementsFromPoint()` 兜底 —— 命中栈按 z 序包含被伪元素盖住的段落，逐层 `closest(DIRECT)` 捞回覆盖层下方的 `h2`/`p`。通用修法，不只对 BBC 生效（stretched link 是新闻站、电商列表页的常见卡片写法）。

### 两个确认点

1. **性能**：`elementsFromPoint()` 会强制同步布局，**没有**在 mouseover 里直接跑，而是放进 `SHOW_DELAY`（140ms）的悬停意图计时器 —— 鼠标划过空白区时计时器每次都被重置，只有真正停住才执行，划过的路上零布局成本。
2. **栈深度**：只取命中栈前 8 层（覆盖层 → 卡片容器 → 标题包裹层 → 段落的典型结构在 3~5 层内），避免深层嵌套页面误命中远处元素。

### 点击可用性

经确认无需改动：挂载点 host 已是 `z-index: 2147483647`（`mount.ts`），远高于 BBC 覆盖层的 990，按钮浮出后点击不会被卡片吃掉。

## 验证（jsdom 集成测试，5/5 PASS）

- A. stretched link 悬停标题（命中栈顶层是 `<a>`）→ 按钮浮出 
- B. 普通段落悬停（原路径回归）→ 按钮浮出 
- C. 空白区域 → 按钮不浮出 
- D. 覆盖层下已翻译段落（`data-pt="done"`）→ 不浮出 
- E. 快速划过空白 → `elementsFromPoint` 仅触发 1 次（划过期间 0 次布局）

`pnpm typecheck` 通过。

## 真机验证建议

- bbc.com 首页悬停中间头条的标题与摘要，确认按钮浮出且能点到、点击不连带卡片跳转
- 回归其它卡片与普通文章页，确认按钮行为无变化