### PR TITLE
fix: 整页翻译零结果时显示 toast 提示，而非静默无反应 (#27)

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -135,7 +135,11 @@ export default defineContentScript({
       if (!ns.enabled) return 'disabled';
 
       const targets = elements ?? collect(document.body, registerHidden);
-      if (targets.length === 0) return 'no-elements';
+      if (targets.length === 0) {
+        if (isMainFrame)
+          toast(tf('hintNoElements', '本页没有可翻译的内容'));
+        return 'no-elements';
+      }
 
       // 归一化内部空白：硬换行切词、撑破 OpenAI 编号结构都源于未折叠的 \n。
       // translatableText 剔除 .notranslate 与站点元数据（如 Google 来源角标）。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## 修复内容

修复 #27：当整页翻译找不到可翻译内容时，不再静默无反应，而是通过 toast 给出明确提示。

### 问题

纯文本 README（<pre> 包裹）在 GitHub 上完全不翻译。用户点击翻译后静默无反应，无法区分「扩展坏了」和「这类内容不支持」。

### 修复方案

在 doTranslate() 采集到 0 个翻译单元时，用 toast 通知用户「本页没有可翻译的内容」，复用已有的 hintNoElements i18n key。

### 变更

- entrypoints/content.ts：零结果分支增加 toast 提示
- package.json：版本号 0.6.12 → 0.6.14

Closes #27