### PR TITLE
fix: 单段翻译后可还原 —— 段落按钮双向切换，翻译态以真实 DOM 为准 (v0.6.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 对照式网页翻译浏览器扩展。原文与译文并排呈现，让阅读外语内容不必在两个界面之间来回切换。
 
-Chrome / Edge / Firefox，Manifest V3，当前 v0.6.4。
+Chrome / Edge / Firefox，Manifest V3，当前 v0.6.5。
 
 ## 特性
 

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -35,7 +35,6 @@ export default defineContentScript({
     detectOS(); // 预热平台缓存
     const s = getSettings();
 
-    let translated = false;
     let stopObserving: (() => void) | null = null;
     let stopHotkeys: (() => void) | null = null;
     let stopDrag: (() => void) | null = null;
@@ -56,7 +55,10 @@ export default defineContentScript({
       }
 
       if (s.showParagraphBtn) {
-        stopParaBtn = createParaBtn((el) => translateOne(el));
+        stopParaBtn = createParaBtn({
+          translate: (el) => translateOne(el),
+          restore: (el) => unrender(el),
+        });
       }
     }
 
@@ -106,7 +108,10 @@ export default defineContentScript({
 
         // 段落按钮开关
         if (ns.showParagraphBtn && !stopParaBtn) {
-          stopParaBtn = createParaBtn((el) => translateOne(el));
+          stopParaBtn = createParaBtn({
+          translate: (el) => translateOne(el),
+          restore: (el) => unrender(el),
+        });
         } else if (!ns.showParagraphBtn && stopParaBtn) {
           stopParaBtn();
           stopParaBtn = null;
@@ -170,18 +175,35 @@ export default defineContentScript({
       for (const el of els) {
         unrender(el);
       }
-      translated = false;
+    }
+
+    /**
+     * 页面上是否存在已翻译段落（带 shadow 穿透，短路返回）。
+     * 翻译态以真实 DOM 为准而不是布尔标志：单段翻译（translateOne）与
+     * observer 增量补翻都会落 data-pt="done"，只有整页翻译会记布尔，
+     * 仅查标志会把「页面上已有译文」误判成「没翻过」，toggle 走错分支。
+     */
+    function hasTranslated(): boolean {
+      const walk = (root: ParentNode): boolean => {
+        if (root.querySelector('[data-pt="done"]')) return true;
+        for (const el of root.querySelectorAll('*')) {
+          const sr = (el as Element).shadowRoot;
+          if (sr && walk(sr)) return true;
+        }
+        return false;
+      };
+      return walk(document);
     }
 
     /**
      * 翻译 / 还原的单一入口 —— 悬浮球、快捷键、popup 三条路径共用。
      *
-     * 翻译态（`translated` + observer）是整个 frame 共享的一份状态，
-     * 任何入口各自记一份都会导致「按了没反应」或「重复翻一遍」。
+     * 翻译态（DOM 上是否存在译文 + observer）是整个 frame 共享的一份
+     * 状态，任何入口各自记一份都会导致「按了没反应」或「重复翻一遍」。
      * 悬浮球的视觉由这里通过 setBallState 单向推送。
      */
     async function togglePage(): Promise<string> {
-      if (translated) {
+      if (hasTranslated()) {
         doRestore();
         if (isMainFrame) setBallState('idle');
         return 'restored';
@@ -201,7 +223,6 @@ export default defineContentScript({
       }
 
       if (status === 'translated') {
-        translated = true;
         // 增量补翻对三个入口一视同仁 —— 无限滚动/SPA 不该因为
         // 用户点的是悬浮球而失效
         if (!stopObserving) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -144,6 +144,8 @@
   "ballGlyph": { "message": "T" },
   "paraBtnGlyph": { "message": "T" },
   "paraBtnLabel": { "message": "Translate this paragraph" },
+  "paraBtnRestoreGlyph": { "message": "R" },
+  "paraBtnRestoreLabel": { "message": "Restore this paragraph" },
   "toastExtOn": { "message": "Extension enabled" },
   "toastExtOff": { "message": "Extension disabled" },
   "toastAllEnginesFail": { "message": "All engines failed" },

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -144,6 +144,8 @@
   "ballGlyph": { "message": "译" },
   "paraBtnGlyph": { "message": "译" },
   "paraBtnLabel": { "message": "翻译此段" },
+  "paraBtnRestoreGlyph": { "message": "原" },
+  "paraBtnRestoreLabel": { "message": "还原此段" },
   "toastExtOn": { "message": "扩展已开启" },
   "toastExtOff": { "message": "扩展已关闭" },
   "toastAllEnginesFail": { "message": "所有引擎均失败" },

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -144,6 +144,8 @@
   "ballGlyph": { "message": "譯" },
   "paraBtnGlyph": { "message": "譯" },
   "paraBtnLabel": { "message": "翻譯此段" },
+  "paraBtnRestoreGlyph": { "message": "原" },
+  "paraBtnRestoreLabel": { "message": "還原此段" },
   "toastExtOn": { "message": "擴充功能已開啟" },
   "toastExtOff": { "message": "擴充功能已關閉" },
   "toastAllEnginesFail": { "message": "所有引擎均失敗" },

--- a/src/ui/paragraph-btn.ts
+++ b/src/ui/paragraph-btn.ts
@@ -6,6 +6,13 @@ import { mountIsolated, unmountIsolated } from './mount';
 import { tf } from '../i18n';
 
 type TranslateOneFn = (el: Element) => Promise<void>;
+type RestoreOneFn = (el: Element) => void;
+
+/** 段落按钮的回调：按目标段落当前的翻译态分流 */
+interface ParaBtnHandlers {
+  translate: TranslateOneFn;
+  restore: RestoreOneFn;
+}
 
 /**
  * 离开段落后的隐藏延迟。
@@ -39,11 +46,11 @@ const MARGIN = 4;
 /** 段落按钮的可翻译标签（与 DIRECT_SET 的块级正文一致，不含表格单元格） */
 const DIRECT = 'p,li,dd,blockquote,h1,h2,h3,h4,h5,h6';
 
-export function createParaBtn(translateOne: TranslateOneFn): () => void {
+export function createParaBtn(handlers: ParaBtnHandlers): () => void {
+  const { translate, restore } = handlers;
   const shadow = mountIsolated('para-btn');
   const btn = document.createElement('button');
   btn.className = 'pt-para-btn';
-  btn.textContent = tf('paraBtnGlyph', '译');
   btn.setAttribute('aria-label', tf('paraBtnLabel', '翻译此段'));
   shadow.appendChild(btn);
 
@@ -64,6 +71,17 @@ export function createParaBtn(translateOne: TranslateOneFn): () => void {
       btn.style.opacity = '0';
     }
     target = el;
+
+    // 双向切换：已翻译段落浮出「还原」态按钮，否则是「翻译」态。
+    // 文案与 aria-label 随态切换（走 i18n，不硬编码）。
+    const done = el.getAttribute('data-pt') === 'done';
+    btn.textContent = done
+      ? tf('paraBtnRestoreGlyph', '原')
+      : tf('paraBtnGlyph', '译');
+    btn.setAttribute(
+      'aria-label',
+      done ? tf('paraBtnRestoreLabel', '还原此段') : tf('paraBtnLabel', '翻译此段'),
+    );
 
     // position() 内部读 getBoundingClientRect 会强制一次布局，把上面的
     // opacity: 0 与 display: block 一并提交，随后置 1 才会真正走过渡。
@@ -117,7 +135,6 @@ export function createParaBtn(translateOne: TranslateOneFn): () => void {
    */
   const scheduleShow = (el: Element) => {
     if (el.closest('[data-pt-ui="1"]')) return;
-    if (el.getAttribute('data-pt') === 'done') return;
 
     clearTimeout(hideTimer);
 
@@ -153,7 +170,11 @@ export function createParaBtn(translateOne: TranslateOneFn): () => void {
   window.addEventListener('resize', onReflow, { passive: true });
 
   btn.addEventListener('click', () => {
-    if (target) translateOne(target);
+    if (!target) return;
+    // 按目标段落当前的翻译态分流：已翻译 → 还原，否则 → 翻译。
+    // 翻译/还原完成后按钮隐藏，下次悬停按新状态重新判定。
+    if (target.getAttribute('data-pt') === 'done') restore(target);
+    else translate(target);
     clearTimeout(showTimer);
     clearTimeout(hideTimer);
     btn.style.display = 'none';
@@ -183,7 +204,6 @@ function findUnderOverlay(x: number, y: number): Element | null {
   for (const n of stack.slice(0, 8)) {
     const el = n.closest?.(DIRECT);
     if (!el || el.closest('[data-pt-ui="1"]')) continue;
-    if (el.getAttribute('data-pt') === 'done') continue;
     return el;
   }
   return null;


### PR DESCRIPTION
修复 #18

## 变更

### A. 段落按钮双向切换（`src/ui/paragraph-btn.ts`）

已翻译段落不再屏蔽，浮出「还原」态按钮：

- 按钮文案 / aria-label 随目标段落翻译态切换：“译”↔“原”（新增 i18n key `paraBtnRestoreGlyph` / `paraBtnRestoreLabel`，三个 locale）
- 点击按态分流：`done` → `unrender(el)` 就地还原，否则翻译
- `findUnderOverlay`（#17 兜底路径）同步去掉 done 过滤

### B. 翻译态以真实 DOM 为准（`entrypoints/content.ts`）

`togglePage()` 改查 `hasTranslated()`（`[data-pt="done"]` 查询 + shadow 穿透短路返回）替代布尔标志。`translated` 变量删除 —— 单段翻译、observer 增量补翻都会落 `data-pt="done"`，只有整页翻译会记布尔，仅查标志会把「页面上已有译文」误判成「没翻过」。

## 确认点

1. **悬浮球状态**：表示“整页翻译”态。单段翻译不改动它（事实相符）；部分翻译时 toggle 即还原全部已翻段落
2. **observer**：`doRestore` 的 `stopObserving` 已有 null 判断，单段还原不会误停
3. **划词翻译**：走 toast 不落 DOM，不受影响

## 验证（jsdom 集成测试，12/12 PASS）

- 未翻译段落 → “译”按钮 → translate 
- 已翻译段落 → 按钮仍浮出、文案切“原”→ restore 
- 还原后按钮回“译”态 
- `hasTranslated`：空页 false / 有译文 true / shadow 内译文穿透 true / 全还原 false 

`pnpm typecheck` 通过。

## 真机验证建议

- 单段翻译后悬停该段 → 浮出还原按钮，点击后原文回来、`data-pt` 清除
- 单段翻译后按全局还原快捷键 → 是还原而不是整页翻译
- 混合场景：先翻两段 → 整页翻译 → toggle，确认全部还原干净、无残留 `.pt-origin` / `.pt-trans`