### PR TITLE
fix: 添加 host 节点守护，防止 SPA 渲染移除悬浮球宿主 (#37)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.15",
+"version": "0.6.16"
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/ui/mount.ts
+++ b/src/ui/mount.ts
@@ -6,8 +6,15 @@
 import tokens from '@/src/styles/tokens.css?inline';
 import injected from '@/src/styles/injected.css?inline';
 
+/** 活跃的 host 守护 observer，按 id 索引。同一 id 只有一个实例。 */
+const guards = new Map<string, MutationObserver>();
+
 /**
  * 创建一个与宿主页面完全隔离的挂载点。
+ *
+ * 包含自动恢复机制：如果宿主元素被页面脚本（如 React SPA 的客户端渲染）
+ * 从 DOM 中移除，MutationObserver 会检测到并自动重新挂载。
+ * 这对于 Reddit 新版等会在 document_end 之后替换 body 子节点的站点至关重要。
  */
 export function mountIsolated(id: string): ShadowRoot {
   const host = document.createElement('div');
@@ -28,9 +35,44 @@ export function mountIsolated(id: string): ShadowRoot {
   shadow.appendChild(style);
 
   document.body.appendChild(host);
+
+  // 启动守护：监听 host 被外部脚本（如 React SPA 渲染）移除的情况
+  startHostGuard(id, host);
+
   return shadow;
 }
 
 export function unmountIsolated(id: string): void {
+  // 先停掉守护，避免 observer 在我们主动移除时重新挂载
+  stopHostGuard(id);
   document.getElementById(`pt-host-${id}`)?.remove();
+}
+
+// ── 内部：host 守护 ──
+
+function startHostGuard(id: string, host: HTMLDivElement): void {
+  // 避免同一 id 注册多个 observer
+  stopHostGuard(id);
+
+  const fullId = `pt-host-${id}`;
+
+  const observer = new MutationObserver(() => {
+    // 检查 host 是否仍在文档中
+    if (!document.getElementById(fullId) && document.body) {
+      document.body.appendChild(host);
+    }
+  });
+
+  // 监听 body 的直接子节点变化（React 替换 body 内容时触发）
+  observer.observe(document.body, { childList: true });
+
+  guards.set(id, observer);
+}
+
+function stopHostGuard(id: string): void {
+  const existing = guards.get(id);
+  if (existing) {
+    existing.disconnect();
+    guards.delete(id);
+  }
 }


### PR DESCRIPTION
## 问题

Closes #37

Reddit 新版等 React SPA 在 `document_end` 之后进行客户端渲染（hydration）时，可能替换 `document.body` 的子节点，导致 `pt-host-ball` 节点被移除后悬浮球不出现。

## 修复

在 `mountIsolated` 中通过 `MutationObserver` 监听 `document.body` 的直接子节点变化：

- 当检测到 host 节点被外部脚本从 DOM 中移除时，自动重新挂载到 `document.body`
- `unmountIsolated` 在主动移除前先停掉 observer，防止守护与主动卸载冲突
- 同一 id 只注册一个 observer（`guards` Map 去重）

## 变更文件

- `src/ui/mount.ts` — 新增 `startHostGuard` / `stopHostGuard` 函数，在 mount/unmount 时配对调用
- `package.json` — 版本号 0.6.15 → 0.6.16