### PR TITLE
fix: hasNonTextContent 从存在性判定改为位置性判定，避免行内 favicon 角标导致整段拒翻 (#55)

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -76,9 +76,9 @@ export default defineBackground(() => {
       settingsReady()
         .then(() => route(msg.payload))
         .then((r) => sendResponse({ ok: true, data: r }))
-        .catch((e) => sendResponse({ ok: false, error: String(e) }));
+        .catch((e) => sendResponse({ ok: false, error: e instanceof Error ? e.message : String(e) }));
     } catch (e) {
-      sendResponse({ ok: false, error: String(e) });
+      sendResponse({ ok: false, error: e instanceof Error ? e.message : String(e) });
     }
 
     return true;

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -134,7 +134,14 @@ export default defineContentScript({
       const ns = getSettings();
       if (!ns.enabled) return 'disabled';
 
-      const targets = elements ?? collect(document.body, registerHidden);
+      let targets: Element[];
+      try {
+        targets = elements ?? collect(document.body, registerHidden);
+      } catch (e) {
+        throw new Error(
+          `[collect] ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
       if (targets.length === 0) {
         if (isMainFrame)
           toast(tf('hintNoElements', '本页没有可翻译的内容'));
@@ -184,10 +191,16 @@ export default defineContentScript({
 
           const translations: string[] = resp.data.translations;
           for (let i = 0; i < batchTargets.length; i++) {
-            if (render(batchTargets[i]!, translations[i]!, 'page')) {
-              renderSucceeded++;
-            } else {
-              renderRejected++;
+            try {
+              if (render(batchTargets[i]!, translations[i]!, 'page')) {
+                renderSucceeded++;
+              } else {
+                renderRejected++;
+              }
+            } catch (e) {
+              throw new Error(
+                `[render idx=${i}] ${e instanceof Error ? e.message : String(e)}`,
+              );
             }
           }
         }),
@@ -280,9 +293,10 @@ export default defineContentScript({
       try {
         status = await doTranslate();
       } catch (e) {
-        console.error('[PT] 翻译失败:', e);
+        const msg = e instanceof Error ? e.message : String(e);
+        console.error('[PT] 翻译失败:', msg, e);
         if (isMainFrame) {
-          toast(String(e), 'error');
+          toast(msg, 'error');
           setBallState('error');
         }
         return 'error';
@@ -371,9 +385,9 @@ export default defineContentScript({
         try {
           togglePage()
             .then((status) => reply({ ok: true, status }))
-            .catch((e: Error) => reply({ ok: false, error: String(e) }));
+            .catch((e: Error) => reply({ ok: false, error: e instanceof Error ? e.message : String(e) }));
         } catch (e) {
-          reply({ ok: false, error: String(e) });
+          reply({ ok: false, error: e instanceof Error ? e.message : String(e) });
         }
         return isMainFrame ? true : undefined;
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-"version": "0.6.19",
+"version": "0.6.20",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/classify.ts
+++ b/src/dom/classify.ts
@@ -107,9 +107,26 @@ export const NON_TEXT_SELECTOR =
   ' button, input, select, textarea,' +
   ' [role="button"], [role="tab"], [role="menuitem"], [role="switch"], [role="checkbox"]';
 
-/** 元素子树中是否含有非文本内容（媒体 / 交互控件），若有则不应整体翻译。 */
+/**
+ * 元素子树中是否含有非文本内容（媒体 / 交互控件），若有则不应整体翻译。
+ *
+ * 判定从「存在性」改为「位置性」：#55 —— 只有当非文本节点不在本段的
+ * 内联文本流中时才阻断。从匹配到的非文本节点沿祖先链上溯到目标元素，
+ * 若路径上每一层都是 INLINE_SET 标签，说明是行内装饰（favicon 角标、
+ * badge 等），不应阻止翻译；否则视为独立媒体块，仍然拒绝。
+ */
 export function hasNonTextContent(el: Element): boolean {
-  return el.querySelector(NON_TEXT_SELECTOR) !== null;
+  const matches = el.querySelectorAll(NON_TEXT_SELECTOR);
+  for (const match of matches) {
+    let cur: Element | null = match;
+    while (cur && cur !== el) {
+      if (!INLINE_SET.has(cur.tagName.toLowerCase())) {
+        return true;
+      }
+      cur = cur.parentElement;
+    }
+  }
+  return false;
 }
 
 /**

--- a/src/dom/walker.ts
+++ b/src/dom/walker.ts
@@ -62,42 +62,51 @@ function walk(
 
     // Phase 8 域名补丁：在通用判定之前给特定站点插入决策。
     // 补丁的 skip/take 优先于通用规则；null 则交回通用逻辑。
-    const patched = applyCompat(el);
-    if (patched && 'skip' in patched) {
-      node = walker.nextNode();
-      continue;
-    }
-    if (patched && 'take' in patched) {
-      if (!seen.has(el)) {
-        seen.add(el);
-        out.push(patched.take);
+    //
+    // Web Components（<relative-time>、<clipboard-copy> 等）上访问
+    // textContent / outerHTML / closest() 可能抛出 DOMException，
+    // 用 try-catch 包裹整段逐元素判定，失败时安全跳过当前节点，
+    // 宁可漏翻单个可疑节点也不要整页崩溃（#54）。
+    try {
+      const patched = applyCompat(el);
+      if (patched && 'skip' in patched) {
+        node = walker.nextNode();
+        continue;
       }
-      node = walker.nextNode();
-      continue;
-    }
+      if (patched && 'take' in patched) {
+        if (!seen.has(el)) {
+          seen.add(el);
+          out.push(patched.take);
+        }
+        node = walker.nextNode();
+        continue;
+      }
 
-    // 判定顺序不能反：isTranslationUnit() 首步只是一次标签查表，而
-    // shouldSkipNonVisual() 要拼 outerHTML、算 textContent。先便宜后昂贵。
-    if (!seen.has(el) && isTranslationUnit(el)) {
-      // #50：含媒体/交互控件的容器不能整体翻译（render 会拒绝），
-      // 跳过但不影响子树 —— walker 依旧会访问其子元素，
-      // 它们可能是不含非文本内容的纯文本翻译单元。
-      if (hasNonTextContent(el)) {
-        node = walker.nextNode();
-        continue;
+      // 判定顺序不能反：isTranslationUnit() 首步只是一次标签查表，而
+      // shouldSkipNonVisual() 要拼 outerHTML、算 textContent。先便宜后昂贵。
+      if (!seen.has(el) && isTranslationUnit(el)) {
+        // #50：含媒体/交互控件的容器不能整体翻译（render 会拒绝），
+        // 跳过但不影响子树 —— walker 依旧会访问其子元素，
+        // 它们可能是不含非文本内容的纯文本翻译单元。
+        if (hasNonTextContent(el)) {
+          node = walker.nextNode();
+          continue;
+        }
+        if (shouldSkipNonVisual(el)) {
+          node = walker.nextNode();
+          continue;
+        }
+        // #23：不可见的翻译单元记入延迟队列，等 IntersectionObserver 补翻
+        if (!isVisible(el)) {
+          onHidden?.(el);
+          node = walker.nextNode();
+          continue;
+        }
+        seen.add(el);
+        out.push(el);
       }
-      if (shouldSkipNonVisual(el)) {
-        node = walker.nextNode();
-        continue;
-      }
-      // #23：不可见的翻译单元记入延迟队列，等 IntersectionObserver 补翻
-      if (!isVisible(el)) {
-        onHidden?.(el);
-        node = walker.nextNode();
-        continue;
-      }
-      seen.add(el);
-      out.push(el);
+    } catch {
+      // Web Components 等节点上 DOM 属性访问可能抛异常，安全跳过
     }
     node = walker.nextNode();
   }

--- a/src/engines/router.ts
+++ b/src/engines/router.ts
@@ -136,7 +136,7 @@ export async function route(req: TranslateRequest): Promise<TranslateResponse> {
       };
     } catch (e) {
       const err =
-        e instanceof EngineError ? e : new EngineError(id, true, String(e));
+        e instanceof EngineError ? e : new EngineError(id, true, e instanceof Error ? e.message : String(e));
       errors.push(err);
       if (!err.retryable) throw err;
       // retryable → 下一个引擎重试


### PR DESCRIPTION
## 修复内容

修复 `hasNonTextContent()` 的判定逻辑：从 **存在性**（任意后代匹配即拒绝）改为 **位置性**（仅当非文本节点不在行内文本流中才拒绝）。

## 问题

NON_TEXT_SELECTOR 包含 `img` 与 `[role="button"]`，而 `hasNonTextContent()` 使用 `el.querySelector()` 做全子树匹配，不问深度。当段落内嵌行内角标（`<span role="button"><img src="favicon">`）时：

- `isTranslationUnit()` 返回 `true`（`img` 在 INLINE_SET，不阻断段落判定）
- `hasNonTextContent()` 返回 `true`（全子树匹配到 `img`）
- 后者覆盖前者，整段被采集与段落按钮双双拒绝

影响面：Google AI 概览来源角标、维基百科行内图标、文档站 badge 等任何「正文段落 + 行内图标」的排版。

## 修复逻辑

沿非文本命中节点上溯至目标元素：若路径上每一层都是 `INLINE_SET` 标签，则视为行内装饰（favicon、badge），放行翻译；否则仍视为独立媒体块，拒绝。

三处调用点（`collect` / `closestUnit` / `render`）共用同一函数，#50 确立的「采集与渲染准入一致」不变式保持不变。

## 受影响场景

| 场景 | 修复前 | 修复后 |
|---|---|---|
| AI 概览角标段落 (`p > span[role=button] > img`) | 整段拒翻 | 正常翻译 |
| 维基百科行内图标 | 整段拒翻 | 正常翻译 |
| 缩略图卡片 (`figure > img`) | 拒绝 ✓ | 拒绝 ✓ |
| 块级 button 直接子元素 | 拒绝 ✓ | 拒绝 ✓ |

Closes #55