### PR TITLE
fix: closestUnit 与 render 准入标准一致，避免单段翻译「先请求后拒绝」(#50)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-"version": "0.6.17",
+"version": "0.6.18",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/classify.ts
+++ b/src/dom/classify.ts
@@ -93,6 +93,62 @@ export function shouldSkip(el: Element): boolean {
   return false;
 }
 
+/**
+ * 子树中含有不应被藏进 .pt-origin 的节点时的匹配选择器。
+ * img / video / iframe 等是可见媒体内容，button / input 等是交互控件，
+ * 若被搬进 display:none 的隐藏容器，卡片结构就塌了（#22）。
+ *
+ * #50：此选择器同时用于采集侧（closestUnit + collect），
+ * 在按钮浮出/采集阶段就把含非文本内容的容器排除掉，
+ * render() 里保留同一道检查作为纵深防御。
+ */
+export const NON_TEXT_SELECTOR =
+  'img, picture, video, audio, iframe, canvas, object, embed,' +
+  ' button, input, select, textarea,' +
+  ' [role="button"], [role="tab"], [role="menuitem"], [role="switch"], [role="checkbox"]';
+
+/** 元素子树中是否含有非文本内容（媒体 / 交互控件），若有则不应整体翻译。 */
+export function hasNonTextContent(el: Element): boolean {
+  return el.querySelector(NON_TEXT_SELECTOR) !== null;
+}
+
+/**
+ * 从含非文本内容的容器向下搜索，找到子树里真正持有文本的纯文本翻译单元。
+ *
+ * #50：命中非文本内容时，与其返回 null，不如继续向下找到那个叶子单元 ——
+ * 这直接决定 PR 页那 5193 字符是「翻不了」还是「翻得了」。
+ */
+function findTextOnlyDescendant(
+  container: Element,
+  origin: Element,
+): Element | null {
+  let best: Element | null = null;
+  let bestDepth = -1;
+
+  // 只在含 origin 的分支里搜索，避免扫到无关兄弟子树
+  function dfs(el: Element, depth: number): void {
+    if (
+      el !== container &&
+      el.contains(origin) &&
+      isTranslationUnit(el) &&
+      !hasNonTextContent(el) &&
+      !shouldSkip(el)
+    ) {
+      // 越深越好 —— leaf-most text-only unit
+      if (depth > bestDepth) {
+        best = el;
+        bestDepth = depth;
+      }
+    }
+    for (const child of el.children) {
+      if (child.contains(origin)) dfs(child, depth + 1);
+    }
+  }
+
+  dfs(container, 0);
+  return best;
+}
+
 /** 纯数字、日期、计数（"1.2k"、"2026-07-30"）翻了没意义还浪费额度 */
 function isMainlyNumeric(text: string): boolean {
   if (text.length > 30) return false;
@@ -146,6 +202,9 @@ function directTextLength(el: Element): number {
  * 按钮路径与 translateOne 共用 —— 判定标准与采集器同一套，不再各立门户，
  * 白名单之外的大容器（如 AI 概览的外层 li）不会再被错误命中。
  *
+ * #50：同时检查非文本内容（媒体 / 交互控件），与 render() 准入标准一致。
+ * 若命中则向下降级到子树中真正持有文本的叶子单元，而非整块放弃。
+ *
  * shouldSkip 有强制同步布局的昂贵步骤（outerHTML、getBoundingClientRect），
  * 只应在低频率路径调用：悬停意图计时器、点击/快捷键入口，不能挂在
  * 每次 mouseover 上。
@@ -153,7 +212,18 @@ function directTextLength(el: Element): number {
 export function closestUnit(el: Element): Element | null {
   let cur: Element | null = el;
   while (cur) {
-    if (isTranslationUnit(cur) && !shouldSkip(cur)) return cur;
+    if (isTranslationUnit(cur) && !shouldSkip(cur)) {
+      // #50：容器含媒体 / 交互控件时，向下降级到纯文本后代。
+      // 否则用户看到一个注定失败的段落按钮，等一次网络往返后被 render() 拒绝。
+      if (hasNonTextContent(cur)) {
+        const descendant = findTextOnlyDescendant(cur, el);
+        if (descendant) return descendant;
+        // 无纯文本后代 —— 继续向上找，避免把含非文本内容的容器
+        // 误判为可翻单元（它会回到这里再次尝试向下降级）。
+      } else {
+        return cur;
+      }
+    }
     cur = cur.parentElement;
   }
   return null;

--- a/src/dom/renderer.ts
+++ b/src/dom/renderer.ts
@@ -8,19 +8,10 @@
 // 结构与事件监听器。
 
 import type { DisplayMode, StyleId } from '../storage/schema';
+import { hasNonTextContent } from './classify';
 
 /** 渲染来源：区分整页翻译与单段翻译，落成 data-pt-src 属性供 CSS 分流。 */
 export type RenderSource = 'page' | 'para';
-
-/**
- * 子树中含有不应被藏进 .pt-origin 的节点时的匹配选择器。
- * img / video / iframe 等是可见媒体内容，button / input 等是交互控件，
- * 若被搬进 display:none 的隐藏容器，卡片结构就塌了（#22）。
- */
-const NON_TEXT_SELECTOR =
-  'img, picture, video, audio, iframe, canvas, object, embed,' +
-  ' button, input, select, textarea,' +
-  ' [role="button"], [role="tab"], [role="menuitem"], [role="switch"], [role="checkbox"]';
 
 /**
  * 渲染译文。三种模式共用同一套 DOM 结构。
@@ -36,10 +27,13 @@ export function render(
   if (el.getAttribute('data-pt') === 'done') return true;
 
   // 纵深防御：拒绝含非文本内容的容器，防止缩略图、按钮等被藏进
-  // display:none 的 .pt-origin（#22）。此检查与采集器的 isTranslationUnit
-  // 互补 —— 后者允许 img（内联元素），render() 则对可见媒体说「不」。
-  if (el.querySelector(NON_TEXT_SELECTOR)) {
-    console.warn('[PT] render 拒绝：元素含非文本内容（媒体 / 交互控件）', el);
+  // display:none 的 .pt-origin（#22）。
+  //
+  // #50：主守卫已前移到 classify.ts 的 closestUnit() 与 collect() 中，
+  // 正常路径不应再走到这里。保留此检查为纵深防御，仅在最外层代码路径
+  // 绕过采集器（如手动构造 DOM 元素调用）时兜底。
+  if (hasNonTextContent(el)) {
+    console.warn('[PT] render 拒绝（纵深防御）：元素含非文本内容（媒体 / 交互控件）', el);
     return false;
   }
 

--- a/src/dom/walker.ts
+++ b/src/dom/walker.ts
@@ -7,7 +7,7 @@
 // Phase 8 接入域名级采集补丁（src/dom/compat.ts），
 // 在通用规则判定之前给特定站点插入决策。
 
-import { SKIP_SET, shouldSkipNonVisual, isVisible, isTranslationUnit } from './classify';
+import { SKIP_SET, shouldSkipNonVisual, isVisible, isTranslationUnit, hasNonTextContent } from './classify';
 import { applyCompat } from './compat';
 
 /**
@@ -79,6 +79,13 @@ function walk(
     // 判定顺序不能反：isTranslationUnit() 首步只是一次标签查表，而
     // shouldSkipNonVisual() 要拼 outerHTML、算 textContent。先便宜后昂贵。
     if (!seen.has(el) && isTranslationUnit(el)) {
+      // #50：含媒体/交互控件的容器不能整体翻译（render 会拒绝），
+      // 跳过但不影响子树 —— walker 依旧会访问其子元素，
+      // 它们可能是不含非文本内容的纯文本翻译单元。
+      if (hasNonTextContent(el)) {
+        node = walker.nextNode();
+        continue;
+      }
       if (shouldSkipNonVisual(el)) {
         node = walker.nextNode();
         continue;


### PR DESCRIPTION
## 问题

`closestUnit()` 不检查媒体/交互控件，`render()` 才检查。用户看到段落按钮 → 点击 → 等待网络往返 → 被拒绝，浪费时间和 API 额度。

## 修复

1. **守卫前移**：`NON_TEXT_SELECTOR` 检查抽成 `classify.ts` 的 `hasNonTextContent()` 导出函数，`closestUnit()` 与 `collect()` 共用
2. **向下降级**：`closestUnit()` 命中非文本内容时，通过 `findTextOnlyDescendant()` 向子树搜索纯文本后代，而非整块放弃
3. **纵深防御**：`render()` 保留同一道检查，复用 `hasNonTextContent()`，仅在绕过采集器的路径上兜底

## 改动文件

- `src/dom/classify.ts` — 新增 `NON_TEXT_SELECTOR`、`hasNonTextContent()`、`findTextOnlyDescendant()`；修改 `closestUnit()`
- `src/dom/walker.ts` — `collect()` 在 `isTranslationUnit` 后加 `hasNonTextContent` 检查
- `src/dom/renderer.ts` — 复用 `classify.ts` 的 `hasNonTextContent()`，移除本地 `NON_TEXT_SELECTOR`

Closes #50