### PR TITLE
fix: Google 搜索 div 型正文可单段翻译 —— 按钮复用采集器判定，来源角标不进入译文 (v0.6.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 对照式网页翻译浏览器扩展。原文与译文并排呈现，让阅读外语内容不必在两个界面之间来回切换。
 
-Chrome / Edge / Firefox，Manifest V3，当前 v0.6.5。
+Chrome / Edge / Firefox，Manifest V3，当前 v0.6.6。
 
 ## 特性
 

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -7,7 +7,9 @@
 import '~/src/styles/tokens.css';
 import '~/src/styles/presets.css';
 import { collect } from '~/src/dom/walker';
+import { closestUnit } from '~/src/dom/classify';
 import { normalizeText } from '~/src/dom/normalize';
+import { translatableText } from '~/src/dom/text';
 import { startObserver } from '~/src/dom/observer';
 import { render, unrender, applyMode, applyStyle } from '~/src/dom/renderer';
 import { applyCustomCss } from '~/src/styles/custom';
@@ -129,8 +131,9 @@ export default defineContentScript({
       const targets = elements ?? collect();
       if (targets.length === 0) return 'no-elements';
 
-      // 归一化内部空白：硬换行切词、撑破 OpenAI 编号结构都源于未折叠的 \n
-      const texts = targets.map((el) => normalizeText(el.textContent ?? ''));
+      // 归一化内部空白：硬换行切词、撑破 OpenAI 编号结构都源于未折叠的 \n。
+      // translatableText 剔除 .notranslate 与站点元数据（如 Google 来源角标）。
+      const texts = targets.map((el) => normalizeText(translatableText(el)));
 
       const resp = await chrome.runtime.sendMessage({
         type: 'pt:translate',
@@ -251,7 +254,14 @@ export default defineContentScript({
       const ns = getSettings();
       if (!ns.enabled) return;
 
-      const text = normalizeText(el.textContent ?? '');
+      // 提级到最近的可翻单元：按钮路径传来的已是精判通过的单元（原样返回）；
+      // 快捷键路径拿的是选区起点的 parentElement，可能是 span 等内联元素，
+      // 由这里统一向上找整段。找不到（超长 / .notranslate / 非正文区 /
+      // 已翻译）则 shouldSkip 已拦下，不翻。
+      const unit = closestUnit(el);
+      if (!unit) return;
+
+      const text = normalizeText(translatableText(unit));
       if (!text) return;
 
       const resp = await chrome.runtime.sendMessage({
@@ -264,7 +274,7 @@ export default defineContentScript({
         return;
       }
 
-      render(el, resp.data.translations[0]);
+      render(unit, resp.data.translations[0]);
     }
 
     // ── 翻译选区 ──

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/classify.ts
+++ b/src/dom/classify.ts
@@ -13,6 +13,15 @@ export const DIRECT_SET = new Set([
   'td', 'th', 'caption', 'summary',
 ]);
 
+/**
+ * div 型正文容器：直接持有文本时本身即为翻译单元（#19）。
+ * Google 搜索摘要、AI 概览等现代站点把正文层层裹在 div 里，白名单
+ * 永远选不中 —— 按钮不浮出、采集器也不收集。此集合在标签之外放行。
+ */
+export const CONTAINER_SET = new Set([
+  'div', 'section', 'article', 'main', 'figure',
+]);
+
 /** 整棵子树跳过，不再深入 */
 export const SKIP_SET = new Set([
   'html', 'body', 'script', 'style', 'noscript',
@@ -71,10 +80,17 @@ function isMainlyNumeric(text: string): boolean {
  * 判定元素是否是一个完整的翻译单元。
  * 核心规则：若子元素中存在非内联且带文本的元素，
  * 说明文本还在更深层，当前节点不是叶子翻译单元。
+ *
+ * div 型正文（CONTAINER_SET）走同一套规则，只多一道门槛：必须直接持有
+ * 文本 —— 纯壳容器（文本全在更深层）不算。两条规则对称，祖先与后代
+ * 不会同时成单元，无需额外去重。
  */
 export function isTranslationUnit(el: Element): boolean {
   const tag = el.tagName.toLowerCase();
-  if (!DIRECT_SET.has(tag)) return false;
+  const isContainer = CONTAINER_SET.has(tag);
+
+  if (isContainer && directTextLength(el) === 0) return false;
+  if (!DIRECT_SET.has(tag) && !isContainer) return false;
 
   for (const child of el.children) {
     const childTag = child.tagName.toLowerCase();
@@ -84,4 +100,31 @@ export function isTranslationUnit(el: Element): boolean {
     if (child.textContent?.trim()) return false;
   }
   return true;
+}
+
+/** 直接子文本节点的字符数（不深入子元素）。div 型正文判定的依据 */
+function directTextLength(el: Element): number {
+  let len = 0;
+  for (const node of el.childNodes) {
+    if (node.nodeType === Node.TEXT_NODE) len += (node.textContent ?? '').length;
+  }
+  return len;
+}
+
+/**
+ * 从 el（含自身）向上找最近的翻译单元（isTranslationUnit + shouldSkip）。
+ * 按钮路径与 translateOne 共用 —— 判定标准与采集器同一套，不再各立门户，
+ * 白名单之外的大容器（如 AI 概览的外层 li）不会再被错误命中。
+ *
+ * shouldSkip 有强制同步布局的昂贵步骤（outerHTML、getBoundingClientRect），
+ * 只应在低频率路径调用：悬停意图计时器、点击/快捷键入口，不能挂在
+ * 每次 mouseover 上。
+ */
+export function closestUnit(el: Element): Element | null {
+  let cur: Element | null = el;
+  while (cur) {
+    if (isTranslationUnit(cur) && !shouldSkip(cur)) return cur;
+    cur = cur.parentElement;
+  }
+  return null;
 }

--- a/src/dom/compat.ts
+++ b/src/dom/compat.ts
@@ -13,6 +13,8 @@ type CompatResult =
 
 type CompatHandler = (el: Element) => CompatResult;
 
+type OmitHandler = (el: Element) => boolean;
+
 /**
  * 取主域名（末两段）。
  * news.ycombinator.com → ycombinator.com
@@ -70,5 +72,24 @@ const HANDLERS: Record<string, CompatHandler> = {
 export function applyCompat(el: Element): CompatResult {
   const handler = HANDLERS[mainDomain(location.hostname)];
   if (!handler) return null;
+  return handler(el);
+}
+
+/**
+ * 提取文本时应剔除的站点元数据（来源角标、计数 chip 等 UI 碎片）。
+ * 与 skip 的区别：skip 影响采集器是否收集该节点，这里影响已收集单元的
+ * 文本内容 —— AI 概览的来源角标是行内元素，永远当不成单元，只能从
+ * 文本层面剔除。
+ *
+ * 类名来自社区抓包记录而非官方文档，Google 改版可能失效 —— 失效只是
+ * 噪声回退（chip 文本重新进入译文），不会翻错。
+ */
+const OMIT_HANDLERS: Record<string, OmitHandler> = {
+  'google.com': (el: Element) => el.matches('span.wJwe6c, .WTfRgd'),
+};
+
+export function shouldOmitText(el: Element): boolean {
+  const handler = OMIT_HANDLERS[mainDomain(location.hostname)];
+  if (!handler) return false;
   return handler(el);
 }

--- a/src/dom/text.ts
+++ b/src/dom/text.ts
@@ -1,0 +1,30 @@
+// Phase 9 — 提取可翻译文本（跳过 .notranslate 与站点元数据子树）。
+//
+// 单元文本不能直接取 textContent：Google AI 概览的来源角标（chip）是
+// UI 元数据不是正文，混进译文就是「YouTube·Tech +2」这类噪声。规则分两层：
+// - .notranslate 类：HTML 标准约定（Google 翻译同样尊重），通用
+// - shouldOmitText()：域名补丁（compat.ts），站点的特定元数据
+
+import { shouldOmitText } from './compat';
+
+/**
+ * 提取元素的全部可翻译文本：递归遍历子节点，跳过 .notranslate 与
+ * 站点元数据子树。无忽略规则时与 textContent 等价。
+ */
+export function translatableText(el: Element): string {
+  let out = '';
+  const walk = (node: Node) => {
+    for (const child of node.childNodes) {
+      if (child.nodeType === Node.TEXT_NODE) {
+        out += child.textContent ?? '';
+      } else if (child.nodeType === Node.ELEMENT_NODE) {
+        const c = child as Element;
+        if (c.classList.contains('notranslate')) continue;
+        if (shouldOmitText(c)) continue;
+        walk(c);
+      }
+    }
+  };
+  walk(el);
+  return out;
+}

--- a/src/ui/paragraph-btn.ts
+++ b/src/ui/paragraph-btn.ts
@@ -3,6 +3,7 @@
 // 单个按钮实例复用，随鼠标在段落间移动，不为每段各建一个。
 
 import { mountIsolated, unmountIsolated } from './mount';
+import { closestUnit } from '../dom/classify';
 import { tf } from '../i18n';
 
 type TranslateOneFn = (el: Element) => Promise<void>;
@@ -43,8 +44,16 @@ const GAP = 4;
 /** 钳制到视口内时留的边距 */
 const MARGIN = 4;
 
-/** 段落按钮的可翻译标签（与 DIRECT_SET 的块级正文一致，不含表格单元格） */
-const DIRECT = 'p,li,dd,blockquote,h1,h2,h3,h4,h5,h6';
+/**
+ * 段落按钮的候选选择器：可翻译块级正文 + div 型正文容器。
+ * 只做便宜的初筛 —— closest() 命中后，真正的判定（isTranslationUnit +
+ * shouldSkip，与采集器同一套）在 SHOW_DELAY 计时器回调里做：
+ * shouldSkip 拼 outerHTML、调 getBoundingClientRect 会强制同步布局，
+ * 不能挂在每次 mouseover 上。
+ */
+const CANDIDATE =
+  'p,li,dd,blockquote,h1,h2,h3,h4,h5,h6,' +
+  'div,section,article,main,figure';
 
 export function createParaBtn(handlers: ParaBtnHandlers): () => void {
   const { translate, restore } = handlers;
@@ -104,45 +113,39 @@ export function createParaBtn(handlers: ParaBtnHandlers): () => void {
   };
 
   const onMouseOver = (e: MouseEvent) => {
-    const hit = (e.target as Element)?.closest?.(DIRECT);
-    if (hit) {
-      scheduleShow(hit);
-      return;
-    }
-
-    // 整卡点击覆盖层（stretched link）的兜底：命中测试落在铺满卡片的
-    // 伪元素上，而伪元素算到产生它的祖先 <a> —— closest() 只向上找，
-    // 够不到被盖住的后代段落（h2/p）。
-    //
-    // elementsFromPoint() 会强制同步布局，所以不在这里直接跑，而是
-    // 设进 SHOW_DELAY 的悬停意图计时器：鼠标划过空白区时计时器每次
-    // 都被重置，只有真正停住才会执行 —— 划过的路上零布局成本。
+    // 便宜初筛：候选选择器向上找最近的段落/容器。Google 搜索摘要等
+    // div 型正文不在旧的 p/li/h* 白名单里 —— 候选放宽到正文容器，
+    // 判定精度交给计时器里的 closestUnit()。
+    const hit = (e.target as Element)?.closest?.(CANDIDATE);
     const x = e.clientX;
     const y = e.clientY;
     clearTimeout(showTimer);
     showTimer = self.setTimeout(() => {
-      const el = findUnderOverlay(x, y);
+      // 悬停意图确认后才做精判。命中测试与 elementsFromPoint 都会强制
+      // 同步布局（shouldSkip 拼 outerHTML、调 getBoundingClientRect），
+      // 鼠标划过时计时器每次都被重置、只有真正停住才执行 ——
+      // 划过的路上零布局成本。
+      //
+      // 自己的 UI（悬浮球等）不触发按钮；兜底找覆盖层也不能越过 UI。
+      if (hit && hit.closest('[data-pt-ui="1"]')) return;
+
+      // 精判（isTranslationUnit + shouldSkip）：按钮与采集器同一套标准，
+      // 白名单之外的大容器（如 AI 概览的外层 li）不会再被错误命中。
+      let el = hit ? closestUnit(hit) : null;
+      if (!el) {
+        // 整卡点击覆盖层（stretched link）的兜底：命中测试落在铺满卡片
+        // 的伪元素上，而伪元素算到产生它的祖先 <a> —— closest() 只向上
+        // 找，够不到被盖住的后代段落（h2/p）。
+        el = findUnderOverlay(x, y);
+      }
       if (!el) return;
+
+      // 已经停在这一段上了 —— 段落内部换子元素不重定位，省掉无谓的强制布局
+      if (el === target && isVisible()) return;
+
       clearTimeout(hideTimer);
       show(el);
     }, SHOW_DELAY);
-  };
-
-  /**
-   * 命中段落 → 计划浮出按钮（停住 SHOW_DELAY 才真正浮出）。
-   * 路过时后一次 mouseover 会把前一段的计时重置掉，于是一路划过去
-   * 一次都不弹。
-   */
-  const scheduleShow = (el: Element) => {
-    if (el.closest('[data-pt-ui="1"]')) return;
-
-    clearTimeout(hideTimer);
-
-    // 已经停在这一段上了 —— 段落内部换子元素不重定位，省掉无谓的强制布局
-    if (el === target && isVisible()) return;
-
-    clearTimeout(showTimer);
-    showTimer = self.setTimeout(() => show(el), SHOW_DELAY);
   };
 
   const onMouseOut = (e: MouseEvent) => {
@@ -194,7 +197,8 @@ export function createParaBtn(handlers: ParaBtnHandlers): () => void {
 /**
  * 沿 elementsFromPoint 的命中栈找被覆盖层遮住的段落（stretched link 兜底）。
  * 命中栈按 z 序从顶层元素排到 <html>，被伪元素盖住的后代段落也在栈里 ——
- * 对每层做 closest(DIRECT)，即可捞到覆盖层下方的 h2/p。
+ * 对每层做 closest(CANDIDATE) 再 closestUnit() 精判，即可捞到覆盖层
+ * 下方可翻的 h2/p/div 型正文。
  *
  * 只取前 8 层：覆盖层 → 卡片容器 → 标题包裹层 → 段落的典型结构在
  * 3~5 层内，更深处在深层嵌套页面上会捞到远处无关元素。
@@ -202,9 +206,10 @@ export function createParaBtn(handlers: ParaBtnHandlers): () => void {
 function findUnderOverlay(x: number, y: number): Element | null {
   const stack = document.elementsFromPoint(x, y);
   for (const n of stack.slice(0, 8)) {
-    const el = n.closest?.(DIRECT);
+    const el = n.closest?.(CANDIDATE);
     if (!el || el.closest('[data-pt-ui="1"]')) continue;
-    return el;
+    const unit = closestUnit(el);
+    if (unit) return unit;
   }
   return null;
 }


### PR DESCRIPTION
## 修复内容（#19）

### A. div 型正文可被识别

`isTranslationUnit()` 新增兜底（`CONTAINER_SET`：`div/section/article/main/figure`）：容器**直接持有文本**且子元素中无非内联带文本元素时，本身即为翻译单元。规则与 `DIRECT_SET` 完全对称 —— 祖先与后代不会同时成单元，无需额外去重，也不需要「直接文本占比」阈值。

Google 搜索摘要（`div.VwiC3b` 类结构）、AI 概览摘要段等 div 型正文从此可被采集，悬停按钮可浮出。

### B. 按钮复用采集器判定

- 按钮候选选择器放宽到正文容器，`SHOW_DELAY` 计时器回调里用 `closestUnit()`（`isTranslationUnit` + `shouldSkip`，与采集器同一套）精判 —— `shouldSkip` 的昂贵步骤（outerHTML、getBoundingClientRect 强制布局）只在用户真正停住后执行，`mouseover` 路径零布局成本
- 修复前按钮只用一次标签白名单匹配，AI 概览的外层 `li`（采集器本会拒收）被错误命中，点击后整棵子树 textContent 揉成一段、嵌套子条目结构塌掉、来源 chip 被翻进正文 —— 现在精判拦截，嵌套子条目各自单独成单元
- `shouldSkip()` 全部护栏（MAX_TEXT / MAX_HTML / `.notranslate` / contentEditable / 纯数字 / 非正文区）在按钮路径从此全部生效
- `translateOne()` 统一提级到最近的可翻单元：快捷键入口（选区起点 `parentElement`，可能落在 `span` 等内联元素）也能翻整段，不可翻（超长 / notranslate / 已翻译）则不发请求

### C. 来源角标不进入译文

新增 `translatableText()`：提取文本时剔除 `.notranslate` 子树（HTML 标准约定）与站点元数据。Google AI 概览来源角标（`span.wJwe6c` / `.WTfRgd`）经 `compat.ts` 域名补丁剔除 —— 译文尾部不再出现「YouTube·Tech +2」这类噪声。整页翻译与单段翻译统一走此提取。

## 说明

- 类名 `wJwe6c`/`WTfRgd` 来自社区抓包记录（2026），非官方文档；Google 改版失效只会回退为「chip 文本进译文」，不会翻错
- Google 真实 DOM 无法自动化实测（人机验证页），但「按钮路径缺采集器判定」这一根因是从代码直接读出的，已独立修复；`translateOne` 入口可在真实浏览器临时打一行 `console.log` 验证

## 验证方式（建议）

- Google 搜索任意关键词，悬停灰色摘要确认按钮浮出，点击后只翻该条摘要
- 出 AI 概览的关键词，确认条目单独可翻、不吞并嵌套子条目和来源 chip
- 构造超长段落（>3072 字符），确认按钮不浮出或点击被拦下，不发出超长请求
- 带 `.notranslate` 类的段落，确认按钮不浮出
- 回归普通文章页（正常 p/li 结构）与整页翻译，确认行为无变化、无性能回退（walk 判定仍先查表后算文本，div 兜底的 directTextLength 只遍历直接子节点）

Closes #19