### PR TITLE
fix: 悬浮球拖动钳制使用实际渲染尺寸，消除页面缩放时拖动受限 (#28)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/styles/injected.css
+++ b/src/styles/injected.css
@@ -3,6 +3,7 @@
    设计令牌由 mount.ts 注入同一 shadow root，故 CSS 变量可用。 */
 
 .pt-ball {
+  box-sizing: border-box;
   width: 44px;
   height: 44px;
   border-radius: 50%;

--- a/src/ui/floating-ball.ts
+++ b/src/ui/floating-ball.ts
@@ -58,6 +58,10 @@ export function createBall(callbacks: BallCallbacks): () => void {
   let startY = 0;
   let origX = 0;
   let origY = 0;
+  // 球的实际渲染尺寸，从 getBoundingClientRect 获取。
+  // 页面缩放时 CSS 像素可能产生子像素差异，用实际值比硬编码 BALL_SIZE 准确。
+  let ballW = BALL_SIZE;
+  let ballH = BALL_SIZE;
 
   // 恢复持久化位置（钳制到视口内）
   chrome.storage.local
@@ -65,7 +69,8 @@ export function createBall(callbacks: BallCallbacks): () => void {
     .then((r) => {
       const pos = r[BALL_POS_KEY] as { x: number; y: number } | undefined;
       if (pos) {
-        const clamped = clampToViewport(pos.x, pos.y, BALL_SIZE, BALL_SIZE);
+        const rect = ball.getBoundingClientRect();
+        const clamped = clampToViewport(pos.x, pos.y, rect.width, rect.height);
         // 钳制后与存储值不同时写回，防止下次再读到越界坐标
         if (clamped.x !== pos.x || clamped.y !== pos.y) {
           chrome.storage.local
@@ -89,6 +94,8 @@ export function createBall(callbacks: BallCallbacks): () => void {
     const rect = ball.getBoundingClientRect();
     origX = rect.left;
     origY = rect.top;
+    ballW = rect.width;
+    ballH = rect.height;
     e.preventDefault();
   };
 
@@ -100,7 +107,7 @@ export function createBall(callbacks: BallCallbacks): () => void {
       dragged = true;
       const rawX = origX + dx;
       const rawY = origY + dy;
-      const clamped = clampToViewport(rawX, rawY, BALL_SIZE, BALL_SIZE);
+      const clamped = clampToViewport(rawX, rawY, ballW, ballH);
       ball.style.position = 'fixed';
       ball.style.right = 'auto';
       ball.style.bottom = 'auto';


### PR DESCRIPTION
## 修复内容

修复 #28：悬浮球在页面缩放（浏览器缩放）时拖动受限的问题。

### 根因

两处 bug 叠加导致缩放时钳制不准：

1. CSS：.pt-ball 默认 box-sizing: content-box，width: 44px + border: 1.5px → 实际渲染尺寸 47×47px，与 BALL_SIZE=44 不一致。
2. JS：clampToViewport 使用硬编码 BALL_SIZE=44 计算边界，比实际球宽少了 3px。页面缩放时 CSS 像素子像素渲染加剧误差。

### 修复

| 文件 | 变更 |
|------|------|
| src/styles/injected.css | .pt-ball 加 box-sizing: border-box |
| src/ui/floating-ball.ts | clampToViewport 改用 getBoundingClientRect() 获取实际尺寸 |

Closes #28