### PR TITLE
fix: 单段翻译拒绝含媒体/交互控件的容器，取文本补空格防粘连 (v0.6.9)

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -276,7 +276,11 @@ export default defineContentScript({
         return;
       }
 
-      render(unit, resp.data.translations[0], 'para');
+      // render() 在含媒体 / 交互控件时会拒绝渲染（#22），此时告知用户
+      // 而非静默吞掉元素
+      if (!render(unit, resp.data.translations[0], 'para')) {
+        toast(tf('toastNotTranslatable', '该区域无法单独翻译'), 'error');
+      }
     }
 
     // ── 翻译选区 ──

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -151,5 +151,6 @@
   "toastExtOn": { "message": "Extension enabled" },
   "toastExtOff": { "message": "Extension disabled" },
   "toastAllEnginesFail": { "message": "All engines failed" },
-  "toastTranslateFail": { "message": "Translation failed" }
+  "toastTranslateFail": { "message": "Translation failed" },
+  "toastNotTranslatable": { "message": "This area cannot be translated individually" }
 }

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -151,5 +151,6 @@
   "toastExtOn": { "message": "扩展已开启" },
   "toastExtOff": { "message": "扩展已关闭" },
   "toastAllEnginesFail": { "message": "所有引擎均失败" },
-  "toastTranslateFail": { "message": "翻译失败" }
+  "toastTranslateFail": { "message": "翻译失败" },
+  "toastNotTranslatable": { "message": "该区域无法单独翻译" }
 }

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -151,5 +151,6 @@
   "toastExtOn": { "message": "擴充功能已開啟" },
   "toastExtOff": { "message": "擴充功能已關閉" },
   "toastAllEnginesFail": { "message": "所有引擎均失敗" },
-  "toastTranslateFail": { "message": "翻譯失敗" }
+  "toastTranslateFail": { "message": "翻譯失敗" },
+  "toastNotTranslatable": { "message": "此區域無法單獨翻譯" }
 }

--- a/src/dom/renderer.ts
+++ b/src/dom/renderer.ts
@@ -13,14 +13,35 @@ import type { DisplayMode, StyleId } from '../storage/schema';
 export type RenderSource = 'page' | 'para';
 
 /**
+ * 子树中含有不应被藏进 .pt-origin 的节点时的匹配选择器。
+ * img / video / iframe 等是可见媒体内容，button / input 等是交互控件，
+ * 若被搬进 display:none 的隐藏容器，卡片结构就塌了（#22）。
+ */
+const NON_TEXT_SELECTOR =
+  'img, picture, video, audio, iframe, canvas, object, embed,' +
+  ' button, input, select, textarea,' +
+  ' [role="button"], [role="tab"], [role="menuitem"], [role="switch"], [role="checkbox"]';
+
+/**
  * 渲染译文。三种模式共用同一套 DOM 结构。
+ *
+ * 返回 false 表示元素含非文本内容（媒体 / 交互控件），拒绝渲染，
+ * 由调用方决定是否提示用户。
  */
 export function render(
   el: Element,
   translation: string,
   src: RenderSource = 'page',
-): void {
-  if (el.getAttribute('data-pt') === 'done') return;
+): boolean {
+  if (el.getAttribute('data-pt') === 'done') return true;
+
+  // 纵深防御：拒绝含非文本内容的容器，防止缩略图、按钮等被藏进
+  // display:none 的 .pt-origin（#22）。此检查与采集器的 isTranslationUnit
+  // 互补 —— 后者允许 img（内联元素），render() 则对可见媒体说「不」。
+  if (el.querySelector(NON_TEXT_SELECTOR)) {
+    console.warn('[PT] render 拒绝：元素含非文本内容（媒体 / 交互控件）', el);
+    return false;
+  }
 
   // 把原有子节点整体包进 .pt-origin，保留其内部结构与事件绑定
   const origin = document.createElement('span');
@@ -35,6 +56,7 @@ export function render(
   el.appendChild(trans);
   el.setAttribute('data-pt', 'done');
   el.setAttribute('data-pt-src', src);
+  return true;
 }
 
 /** 还原原文，把 .pt-origin 的子节点放回去 */

--- a/src/dom/text.ts
+++ b/src/dom/text.ts
@@ -21,7 +21,12 @@ export function translatableText(el: Element): string {
         const c = child as Element;
         if (c.classList.contains('notranslate')) continue;
         if (shouldOmitText(c)) continue;
+        // 元素子节点之间补空格，防止源 HTML 中相邻元素无空白时
+        // textContent 把末字与首字粘在一起（如 "CertifiedProfessional"，#22）。
+        // normalizeText 会将多余空白折叠为单个空格，多余的不会到达引擎。
+        out += ' ';
         walk(c);
+        out += ' ';
       }
     }
   };


### PR DESCRIPTION
## 修复 #22：单段翻译整条卡片被摧毁

### 问题

Google 搜索「引用来源」卡片中，对来源条目点击单段翻译后，整条卡片被摧毁：标题、摘要、来源署名、缩略图全部消失，原地只剩一段连读中文。

### 根因

两个独立缺陷叠加：

1. **render() 无条件搬移子节点** —— 把 img / button 等非文本内容搬进 display:none 的 .pt-origin，缩略图与交互控件一并消失
2. **textContent 无分隔拼接** —— 源 HTML 中相邻元素无空白时，末字与首字粘连（如 `CertifiedProfessional`）

### 修复（三层防御）

1. **render() 纵深防御**：子树含 img/video/button/iframe 等非文本节点时拒绝渲染并返回 false
2. **translateOne() 入口处理**：render() 返回 false 时 toast 提示「该区域无法单独翻译」
3. **translatableText() 分隔符**：在元素子节点间补空格，normalizeText 折叠多余空白

### 变更文件

| 文件 | 变更 |
|------|------|
| src/dom/renderer.ts | +13：NON\_TEXT\_SELECTOR + render() 检查 + 返回值 bool |
| src/dom/text.ts | +4：元素子节点间补空格 |
| entrypoints/content.ts | +4：处理 render() 拒绝 + toast 提示 |
| public/\_locales/\*/messages.json | +3：toastNotTranslatable（中/英/繁） |
| package.json | 0.6.8 → 0.6.9 |