### PR TITLE
fix: DOMException 错误信息丢失 —— String(e) 输出 [object DOMException] 而非真实错误消息 (#54)

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -76,9 +76,9 @@ export default defineBackground(() => {
       settingsReady()
         .then(() => route(msg.payload))
         .then((r) => sendResponse({ ok: true, data: r }))
-        .catch((e) => sendResponse({ ok: false, error: String(e) }));
+        .catch((e) => sendResponse({ ok: false, error: e instanceof Error ? e.message : String(e) }));
     } catch (e) {
-      sendResponse({ ok: false, error: String(e) });
+      sendResponse({ ok: false, error: e instanceof Error ? e.message : String(e) });
     }
 
     return true;

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -134,7 +134,14 @@ export default defineContentScript({
       const ns = getSettings();
       if (!ns.enabled) return 'disabled';
 
-      const targets = elements ?? collect(document.body, registerHidden);
+      let targets: Element[];
+      try {
+        targets = elements ?? collect(document.body, registerHidden);
+      } catch (e) {
+        throw new Error(
+          `[collect] ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
       if (targets.length === 0) {
         if (isMainFrame)
           toast(tf('hintNoElements', '本页没有可翻译的内容'));
@@ -184,10 +191,16 @@ export default defineContentScript({
 
           const translations: string[] = resp.data.translations;
           for (let i = 0; i < batchTargets.length; i++) {
-            if (render(batchTargets[i]!, translations[i]!, 'page')) {
-              renderSucceeded++;
-            } else {
-              renderRejected++;
+            try {
+              if (render(batchTargets[i]!, translations[i]!, 'page')) {
+                renderSucceeded++;
+              } else {
+                renderRejected++;
+              }
+            } catch (e) {
+              throw new Error(
+                `[render idx=${i}] ${e instanceof Error ? e.message : String(e)}`,
+              );
             }
           }
         }),
@@ -280,9 +293,10 @@ export default defineContentScript({
       try {
         status = await doTranslate();
       } catch (e) {
-        console.error('[PT] 翻译失败:', e);
+        const msg = e instanceof Error ? e.message : String(e);
+        console.error('[PT] 翻译失败:', msg, e);
         if (isMainFrame) {
-          toast(String(e), 'error');
+          toast(msg, 'error');
           setBallState('error');
         }
         return 'error';
@@ -371,9 +385,9 @@ export default defineContentScript({
         try {
           togglePage()
             .then((status) => reply({ ok: true, status }))
-            .catch((e: Error) => reply({ ok: false, error: String(e) }));
+            .catch((e: Error) => reply({ ok: false, error: e instanceof Error ? e.message : String(e) }));
         } catch (e) {
-          reply({ ok: false, error: String(e) });
+          reply({ ok: false, error: e instanceof Error ? e.message : String(e) });
         }
         return isMainFrame ? true : undefined;
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-"version": "0.6.19",
+"version": "0.6.20",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/walker.ts
+++ b/src/dom/walker.ts
@@ -62,42 +62,51 @@ function walk(
 
     // Phase 8 域名补丁：在通用判定之前给特定站点插入决策。
     // 补丁的 skip/take 优先于通用规则；null 则交回通用逻辑。
-    const patched = applyCompat(el);
-    if (patched && 'skip' in patched) {
-      node = walker.nextNode();
-      continue;
-    }
-    if (patched && 'take' in patched) {
-      if (!seen.has(el)) {
-        seen.add(el);
-        out.push(patched.take);
+    //
+    // Web Components（<relative-time>、<clipboard-copy> 等）上访问
+    // textContent / outerHTML / closest() 可能抛出 DOMException，
+    // 用 try-catch 包裹整段逐元素判定，失败时安全跳过当前节点，
+    // 宁可漏翻单个可疑节点也不要整页崩溃（#54）。
+    try {
+      const patched = applyCompat(el);
+      if (patched && 'skip' in patched) {
+        node = walker.nextNode();
+        continue;
       }
-      node = walker.nextNode();
-      continue;
-    }
+      if (patched && 'take' in patched) {
+        if (!seen.has(el)) {
+          seen.add(el);
+          out.push(patched.take);
+        }
+        node = walker.nextNode();
+        continue;
+      }
 
-    // 判定顺序不能反：isTranslationUnit() 首步只是一次标签查表，而
-    // shouldSkipNonVisual() 要拼 outerHTML、算 textContent。先便宜后昂贵。
-    if (!seen.has(el) && isTranslationUnit(el)) {
-      // #50：含媒体/交互控件的容器不能整体翻译（render 会拒绝），
-      // 跳过但不影响子树 —— walker 依旧会访问其子元素，
-      // 它们可能是不含非文本内容的纯文本翻译单元。
-      if (hasNonTextContent(el)) {
-        node = walker.nextNode();
-        continue;
+      // 判定顺序不能反：isTranslationUnit() 首步只是一次标签查表，而
+      // shouldSkipNonVisual() 要拼 outerHTML、算 textContent。先便宜后昂贵。
+      if (!seen.has(el) && isTranslationUnit(el)) {
+        // #50：含媒体/交互控件的容器不能整体翻译（render 会拒绝），
+        // 跳过但不影响子树 —— walker 依旧会访问其子元素，
+        // 它们可能是不含非文本内容的纯文本翻译单元。
+        if (hasNonTextContent(el)) {
+          node = walker.nextNode();
+          continue;
+        }
+        if (shouldSkipNonVisual(el)) {
+          node = walker.nextNode();
+          continue;
+        }
+        // #23：不可见的翻译单元记入延迟队列，等 IntersectionObserver 补翻
+        if (!isVisible(el)) {
+          onHidden?.(el);
+          node = walker.nextNode();
+          continue;
+        }
+        seen.add(el);
+        out.push(el);
       }
-      if (shouldSkipNonVisual(el)) {
-        node = walker.nextNode();
-        continue;
-      }
-      // #23：不可见的翻译单元记入延迟队列，等 IntersectionObserver 补翻
-      if (!isVisible(el)) {
-        onHidden?.(el);
-        node = walker.nextNode();
-        continue;
-      }
-      seen.add(el);
-      out.push(el);
+    } catch {
+      // Web Components 等节点上 DOM 属性访问可能抛异常，安全跳过
     }
     node = walker.nextNode();
   }

--- a/src/engines/router.ts
+++ b/src/engines/router.ts
@@ -136,7 +136,7 @@ export async function route(req: TranslateRequest): Promise<TranslateResponse> {
       };
     } catch (e) {
       const err =
-        e instanceof EngineError ? e : new EngineError(id, true, String(e));
+        e instanceof EngineError ? e : new EngineError(id, true, e instanceof Error ? e.message : String(e));
       errors.push(err);
       if (!err.retryable) throw err;
       // retryable → 下一个引擎重试


### PR DESCRIPTION
## 修复内容

### 1. 正确提取 DOMException 的 message（必须）

所有 `String(e)` 站点改为 `e instanceof Error ? e.message : String(e)`，覆盖 7 处：

| 文件 | 位置 | 说明 |
|------|------|------|
| `entrypoints/content.ts` | togglePage catch / popup reply ×2 | toast 与日志中的错误消息 |
| `entrypoints/background.ts` | sendResponse 错误路径 ×2 | 翻译代理的错误回传 |
| `src/engines/router.ts` | EngineError 构造 | 引擎错误的 message 字段 |

`DOMException` 继承自 `Error`，`.name` 与 `.message` 均已有值，但 `String(e)` 在特定 console 实现中走 `Object.prototype.toString` 路径，输出 `[object DOMException]` 而非真实错误描述。

### 2. 为 walker 逐元素判定增加防御（推荐）

`src/dom/walker.ts` 中的 `applyCompat` / `shouldSkipNonVisual` / `hasNonTextContent` 调用包裹在 try-catch 中。GitHub 大量 Web Components（`<relative-time>`、`<clipboard-copy>`、`<include-fragment>` 等）上访问 `textContent` / `outerHTML` 的 getter 可能抛出，失败时安全跳过当前节点，宁可漏翻单个可疑节点也不要整页崩溃。

### 3. 为 doTranslate 增加阶段标记（推荐）

- `collect()` 阶段异常标记为 `[collect]`
- `render()` 阶段异常标记为 `[render idx=N]`

即使 `.message` 不完整也能缩小排查范围。

Closes #54