### PR TITLE
fix: 混合内容元素直接文本可翻译 + 折叠内容可见时补翻 (v0.6.10, closes #23)

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -9,8 +9,8 @@ import '~/src/styles/presets.css';
 import { collect } from '~/src/dom/walker';
 import { closestUnit } from '~/src/dom/classify';
 import { normalizeText } from '~/src/dom/normalize';
-import { translatableText } from '~/src/dom/text';
-import { startObserver } from '~/src/dom/observer';
+import { translatableText, shallowTranslatableText, hasBlockTextChildren } from '~/src/dom/text';
+import { startObserver, registerHidden } from '~/src/dom/observer';
 import { render, unrender, applyMode, applyStyle } from '~/src/dom/renderer';
 import { applyCustomCss } from '~/src/styles/custom';
 import { createBall, setBallState } from '~/src/ui/floating-ball';
@@ -130,12 +130,20 @@ export default defineContentScript({
       const ns = getSettings();
       if (!ns.enabled) return 'disabled';
 
-      const targets = elements ?? collect();
+      const targets = elements ?? collect(document.body, registerHidden);
       if (targets.length === 0) return 'no-elements';
 
       // 归一化内部空白：硬换行切词、撑破 OpenAI 编号结构都源于未折叠的 \n。
       // translatableText 剔除 .notranslate 与站点元数据（如 Google 来源角标）。
-      const texts = targets.map((el) => normalizeText(translatableText(el)));
+      // #23：混合内容元素（直接文本 + 块级子元素）使用 shallowTranslatableText，
+      // 只提取直接文本，嵌套块级子元素由各自的翻译单元独立翻译。
+      const texts = targets.map((el) =>
+        normalizeText(
+          hasBlockTextChildren(el)
+            ? shallowTranslatableText(el)
+            : translatableText(el),
+        ),
+      );
 
       const resp = await chrome.runtime.sendMessage({
         type: 'pt:translate',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/classify.ts
+++ b/src/dom/classify.ts
@@ -45,7 +45,8 @@ const MAX_TEXT = 3072;
 const MAX_HTML = 4096;
 const MIN_TEXT = 3;
 
-export function shouldSkip(el: Element): boolean {
+/** 非可见性相关的所有跳过判定。元素即便变为可见，这些条件也不会改变。 */
+export function shouldSkipNonVisual(el: Element): boolean {
   const tag = el.tagName.toLowerCase();
   if (SKIP_SET.has(tag)) return true;
   if (el.classList.contains('notranslate')) return true;
@@ -58,15 +59,24 @@ export function shouldSkip(el: Element): boolean {
   // 非正文区域：导航、页脚、侧栏、参考文献等
   if (el.closest(NON_CONTENT)) return true;
 
-  // 不可见元素（display:none 或祖先被隐藏）
-  const rect = (el as HTMLElement).getBoundingClientRect?.();
-  if (rect && rect.width === 0 && rect.height === 0) return true;
-
   const text = el.textContent?.trim() ?? '';
   if (text.length < MIN_TEXT || text.length > MAX_TEXT) return true;
   if ((el as HTMLElement).outerHTML.length > MAX_HTML) return true;
   if (isMainlyNumeric(text)) return true;
 
+  return false;
+}
+
+/** 元素是否可见（非 display:none 且祖先均可见）。 */
+export function isVisible(el: Element): boolean {
+  const rect = (el as HTMLElement).getBoundingClientRect?.();
+  if (rect && rect.width === 0 && rect.height === 0) return false;
+  return true;
+}
+
+export function shouldSkip(el: Element): boolean {
+  if (shouldSkipNonVisual(el)) return true;
+  if (!isVisible(el)) return true;
   return false;
 }
 
@@ -92,12 +102,19 @@ export function isTranslationUnit(el: Element): boolean {
   if (isContainer && directTextLength(el) === 0) return false;
   if (!DIRECT_SET.has(tag) && !isContainer) return false;
 
+  // #23：元素自身持有直接文本时，即使有带文本的块级子元素也接受为翻译单元。
+  // 直接文本部分由 shallowTranslatableText 提取，嵌套块级子元素各自独立采集。
+  const hasDirect = directTextLength(el) > 0;
+
   for (const child of el.children) {
     const childTag = child.tagName.toLowerCase();
     // 内联子元素属于本段的一部分，不影响判定
     if (INLINE_SET.has(childTag)) continue;
-    // 非内联且有文本 → 文本在更深层，当前节点不是翻译单元
-    if (child.textContent?.trim()) return false;
+    // 非内联且有文本 → 若当前元素有直接文本则接受（仅翻直接文本），否则拒收
+    if (child.textContent?.trim()) {
+      if (hasDirect) continue;
+      return false;
+    }
   }
   return true;
 }

--- a/src/dom/observer.ts
+++ b/src/dom/observer.ts
@@ -1,4 +1,4 @@
-// Phase 3 — MutationObserver 增量补翻。
+// Phase 3 — MutationObserver 增量补翻 + IntersectionObserver 可见性补翻。
 //
 // 监听 DOM 变化，对新增节点补翻。
 // 覆盖三种场景：无限滚动、SPA 路由切换、懒加载内容。
@@ -10,6 +10,12 @@
 //   不防抖会导致全量采集与翻译请求瞬间打爆并发闸门
 // - 每个 shadowRoot 各挂一个 MutationObserver ——
 //   MutationObserver 与 TreeWalker 一样不穿透 shadow 边界
+//
+// #23 新增 IntersectionObserver：
+// - 初次采集时 display:none 的元素被跳过（0×0 rect），展开时若无 DOM 增删
+//   （纯 CSS class/style 切换），MutationObserver 感知不到，内容永久漏翻。
+// - IntersectionObserver 监听这些隐藏元素，一旦进入视口就触发补翻。
+// - rootMargin 提前 300px 触发，让即将滚入视口的内容提前翻译。
 
 import { collect } from './walker';
 
@@ -55,10 +61,53 @@ function observeShadowRoots(
   return observers;
 }
 
+// ── #23 可见性追踪 ──
+
+/** 初次采集时因 display:none 被跳过的翻译单元 */
+const hiddenTargets = new Set<Element>();
+let io: IntersectionObserver | null = null;
+let onVisibleCb: ((els: Element[]) => void) | null = null;
+
 /**
- * 启动 MutationObserver，对新增节点触发补翻回调。
- * 返回取消订阅函数。
+ * 注册因不可见而被跳过的翻译单元。
+ * 由 walker 的 onHidden 回调调用，也可在 IO 启动后直接挂载观察。
  */
+export function registerHidden(el: Element): void {
+  hiddenTargets.add(el);
+  if (io) io.observe(el);
+}
+
+function startWatching(onNewNodes: (els: Element[]) => void): void {
+  if (io) return; // 已经启动
+  onVisibleCb = onNewNodes;
+  io = new IntersectionObserver(
+    (entries) => {
+      const newlyVisible: Element[] = [];
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          io!.unobserve(entry.target);
+          hiddenTargets.delete(entry.target as Element);
+          // 元素变为可见，重新采集其子树中的翻译单元
+          newlyVisible.push(...collect(entry.target, registerHidden));
+        }
+      }
+      if (newlyVisible.length && onVisibleCb) {
+        onVisibleCb(newlyVisible);
+      }
+    },
+    {
+      // 提前 300px 触发，让即将滚入视口的内容提前翻译
+      rootMargin: '300px',
+      threshold: 0,
+    },
+  );
+  // 观察所有已注册的隐藏元素
+  for (const el of hiddenTargets) {
+    io.observe(el);
+  }
+}
+
+/** 启动 MutationObserver，对新增节点触发补翻回调。 */
 export function startObserver(
   onNewNodes: (els: Element[]) => void,
 ): () => void {
@@ -74,7 +123,7 @@ export function startObserver(
     const batch = pending;
     pending = [];
     const found = batch.flatMap((n) =>
-      n.nodeType === Node.ELEMENT_NODE ? collect(n) : [],
+      n.nodeType === Node.ELEMENT_NODE ? collect(n, registerHidden) : [],
     );
 
     // 新增节点中可能出现新的 shadow host，为其 shadow root 补挂 observer
@@ -116,8 +165,17 @@ export function startObserver(
   const initial = observeShadowRoots(document.body, onMutationRecord, observedRoots);
   observers.push(...initial);
 
+  // #23：启动 IntersectionObserver，监听初次采集时因 display:none 被跳过的元素
+  startWatching(onNewNodes);
+
   return () => {
     for (const mo of observers) mo.disconnect();
     if (timer) clearTimeout(timer);
+    if (io) {
+      io.disconnect();
+      io = null;
+    }
+    hiddenTargets.clear();
+    onVisibleCb = null;
   };
 }

--- a/src/dom/text.ts
+++ b/src/dom/text.ts
@@ -6,6 +6,7 @@
 // - shouldOmitText()：域名补丁（compat.ts），站点的特定元数据
 
 import { shouldOmitText } from './compat';
+import { INLINE_SET } from './classify';
 
 /**
  * 提取元素的全部可翻译文本：递归遍历子节点，跳过 .notranslate 与
@@ -32,4 +33,46 @@ export function translatableText(el: Element): string {
   };
   walk(el);
   return out;
+}
+
+/**
+ * 浅层提取：只取直接文本节点与内联子元素的文本，跳过块级子元素。
+ *
+ * #23 混合内容元素专用 —— 对 `<li>标签文字<ul><li>子条目</li></ul></li>`
+ * 只提取"标签文字"，子条目由各自的翻译单元独立翻译，避免重复。
+ */
+export function shallowTranslatableText(el: Element): string {
+  let out = '';
+  for (const child of el.childNodes) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      out += child.textContent ?? '';
+    } else if (child.nodeType === Node.ELEMENT_NODE) {
+      const c = child as Element;
+      const tag = c.tagName.toLowerCase();
+
+      // 跳过块级子元素 —— 它们的文本由各自翻译单元覆盖
+      if (!INLINE_SET.has(tag)) continue;
+
+      if (c.classList.contains('notranslate')) continue;
+      if (shouldOmitText(c)) continue;
+      out += ' ';
+      out += translatableText(c); // 内联元素全递归
+      out += ' ';
+    }
+  }
+  return out;
+}
+
+/**
+ * 元素是否含有带文本的非内联子元素（即混合内容元素）。
+ * 此类元素在整页翻译时应使用 shallowTranslatableText，
+ * 避免把嵌套子条目的文本重复翻译进父单元。
+ */
+export function hasBlockTextChildren(el: Element): boolean {
+  for (const child of el.children) {
+    const tag = child.tagName.toLowerCase();
+    if (INLINE_SET.has(tag)) continue;
+    if (child.textContent?.trim()) return true;
+  }
+  return false;
 }

--- a/src/dom/walker.ts
+++ b/src/dom/walker.ts
@@ -7,21 +7,29 @@
 // Phase 8 接入域名级采集补丁（src/dom/compat.ts），
 // 在通用规则判定之前给特定站点插入决策。
 
-import { SKIP_SET, shouldSkip, isTranslationUnit } from './classify';
+import { SKIP_SET, shouldSkipNonVisual, isVisible, isTranslationUnit } from './classify';
 import { applyCompat } from './compat';
 
 /**
  * 采集可翻译节点。
  * TreeWalker 不会自动进入 shadowRoot，必须显式递归。
  */
-export function collect(root: Node = document.body): Element[] {
+export function collect(
+  root: Node = document.body,
+  onHidden?: (el: Element) => void,
+): Element[] {
   const out: Element[] = [];
   const seen = new Set<Element>();
-  walk(root, out, seen);
+  walk(root, out, seen, onHidden);
   return out;
 }
 
-function walk(root: Node, out: Element[], seen: Set<Element>): void {
+function walk(
+  root: Node,
+  out: Element[],
+  seen: Set<Element>,
+  onHidden?: (el: Element) => void,
+): void {
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, {
     acceptNode(node) {
       const el = node as Element;
@@ -69,9 +77,18 @@ function walk(root: Node, out: Element[], seen: Set<Element>): void {
     }
 
     // 判定顺序不能反：isTranslationUnit() 首步只是一次标签查表，而
-    // shouldSkip() 要拼 outerHTML、算 textContent、调 getBoundingClientRect
-    // （真实浏览器中会强制同步布局）。先便宜后昂贵，整页采集耗时约降至 1/5。
-    if (!seen.has(el) && isTranslationUnit(el) && !shouldSkip(el)) {
+    // shouldSkipNonVisual() 要拼 outerHTML、算 textContent。先便宜后昂贵。
+    if (!seen.has(el) && isTranslationUnit(el)) {
+      if (shouldSkipNonVisual(el)) {
+        node = walker.nextNode();
+        continue;
+      }
+      // #23：不可见的翻译单元记入延迟队列，等 IntersectionObserver 补翻
+      if (!isVisible(el)) {
+        onHidden?.(el);
+        node = walker.nextNode();
+        continue;
+      }
       seen.add(el);
       out.push(el);
     }


### PR DESCRIPTION
## 修复内容

三处修改解决整页翻译大面积漏翻（#23）：

### 1. 混合内容元素直接文本无人认领（原因 A）

**问题**：`<li>标签文字<ul><li>子条目</li></ul></li>` 中，外层 `<li>` 因含带文本的块级子元素被 `isTranslationUnit()` 拒收，其直接文本（标签文字）永久漏翻。

**修复**：
- `isTranslationUnit()` 接受持有直接文本的混合内容元素
- 新增 `shallowTranslatableText()`：只提取直接文本节点与内联子元素的文本，跳过块级子元素
- 整页翻译时，混合内容元素使用浅层提取，嵌套子条目由各自翻译单元独立翻译
- 单段翻译路径不受影响（仍用完整文本提取 `translatableText`）

### 2. 折叠内容展开后永不补翻（原因 B）

**问题**：初次采集时 `display:none` 的内容被跳过（0×0 rect），之后 CSS class/style 切换展开时无 DOM 增删，`MutationObserver`（仅监听 `childList`）感知不到，内容永久漏翻。

**修复**：
- `shouldSkip` 拆分为 `shouldSkipNonVisual`（永久性判定）与 `isVisible`（临时性判定）
- `collect()` 接受 `onHidden` 回调，把不可见的翻译单元记入延迟队列
- 新增 `IntersectionObserver`（rootMargin 300px），监听隐藏元素进入视口时触发 `collect()` 补翻
- `registerHidden()` 导出供初始采集与增量采集共用

### 3. div 型正文盲区

已在 #19/\#38 通过 `CONTAINER_SET` 引入，本次 `isTranslationUnit` 的修改对 `CONTAINER_SET` 与 `DIRECT_SET` 对称生效。

## 变更文件

| 文件 | 改动 |
| --- | --- |
| `src/dom/classify.ts` | 拆分 `shouldSkipNonVisual` / `isVisible`；`isTranslationUnit` 接受混合内容元素 |
| `src/dom/text.ts` | 新增 `shallowTranslatableText` / `hasBlockTextChildren` |
| `src/dom/walker.ts` | `collect()` 接受 `onHidden` 回调，区分可见与隐藏翻译单元 |
| `src/dom/observer.ts` | 新增 `IntersectionObserver` 可见性追踪 + `registerHidden` 导出 |
| `entrypoints/content.ts` | 整页翻译对混合元素用浅层提取；初始采集注册隐藏元素 |
| `package.json` | 版本号 0.6.9 → 0.6.10 |

## 验证方式

- 构造 `<li>标签文字<ul><li>子条目</li></ul></li>` 结构，整页翻译后确认标签文字与子条目各有译文
- 构造 CSS class 切换的折叠区块，翻译后展开，确认内容被补翻
- 回归：`shouldSkip` 行为不变；单段翻译路径不受影响
- 回归：observer 死循环防护（MutationObserver 仍仅监听 childList）

Closes #23