### PR TITLE
feat: 首次安装打开欢迎页，显示快捷键与交互入口 (#24)

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -3,9 +3,25 @@
 
 import { cacheSet, cacheKey, cacheGet, cacheClear } from '~/src/storage/cache';
 import { getKey, setKey, removeKey } from '~/src/storage/keys';
-import { settingsReady, onSettingsChanged } from '~/src/storage/settings';
+import { settingsReady, patchSettings, onSettingsChanged } from '~/src/storage/settings';
 import { route } from '~/src/engines/router';
 import { initContextMenu } from '~/src/ui/context-menu';
+
+/** 将浏览器 UI 语言映射到 LANG_LIST 中可用的目标语言码 */
+function deriveTargetLanguage(uiLang: string): string {
+  const lang = uiLang.split('-')[0]?.toLowerCase() ?? '';
+  // 中文特殊处理：繁体 → zh-TW，其余默认简体
+  if (lang === 'zh') {
+    return uiLang.includes('TW') || uiLang.includes('Hant') ? 'zh-TW' : 'zh-CN';
+  }
+  // 已知语言前缀 → 对应语言码
+  const MAP: Record<string, string> = {
+    en: 'en', ja: 'ja', ko: 'ko', fr: 'fr', de: 'de',
+    es: 'es', pt: 'pt', ru: 'ru', ar: 'ar', th: 'th',
+    vi: 'vi', it: 'it',
+  };
+  return MAP[lang] ?? 'en';
+}
 
 export default defineBackground(() => {
   console.log('[PT] Background service worker started');
@@ -22,9 +38,25 @@ export default defineBackground(() => {
   (self as any).setKey = setKey;
   (self as any).removeKey = removeKey;
 
-  // 右键菜单 —— onInstalled 中注册，避免每次 SW 唤醒重复创建报错
-  chrome.runtime.onInstalled.addListener(() => {
+  // 右键菜单 + 首次安装引导
+  chrome.runtime.onInstalled.addListener((details) => {
     initContextMenu();
+
+    if (details.reason === 'install') {
+      // 根据浏览器 UI 语言推导默认目标语言
+      settingsReady()
+        .then(async () => {
+          const uiLang = chrome.i18n.getUILanguage();
+          const derived = deriveTargetLanguage(uiLang);
+          if (derived !== 'zh-CN') {
+            await patchSettings({ to: derived });
+          }
+        })
+        .catch((e) => console.error('[PT] 设置默认语言失败:', e));
+
+      // 打开欢迎页
+      chrome.tabs.create({ url: chrome.runtime.getURL('welcome.html') });
+    }
   });
 
   chrome.contextMenus.onClicked.addListener((info, tab) => {

--- a/entrypoints/welcome/index.html
+++ b/entrypoints/welcome/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="./welcome.css" />
+  <script type="module" src="./main.ts"></script>
+</head>
+<body>
+  <div class="pt-welcome">
+    <header class="pt-welcome-header">
+      <h1>Parallel-Translation</h1>
+      <p class="pt-welcome-tagline" data-i18n="welcomeTagline">对照式网页翻译，开箱即用</p>
+    </header>
+
+    <section class="pt-card">
+      <h2 class="pt-welcome-section-title" data-i18n="welcomeReady">✅ 现在就能用</h2>
+      <p data-i18n="welcomeReadyDesc">默认使用 Google 翻译引擎，无需额外配置。点击工具栏图标或使用快捷键即可开始翻译。</p>
+    </section>
+
+    <section class="pt-card">
+      <h2 class="pt-welcome-section-title" data-i18n="welcomeHotkeys">⌨️ 快捷键</h2>
+      <p class="pt-welcome-desc" data-i18n="welcomeHotkeysDesc">以下快捷键在所有页面均可使用：</p>
+      <div class="pt-welcome-hotkeys" id="pt-welcome-hotkeys">
+        <!-- 动态渲染 -->
+      </div>
+    </section>
+
+    <section class="pt-card">
+      <h2 class="pt-welcome-section-title" data-i18n="welcomeTargetLang">🌐 目标语言</h2>
+      <p class="pt-welcome-desc" data-i18n="welcomeTargetLangDesc">翻译结果将以此语言显示，可根据需要修改：</p>
+      <select class="pt-select" id="pt-welcome-lang-select"></select>
+    </section>
+
+    <section class="pt-card">
+      <h2 class="pt-welcome-section-title" data-i18n="welcomeInteractions">🖱️ 交互方式</h2>
+      <ul class="pt-welcome-interactions">
+        <li>
+          <strong data-i18n="welcomeBall">悬浮球</strong>
+          <span data-i18n="welcomeBallDesc">页面右侧的悬浮按钮「译」，点击即可翻译整页</span>
+        </li>
+        <li>
+          <strong data-i18n="welcomeParaBtn">段落悬停按钮</strong>
+          <span data-i18n="welcomeParaBtnDesc">鼠标悬停在段落上时出现「译」按钮，点击翻译该段落</span>
+        </li>
+        <li>
+          <strong data-i18n="welcomeSelection">划词与右键翻译</strong>
+          <span data-i18n="welcomeSelectionDesc">选中文本后右键，点击「翻译所选文本」即可翻译选中内容</span>
+        </li>
+      </ul>
+    </section>
+
+    <footer class="pt-welcome-footer">
+      <button class="pt-btn pt-btn-secondary" id="pt-welcome-settings" data-i18n="welcomeOpenSettings">打开完整设置</button>
+      <button class="pt-btn" id="pt-welcome-close" data-i18n="welcomeClose">开始使用</button>
+    </footer>
+  </div>
+</body>
+</html>

--- a/entrypoints/welcome/main.ts
+++ b/entrypoints/welcome/main.ts
@@ -1,0 +1,81 @@
+import './welcome.css';
+import { applyI18n } from '~/src/i18n';
+import { detectOS, formatHotkey } from '~/src/hotkeys/platform';
+import { settingsReady, getSettings, patchSettings } from '~/src/storage/settings';
+import { DEFAULT_SETTINGS, LANG_LIST, type HotkeyAction } from '~/src/storage/schema';
+
+// ---- 快捷键渲染 ----
+
+const HOTKEY_ACTIONS: { action: HotkeyAction; i18nKey: string }[] = [
+  { action: 'toggle-translate', i18nKey: 'actionToggleTranslate' },
+  { action: 'toggle-mode', i18nKey: 'actionToggleMode' },
+  { action: 'translate-paragraph', i18nKey: 'actionTranslateParagraph' },
+  { action: 'toggle-extension', i18nKey: 'actionToggleExtension' },
+];
+
+function renderHotkeys(os: Awaited<ReturnType<typeof detectOS>>): void {
+  const container = document.getElementById('pt-welcome-hotkeys');
+  if (!container) return;
+
+  const hotkeys = DEFAULT_SETTINGS.hotkeys;
+
+  container.innerHTML = HOTKEY_ACTIONS.map(({ action, i18nKey }) => {
+    const label = chrome.i18n.getMessage(i18nKey) || action;
+    const combo = formatHotkey(hotkeys[action], os);
+    return `<div class="pt-welcome-hotkey-row">
+      <span class="pt-welcome-hotkey-label">${label}</span>
+      <kbd class="pt-welcome-kbd">${combo}</kbd>
+    </div>`;
+  }).join('');
+}
+
+// ---- 语言选择 ----
+
+function renderLangSelect(currentTo: string): void {
+  const select = document.getElementById('pt-welcome-lang-select') as HTMLSelectElement;
+  if (!select) return;
+
+  // 排除 'auto'，欢迎页只选目标语言
+  const targets = LANG_LIST.filter((l) => l.code !== 'auto');
+
+  select.innerHTML = targets.map((l) => {
+    const selected = l.code === currentTo ? ' selected' : '';
+    return `<option value="${l.code}"${selected}>${l.label}</option>`;
+  }).join('');
+
+  select.addEventListener('change', () => {
+    patchSettings({ to: select.value }).catch((e) =>
+      console.error('[PT] 保存目标语言失败:', e),
+    );
+  });
+}
+
+// ---- 按钮事件 ----
+
+function bindButtons(): void {
+  document.getElementById('pt-welcome-settings')?.addEventListener('click', () => {
+    chrome.runtime.openOptionsPage?.() ??
+      chrome.tabs.create({ url: chrome.runtime.getURL('options.html') });
+  });
+
+  document.getElementById('pt-welcome-close')?.addEventListener('click', () => {
+    window.close();
+  });
+}
+
+// ---- 初始化 ----
+
+async function init(): Promise<void> {
+  await settingsReady();
+  const settings = getSettings();
+  const os = await detectOS();
+
+  applyI18n();
+  renderHotkeys(os);
+  renderLangSelect(settings.to);
+  bindButtons();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  init().catch((e) => console.error('[PT] 欢迎页初始化失败:', e));
+});

--- a/entrypoints/welcome/welcome.css
+++ b/entrypoints/welcome/welcome.css
@@ -1,0 +1,181 @@
+@import '../../src/styles/tokens.css';
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: var(--pt-paper);
+  color: var(--pt-forest);
+  font-family: var(--pt-font-ui);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+/* ===== Layout ===== */
+
+.pt-welcome {
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 48px 24px 32px;
+}
+
+/* ===== Header ===== */
+
+.pt-welcome-header {
+  text-align: center;
+  margin-bottom: 28px;
+}
+
+.pt-welcome-header h1 {
+  font-family: var(--pt-font-mono);
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -.02em;
+  margin-bottom: 6px;
+}
+
+.pt-welcome-tagline {
+  font-size: 13px;
+  color: var(--pt-forest-55);
+}
+
+/* ===== Cards ===== */
+
+.pt-welcome .pt-card {
+  background: var(--pt-surface);
+  border: 1px solid var(--pt-forest-09);
+  border-radius: var(--pt-r-md);
+  padding: 20px 24px;
+  margin-bottom: 14px;
+}
+
+.pt-welcome-section-title {
+  font-family: var(--pt-font-mono);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -.02em;
+  margin-bottom: 8px;
+}
+
+.pt-welcome-desc {
+  font-size: 12px;
+  color: var(--pt-forest-55);
+  margin-bottom: 14px;
+}
+
+/* ===== Hotkey list ===== */
+
+.pt-welcome-hotkeys {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.pt-welcome-hotkey-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.pt-welcome-hotkey-label {
+  font-size: 13px;
+  color: var(--pt-forest);
+}
+
+.pt-welcome-kbd {
+  font-family: var(--pt-font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 10px;
+  background: var(--pt-paper);
+  border: 1px solid var(--pt-forest-15);
+  border-radius: var(--pt-r-sm);
+  color: var(--pt-forest);
+  white-space: nowrap;
+}
+
+/* ===== Select ===== */
+
+.pt-select {
+  font-family: var(--pt-font-mono);
+  font-size: 12px;
+  color: var(--pt-forest);
+  background: var(--pt-paper);
+  border: 1px solid var(--pt-forest-22);
+  border-radius: var(--pt-r-sm);
+  padding: 6px 10px;
+  cursor: pointer;
+  appearance: none;
+  min-width: 160px;
+}
+
+/* ===== Interaction list ===== */
+
+.pt-welcome-interactions {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.pt-welcome-interactions li {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.pt-welcome-interactions strong {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.pt-welcome-interactions span {
+  font-size: 12px;
+  color: var(--pt-forest-55);
+}
+
+/* ===== Footer ===== */
+
+.pt-welcome-footer {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  margin-top: 28px;
+}
+
+/* ===== Buttons ===== */
+
+.pt-btn {
+  font-family: var(--pt-font-mono);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  background: var(--pt-forest);
+  color: var(--pt-paper);
+  border: none;
+  border-radius: var(--pt-r-sm);
+  padding: 10px 24px;
+  cursor: pointer;
+  transition: opacity .15s ease;
+}
+
+.pt-btn:hover { opacity: 0.85; }
+.pt-btn:active { opacity: 0.7; }
+
+.pt-btn.pt-btn-secondary {
+  background: transparent;
+  color: var(--pt-forest-55);
+  border: 1px solid var(--pt-forest-15);
+}
+
+.pt-btn.pt-btn-secondary:hover {
+  background: var(--pt-forest-08);
+  color: var(--pt-forest);
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -152,5 +152,22 @@
   "toastExtOff": { "message": "Extension disabled" },
   "toastAllEnginesFail": { "message": "All engines failed" },
   "toastTranslateFail": { "message": "Translation failed" },
-  "toastNotTranslatable": { "message": "This area cannot be translated individually" }
+  "toastNotTranslatable": { "message": "This area cannot be translated individually" },
+
+  "welcomeTagline": { "message": "Bilingual web translation, ready out of the box" },
+  "welcomeReady": { "message": "Ready to use" },
+  "welcomeReadyDesc": { "message": "Uses Google Translate by default — no configuration needed. Click the toolbar icon or use a keyboard shortcut to start translating." },
+  "welcomeHotkeys": { "message": "Keyboard shortcuts" },
+  "welcomeHotkeysDesc": { "message": "These shortcuts work on every page:" },
+  "welcomeTargetLang": { "message": "Target language" },
+  "welcomeTargetLangDesc": { "message": "Translations will be shown in this language. Change it here or in Settings anytime:" },
+  "welcomeInteractions": { "message": "Ways to interact" },
+  "welcomeBall": { "message": "Floating ball" },
+  "welcomeBallDesc": { "message": "The \"T\" button on the right side of the page — click to translate the entire page" },
+  "welcomeParaBtn": { "message": "Paragraph hover button" },
+  "welcomeParaBtnDesc": { "message": "A \"T\" button appears when you hover over a paragraph — click to translate just that paragraph" },
+  "welcomeSelection": { "message": "Selection & context menu" },
+  "welcomeSelectionDesc": { "message": "Select text, right-click, and choose \"Translate selected text\" to translate the selection" },
+  "welcomeOpenSettings": { "message": "Open full settings" },
+  "welcomeClose": { "message": "Get started" }
 }

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -152,5 +152,22 @@
   "toastExtOff": { "message": "扩展已关闭" },
   "toastAllEnginesFail": { "message": "所有引擎均失败" },
   "toastTranslateFail": { "message": "翻译失败" },
-  "toastNotTranslatable": { "message": "该区域无法单独翻译" }
+  "toastNotTranslatable": { "message": "该区域无法单独翻译" },
+
+  "welcomeTagline": { "message": "对照式网页翻译，开箱即用" },
+  "welcomeReady": { "message": "现在就能用" },
+  "welcomeReadyDesc": { "message": "默认使用 Google 翻译引擎，无需额外配置。点击工具栏图标或使用快捷键即可开始翻译。" },
+  "welcomeHotkeys": { "message": "快捷键" },
+  "welcomeHotkeysDesc": { "message": "以下快捷键在所有页面均可使用：" },
+  "welcomeTargetLang": { "message": "目标语言" },
+  "welcomeTargetLangDesc": { "message": "翻译结果将以此语言显示，可根据需要修改：" },
+  "welcomeInteractions": { "message": "交互方式" },
+  "welcomeBall": { "message": "悬浮球" },
+  "welcomeBallDesc": { "message": "页面右侧的悬浮按钮「译」，点击即可翻译整页" },
+  "welcomeParaBtn": { "message": "段落悬停按钮" },
+  "welcomeParaBtnDesc": { "message": "鼠标悬停在段落上时出现「译」按钮，点击翻译该段落" },
+  "welcomeSelection": { "message": "划词与右键翻译" },
+  "welcomeSelectionDesc": { "message": "选中文本后右键，点击「翻译所选文本」即可翻译选中内容" },
+  "welcomeOpenSettings": { "message": "打开完整设置" },
+  "welcomeClose": { "message": "开始使用" }
 }

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -152,5 +152,22 @@
   "toastExtOff": { "message": "擴充功能已關閉" },
   "toastAllEnginesFail": { "message": "所有引擎均失敗" },
   "toastTranslateFail": { "message": "翻譯失敗" },
-  "toastNotTranslatable": { "message": "此區域無法單獨翻譯" }
+  "toastNotTranslatable": { "message": "此區域無法單獨翻譯" },
+
+  "welcomeTagline": { "message": "對照式網頁翻譯，開箱即用" },
+  "welcomeReady": { "message": "現在就能用" },
+  "welcomeReadyDesc": { "message": "預設使用 Google 翻譯引擎，無需額外設定。點擊工具列圖示或使用快速鍵即可開始翻譯。" },
+  "welcomeHotkeys": { "message": "快速鍵" },
+  "welcomeHotkeysDesc": { "message": "以下快速鍵在所有頁面均可使用：" },
+  "welcomeTargetLang": { "message": "目標語言" },
+  "welcomeTargetLangDesc": { "message": "翻譯結果將以此語言顯示，可依需求修改：" },
+  "welcomeInteractions": { "message": "互動方式" },
+  "welcomeBall": { "message": "浮動球" },
+  "welcomeBallDesc": { "message": "頁面右側的浮動按鈕「譯」，點擊即可翻譯整頁" },
+  "welcomeParaBtn": { "message": "段落停留按鈕" },
+  "welcomeParaBtnDesc": { "message": "滑鼠停留在段落上時出現「譯」按鈕，點擊翻譯該段落" },
+  "welcomeSelection": { "message": "選取文字與右鍵翻譯" },
+  "welcomeSelectionDesc": { "message": "選取文字後按右鍵，點擊「翻譯所選文字」即可翻譯選取內容" },
+  "welcomeOpenSettings": { "message": "開啟完整設定" },
+  "welcomeClose": { "message": "開始使用" }
 }


### PR DESCRIPTION
## 改动

- 新增 welcome 页面：首次安装自动打开，展示快捷键（按平台格式化）、目标语言确认、交互方式说明、设置入口
- onInstalled 仅 reason=install 时弹欢迎页，更新不弹
- 首次安装根据浏览器 UI 语言推导默认目标语言
- 新增约 15 i18n key，覆盖 zh_CN/zh_TW/en
- 版本号 0.6.10 -> 0.6.11

Closes #24