### PR TITLE
fix: directTextLength() trim 格式化空白，修复壳容器误判为翻译单元

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-"version": "0.6.16"
+"version": "0.6.17",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/classify.ts
+++ b/src/dom/classify.ts
@@ -119,11 +119,11 @@ export function isTranslationUnit(el: Element): boolean {
   return true;
 }
 
-/** 直接子文本节点的字符数（不深入子元素）。div 型正文判定的依据 */
+/** 直接子文本节点的有效字符数（不深入子元素，trim 后计数，排除格式化空白）。div 型正文判定的依据 */
 function directTextLength(el: Element): number {
   let len = 0;
   for (const node of el.childNodes) {
-    if (node.nodeType === Node.TEXT_NODE) len += (node.textContent ?? '').length;
+    if (node.nodeType === Node.TEXT_NODE) len += (node.textContent ?? '').trim().length;
   }
   return len;
 }


### PR DESCRIPTION
## 修复内容

`directTextLength()` 按 trim 后长度计数，一处改动同时修好两道关口。

## 根因

格式化 HTML 中元素之间的换行缩进（`\n      `）被当作直接文本节点，`directTextLength()` 不 trim 直接累加，导致：

- **CONTAINER_SET 门槛被绕过**：纯壳 `<div>` 的直接文本长度为 12~36（全来自换行缩进），`> 0` → 门槛形同虚设
- **hasDirect 被误置为 true**：祖先元素即使没有自己的文字，也因空白而被当作"持有直接文本"，`return false` 分支永远走不到

实测 GitHub PR 页 81 个采集单元中 54% 是壳容器，51% 处在祖先-后代包含关系中。

## 修改

`src/dom/classify.ts:126` — `directTextLength()` 加 `.trim()`：

```diff
- if (node.nodeType === Node.TEXT_NODE) len += (node.textContent ?? ).length;
+ if (node.nodeType === Node.TEXT_NODE) len += (node.textContent ?? ).trim().length;
```

## 影响

- 壳容器（直接文本 trim 后为 0）重新被门槛拦下，`isTranslationUnit()` 返回 false
- `hasDirect` 只在元素真正持有自己的文字时为真，祖先-后代对称性恢复
- `shallowTranslatableText()` 无需改动：其输出经过 `normalizeText()`，且它只做文本提取不做布尔判定

Closes #48