### PR TITLE
fix: 悬浮球默认定位右下角 + 视口钳制 + resize 贴合 + 设置页复位按钮 (#26)

### DIFF
--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -69,6 +69,7 @@
             <span class="pt-row-label" data-i18n="rowParagraphBtn">段落悬停按钮</span>
             <button class="pt-toggle pt-on" id="pt-toggle-paragraph-btn"></button>
           </div>
+          <button class="pt-btn pt-btn-secondary" id="pt-reset-ball-pos-btn" data-i18n="btnResetBallPos">重置悬浮球位置</button>
         </div>
       </section>
 

--- a/entrypoints/options/sections/general.ts
+++ b/entrypoints/options/sections/general.ts
@@ -73,6 +73,16 @@ export function initGeneral(): void {
     savePatch({ showParagraphBtn: !getSettings().showParagraphBtn });
   });
 
+  const resetBallPosBtn = document.getElementById('pt-reset-ball-pos-btn')!;
+  resetBallPosBtn.addEventListener('click', () => {
+    chrome.storage.local.remove('pt-ball-pos').catch(() => {});
+    // 简单反馈：按钮文字短暂变化
+    resetBallPosBtn.textContent = tf('toastBallPosReset', '已重置');
+    setTimeout(() => {
+      resetBallPosBtn.textContent = tf('btnResetBallPos', '重置悬浮球位置');
+    }, 1500);
+  });
+
   syncUI();
   onSettingsChanged(() => syncUI());
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -26,6 +26,8 @@
   "cardFloatingUi": { "message": "Floating UI" },
   "rowFloatingBall": { "message": "Floating ball" },
   "rowParagraphBtn": { "message": "Paragraph hover button" },
+  "btnResetBallPos": { "message": "Reset ball position" },
+  "toastBallPosReset": { "message": "Reset" },
 
   "secEnginesDesc": { "message": "Drag to reorder engine priority (top to bottom is the failover order), and configure API keys for BYOK engines." },
   "cardPriority": { "message": "Priority (drag to reorder)" },

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -26,6 +26,8 @@
   "cardFloatingUi": { "message": "悬浮 UI" },
   "rowFloatingBall": { "message": "悬浮球" },
   "rowParagraphBtn": { "message": "段落悬停按钮" },
+  "btnResetBallPos": { "message": "重置悬浮球位置" },
+  "toastBallPosReset": { "message": "已重置" },
 
   "secEnginesDesc": { "message": "拖拽调整引擎优先级（从上到下即故障切换顺序），为 BYOK 引擎配置 API key。" },
   "cardPriority": { "message": "优先级（拖拽排序）" },

--- a/public/_locales/zh_TW/messages.json
+++ b/public/_locales/zh_TW/messages.json
@@ -26,6 +26,8 @@
   "cardFloatingUi": { "message": "浮動 UI" },
   "rowFloatingBall": { "message": "浮動球" },
   "rowParagraphBtn": { "message": "段落停留按鈕" },
+  "btnResetBallPos": { "message": "重設浮動球位置" },
+  "toastBallPosReset": { "message": "已重設" },
 
   "secEnginesDesc": { "message": "拖曳調整引擎優先順序（由上而下即故障切換順序），為 BYOK 引擎設定 API key。" },
   "cardPriority": { "message": "優先順序（拖曳排序）" },

--- a/src/ui/floating-ball.ts
+++ b/src/ui/floating-ball.ts
@@ -6,8 +6,28 @@ import { mountIsolated, unmountIsolated } from './mount';
 import { tf } from '../i18n';
 
 const BALL_POS_KEY = 'pt-ball-pos';
+const BALL_SIZE = 44;
+const VIEWPORT_MARGIN = 8;
 
 type BallState = 'idle' | 'loading' | 'done' | 'error';
