### PR TITLE
perf: 整页翻译分批渐进渲染 + 缓存并行查询 + 单条失败不丢弃 (v0.6.12)

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -124,6 +124,10 @@ export default defineContentScript({
     });
 
     // ── 翻译全页 ──
+    // #25: 分批发送 + 渐进渲染。每批独立 sendMessage，返回即渲染，
+    // 用户在第一屏译文出现前不再需要等待全页最慢段。
+    const FULL_PAGE_BATCH_SIZE = 15;
+
     async function doTranslate(
       elements?: Element[],
     ): Promise<string> {
@@ -145,21 +149,44 @@ export default defineContentScript({
         ),
       );
 
-      const resp = await chrome.runtime.sendMessage({
-        type: 'pt:translate',
-        payload: { texts, from: ns.from, to: ns.to },
-      });
-
-      if (!resp?.ok) {
-        console.error('[PT] 翻译失败:', resp?.error ?? '未知错误');
-        if (isMainFrame)
-          toast(resp?.error ?? tf('toastAllEnginesFail', '所有引擎均失败'), 'error');
-        return 'error';
+      // 切分为批次
+      const batches: { texts: string[]; targets: Element[] }[] = [];
+      for (let i = 0; i < targets.length; i += FULL_PAGE_BATCH_SIZE) {
+        batches.push({
+          texts: texts.slice(i, i + FULL_PAGE_BATCH_SIZE),
+          targets: targets.slice(i, i + FULL_PAGE_BATCH_SIZE),
+        });
       }
 
-      const translations: string[] = resp.data.translations;
-      for (let i = 0; i < targets.length; i++) {
-        render(targets[i]!, translations[i]!, 'page');
+      let allFailed = true;
+
+      // 所有批次并发发送，每批返回即渲染。
+      // Google Web 的并发闸门是惰性单例，所有批次共享，自然排队。
+      await Promise.all(
+        batches.map(async ({ texts: batchTexts, targets: batchTargets }) => {
+          const resp = await chrome.runtime.sendMessage({
+            type: 'pt:translate',
+            payload: { texts: batchTexts, from: ns.from, to: ns.to },
+          });
+
+          if (!resp?.ok) {
+            console.error('[PT] 批次翻译失败:', resp?.error ?? '未知错误');
+            return;
+          }
+
+          allFailed = false;
+
+          const translations: string[] = resp.data.translations;
+          for (let i = 0; i < batchTargets.length; i++) {
+            render(batchTargets[i]!, translations[i]!, 'page');
+          }
+        }),
+      );
+
+      if (allFailed) {
+        if (isMainFrame)
+          toast(tf('toastAllEnginesFail', '所有引擎均失败'), 'error');
+        return 'error';
       }
 
       return 'translated';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/google-web.ts
+++ b/src/engines/google-web.ts
@@ -59,9 +59,31 @@ export const googleWeb: TranslateEngine = {
   supportedLangs: 'all',
 
   async translate({ texts, from, to }) {
-    const translations = await Promise.all(
+    const results = await Promise.allSettled(
       texts.map((text) => getGate()(() => fetchOne(text, from, to))),
     );
-    return { translations };
+
+    const translations: string[] = [];
+    const failedIndices: number[] = [];
+
+    for (let i = 0; i < results.length; i++) {
+      const r = results[i]!;
+      if (r.status === 'fulfilled') {
+        translations[i] = r.value;
+      } else {
+        translations[i] = '';
+        failedIndices.push(i);
+      }
+    }
+
+    // 全部失败 → 抛出让 router 整体切换到下一个引擎
+    if (failedIndices.length === texts.length) {
+      throw new EngineError('google-web', true, `全部 ${texts.length} 条翻译失败`);
+    }
+
+    return {
+      translations,
+      failedIndices: failedIndices.length > 0 ? failedIndices : undefined,
+    };
   },
 };

--- a/src/engines/router.ts
+++ b/src/engines/router.ts
@@ -44,14 +44,23 @@ export async function route(req: TranslateRequest): Promise<TranslateResponse> {
     const uncached: { idx: number; text: string }[] = [];
 
     if (useCache) {
-      for (let i = 0; i < req.texts.length; i++) {
+      // 并行查询缓存 —— cacheKey 内的 crypto.subtle.digest 是纯 CPU 操作，
+      // N 条可以并行计算，消除串行 for-await 的 2N 次往返延迟。
+      const cacheChecks = await Promise.all(
+        req.texts.map(async (text, i) => {
+          if (translations[i] !== null) return { i, cached: null, text };
+          const k = await cacheKey(id, req.from, req.to, text);
+          const cached = await cacheGet(k);
+          return { i, cached, text };
+        }),
+      );
+
+      for (const { i, cached, text } of cacheChecks) {
         if (translations[i] !== null) continue;
-        const k = await cacheKey(id, req.from, req.to, req.texts[i]!);
-        const cached = await cacheGet(k);
         if (cached !== null) {
           translations[i] = cached;
         } else {
-          uncached.push({ idx: i, text: req.texts[i]! });
+          uncached.push({ idx: i, text: text! });
         }
       }
     } else {
@@ -78,12 +87,47 @@ export async function route(req: TranslateRequest): Promise<TranslateResponse> {
         translations[uncached[j]!.idx] = resp.translations[j]!;
       }
 
-      // 写缓存
-      if (useCache) {
-        for (let j = 0; j < uncached.length; j++) {
-          const k = await cacheKey(id, req.from, req.to, uncached[j]!.text);
-          await cacheSet(k, resp.translations[j]!);
+      // 处理部分失败：将失败槽位重置为 null，交给下一个引擎重试
+      if (resp.failedIndices && resp.failedIndices.length > 0) {
+        for (const j of resp.failedIndices) {
+          translations[uncached[j]!.idx] = null;
         }
+
+        // 并行写缓存（仅成功的条目）
+        if (useCache) {
+          const succeeded = uncached.filter(
+            (_, j) => !resp.failedIndices!.includes(j),
+          );
+          if (succeeded.length > 0) {
+            await Promise.all(
+              succeeded.map(async (u) => {
+                const k = await cacheKey(id, req.from, req.to, u.text);
+                const idx = uncached.indexOf(u);
+                await cacheSet(k, resp.translations[idx]!);
+              }),
+            );
+          }
+        }
+
+        errors.push(
+          new EngineError(
+            id,
+            true,
+            `${resp.failedIndices.length}/${uncached.length} 条失败，尝试下一个引擎`,
+          ),
+        );
+        continue; // 下一个引擎自动拾取 translations[i] === null 的槽位
+      }
+
+      // 全部成功 → 并行写缓存
+      if (useCache) {
+        await Promise.all(
+          uncached.map(async (u) => {
+            const k = await cacheKey(id, req.from, req.to, u.text);
+            const idx = uncached.indexOf(u);
+            await cacheSet(k, resp.translations[idx]!);
+          }),
+        );
       }
 
       return {

--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -14,6 +14,12 @@ export interface TranslateResponse {
   translations: string[];
   /** 检测到的源语言（可选）。 */
   detectedFrom?: string;
+  /**
+   * 翻译失败的槽位索引（可选）。
+   * router 根据此字段将失败槽位交给下一个引擎重试，
+   * 已成功的译文保留在 translations 中不被丢弃。
+   */
+  failedIndices?: number[];
 }
 
 export interface TranslateEngine {


### PR DESCRIPTION
## 修复内容

Closes #25

### 问题

长页面整页翻译等待过久——点下翻译后页面长时间毫无变化，直到全部翻完才一次性出现译文。

原有流程：采集全页 N 段 → 一次 sendMessage 全量发送 → 串行查缓存 → 引擎翻译 → 全部返回后一次性渲染。

### 修复

**1. 分批 + 渐进渲染（体感收益最大）**
- content script 将全页文本切为每批 15 条，并发发送
- 每批返回即渲染，用户 1-2 秒内看到首屏译文
- 部分批次失败不影响已成功的译文

**2. 缓存查询并行化**
- router.ts 中 useCache 分支的串行 `for-await` 改为 `Promise.all`
- `crypto.subtle.digest` 并行计算，消除 2N 次串行往返延迟

**3. Promise.allSettled + 槽位回退**
- google-web.ts 中 `Promise.all` 改为 `Promise.allSettled`
- 单条请求失败不再作废整批，只将失败槽位交给下一个引擎重试
- `TranslateResponse` 新增 `failedIndices` 字段支持精确定位

### 变更文件

| 文件 | 改动 |
|------|------|
| `entrypoints/content.ts` | 分批 + 渐进渲染 |
| `src/engines/router.ts` | 并行缓存查询 + 槽位回退处理 |
| `src/engines/google-web.ts` | Promise.allSettled |
| `src/engines/types.ts` | TranslateResponse 新增 failedIndices |

### 版本

v0.6.12