### PR TITLE
fix: 含行内 `code` 的段落整条不翻译 —— code 加入 INLINE_SET 并补齐遗漏行内标签 (#41)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-"version": "0.6.16"
+"version": "0.6.17",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/classify.ts
+++ b/src/dom/classify.ts
@@ -22,17 +22,30 @@ export const CONTAINER_SET = new Set([
   'div', 'section', 'article', 'main', 'figure',
 ]);
 
-/** 整棵子树跳过，不再深入 */
+/**
+ * 整棵子树跳过，不再深入。
+ * code 同时属于 INLINE_SET —— 见 INLINE_SET 注释（#41）。
+ */
 export const SKIP_SET = new Set([
   'html', 'body', 'script', 'style', 'noscript',
   'input', 'textarea', 'select', 'button',
   'code', 'pre',
 ]);
 
-/** 内联元素：自身不作为翻译单元，需向上找可翻父节点 */
+/**
+ * 内联元素：自身不作为翻译单元，需向上找可翻父节点。
+ *
+ * code 同时属于 SKIP_SET 与 INLINE_SET —— 两个集合回答不同的问题：
+ * SKIP_SET 告诉 walker「不要下沉进 code 子树」（行内代码内容不独立采集），
+ * INLINE_SET 告诉 isTranslationUnit「code 子元素不阻断父段落判定」，
+ * 使含行内代码的段落仍能被识别为翻译单元（#41）。
+ */
 export const INLINE_SET = new Set([
   'a', 'b', 'strong', 'span', 'em', 'i', 'u', 'small', 'sub', 'sup',
   'font', 'mark', 'cite', 'q', 'abbr', 'time', 'ruby', 'img', 'br', 'svg',
+  'code', 'kbd', 'samp', 'var', 'dfn',
+  'del', 'ins', 's', 'bdi', 'bdo', 'wbr',
+  'tt', 'big',
 ]);
 
 /** 应被整体跳过的非正文区域选择器（导航、页脚、侧栏、参考文献等） */

--- a/src/dom/compat.ts
+++ b/src/dom/compat.ts
@@ -4,8 +4,6 @@
 //
 // 补丁只做两件事：跳过(skip)、改指(take)。不在此处写翻译逻辑或 DOM 操作。
 
-import { normalizeText } from './normalize';
-
 type CompatResult =
   | { skip: true }
   | { take: Element }
@@ -57,14 +55,9 @@ const HANDLERS: Record<string, CompatHandler> = {
     ) {
       return { skip: true };
     }
-    // 独立的行内 code 在非 pre 上下文中通常是变量名/hash
-    if (el.tagName === 'CODE' && !el.closest('pre, .blob-code')) {
-      const text = normalizeText(el.textContent ?? '');
-      // 短 hash / 变量名 / 数字 不翻
-      if (/^[a-f0-9]{7,40}$/.test(text) || /^[._a-zA-Z]\w*$/.test(text) || /^\d+$/.test(text)) {
-        return { skip: true };
-      }
-    }
+    // 行内 code 的短 hash / 变量名 / 纯数字判定（#61-#67）已移除：
+    // walker 的 acceptNode 通过 SKIP_SET 先一步拒绝 CODE 节点，
+    // applyCompat(el) 永远收不到 CODE，该分支不可达（#41 附带分析）。
     return null;
   },
 };


### PR DESCRIPTION
## 问题

close #41

含行内 `code` 的段落（GitHub README、MDN、技术文档等极其常见）整条不翻译。根因是 `code` 只进了 `SKIP_SET` 没进 `INLINE_SET`，`isTranslationUnit()` 遍历子元素时把 code 当成「文本在更深层」的证据而判定父段落不是翻译单元。

## 修复

1. **`code` 同时加入 `INLINE_SET`**（保留在 `SKIP_SET`），使含行内代码的段落恢复为翻译单元
   - `SKIP_SET` → walker 不下沉进 code 子树（行内代码不独立采集）
   - `INLINE_SET` → isTranslationUnit 不因 code 阻断父段落判定
2. **补齐 `INLINE_SET` 遗漏的行内标签**：`kbd`、`samp`、`var`、`dfn`、`del`、`ins`、`s`、`bdi`、`bdo`、`wbr`、`tt`、`big`
3. **移除 compat.ts 中不可达的 CODE 行内判定分支**（walker acceptNode 先一步通过 SKIP_SET 拒绝 CODE 节点）

## 验证

- TypeScript 类型检查通过
- 构建 chrome/firefox/edge 三目标成功