+
+/**
+ * 将坐标钳制在视口内。
+ * 先取上限再取下限：视口比球还小时不会算出负值。
+ */
+function clampToViewport(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): { x: number; y: number } {
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  return {
+    x: Math.max(VIEWPORT_MARGIN, Math.min(x, vw - w - VIEWPORT_MARGIN)),
+    y: Math.max(VIEWPORT_MARGIN, Math.min(y, vh - h - VIEWPORT_MARGIN)),
+  };
+}
 
 interface BallCallbacks {
   /**
@@ -39,17 +59,24 @@ export function createBall(callbacks: BallCallbacks): () => void {
   let origX = 0;
   let origY = 0;
 
-  // 恢复持久化位置
+  // 恢复持久化位置（钳制到视口内）
   chrome.storage.local
     .get(BALL_POS_KEY)
     .then((r) => {
       const pos = r[BALL_POS_KEY] as { x: number; y: number } | undefined;
       if (pos) {
+        const clamped = clampToViewport(pos.x, pos.y, BALL_SIZE, BALL_SIZE);
+        // 钳制后与存储值不同时写回，防止下次再读到越界坐标
+        if (clamped.x !== pos.x || clamped.y !== pos.y) {
+          chrome.storage.local
+            .set({ [BALL_POS_KEY]: clamped })
+            .catch(() => {});
+        }
         ball.style.position = 'fixed';
         ball.style.right = 'auto';
         ball.style.bottom = 'auto';
-        ball.style.left = `${pos.x}px`;
-        ball.style.top = `${pos.y}px`;
+        ball.style.left = `${clamped.x}px`;
+        ball.style.top = `${clamped.y}px`;
       }
     })
     .catch(() => {});
@@ -71,11 +98,14 @@ export function createBall(callbacks: BallCallbacks): () => void {
     const dy = e.clientY - startY;
     if (Math.abs(dx) > 3 || Math.abs(dy) > 3) {
       dragged = true;
+      const rawX = origX + dx;
+      const rawY = origY + dy;
+      const clamped = clampToViewport(rawX, rawY, BALL_SIZE, BALL_SIZE);
       ball.style.position = 'fixed';
       ball.style.right = 'auto';
       ball.style.bottom = 'auto';
-      ball.style.left = `${origX + dx}px`;
-      ball.style.top = `${origY + dy}px`;
+      ball.style.left = `${clamped.x}px`;
+      ball.style.top = `${clamped.y}px`;
     }
   };
 
@@ -104,7 +134,29 @@ export function createBall(callbacks: BallCallbacks): () => void {
     callbacks.onToggle();
   });
 
+  // --- 窗口 resize 时重新贴合 ---
+  // 窗口缩小后，曾经合法的拖动位置可能落出视口。
+  // 仅在球被手动定位（position= fixed）时才需要做这件事；
+  // 默认右下角锚点由 host 的 right/bottom 保证，不受 resize 影响。
+  const onResize = () => {
+    // 拖动过程中不干预 —— onMouseMove 已经在做钳制
+    if (dragging) return;
+    // 没有手动定位的球靠 host 的 right/bottom 锚定，无需处理
+    if (ball.style.position !== 'fixed') return;
+    const rect = ball.getBoundingClientRect();
+    const clamped = clampToViewport(rect.left, rect.top, rect.width, rect.height);
+    if (clamped.x !== rect.left || clamped.y !== rect.top) {
+      ball.style.left = `${clamped.x}px`;
+      ball.style.top = `${clamped.y}px`;
+      chrome.storage.local
+        .set({ [BALL_POS_KEY]: { x: clamped.x, y: clamped.y } })
+        .catch(() => {});
+    }
+  };
+  window.addEventListener('resize', onResize);
+
   return () => {
+    window.removeEventListener('resize', onResize);
     document.removeEventListener('mousemove', onMouseMove);
     document.removeEventListener('mouseup', onMouseUp);
     clearTimeout(errorTimer);

--- a/src/ui/mount.ts
+++ b/src/ui/mount.ts
@@ -19,7 +19,7 @@ export function mountIsolated(id: string): ShadowRoot {
   // 宿主页面可能有 div { position: static !important } 之类的规则，
   // 用 all: initial 兜底
   host.style.cssText =
-    'all: initial; position: fixed; z-index: 2147483647;';
+    'all: initial; position: fixed; z-index: 2147483647; right: 24px; bottom: 24px;';
 
   const shadow = host.attachShadow({ mode: 'open' });
 


### PR DESCRIPTION
## 修复内容

Closes #26

### 根因
`.pt-ball` 及其 host 容器没有任何默认定位 —— host 的 `position: fixed` 四个偏移量全为 `auto`，导致球的默认位置取决于宿主页面 body 末尾元素的布局落点。Reddit 等使用 flex/grid 布局 body 的站点上，球完全不可见。

### 修改

**A. 默认定位 (mount.ts)**
- host 的 `cssText` 补齐 `right: 24px; bottom: 24px;`，确保球首次使用时固定在右下角

**B. 视口钳制 (floating-ball.ts)**
- 新增 `clampToViewport()` 工具函数（复用 paragraph-btn.ts 的先取上限再取下限思路）
- 位置恢复时钳制：从 storage 读回的坐标经过钳制后再写入，越界值自动修正并写回 storage
- 拖动过程中实时钳制：用户无法将球拖出视口

**C. resize 贴合 (floating-ball.ts)**
- 监听 `window.resize`，窗口缩小时自动将球拉回视口内，并持久化新位置

**D. 设置页复位入口 (general.ts + index.html)**
- "悬浮 UI"卡片内新增"重置悬浮球位置"按钮
- 点击后删除 `pt-ball-pos` 存储值，球回到右下角默认位置
- 按钮文字短暂变为"已重置"作为反馈

### 涉及文件
| 文件 | 改动 |
|------|------|
| `src/ui/mount.ts` | host cssText 补 right/bottom |
| `src/ui/floating-ball.ts` | +clampToViewport, 位置恢复/拖动钳制, +resize 监听 |
| `entrypoints/options/index.html` | 悬浮 UI 卡片 +重置按钮 |
| `entrypoints/options/sections/general.ts` | 重置按钮事件处理 |
| `public/_locales/*/messages.json` | +btnResetBallPos, +toastBallPosReset |
| `package.json` | 0.6.12 → 0.6.13 |