### PR TITLE
fix: shouldOmitText 新增通用行内角标识别，不再只依赖 Google 混淆类名 (#56)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-"version": "0.6.20",
+"version": "0.6.21",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/compat.ts
+++ b/src/dom/compat.ts
@@ -24,16 +24,28 @@ const MAX_FAVICON_PX = 24;
 const MAX_BADGE_TEXT = 40;
 
 /**
- * 元素是否包含 favicon 尺寸的图片（任一边 ≤ MAX_FAVICON_PX）。
- * 来源角标通常内嵌站点 favicon，而正文内链不含此类小图。
+ * 折叠计数角标："+3"、" +12"。+N 必须顶在行首或空白之后、
+ * 位于文本末尾 —— 排除 "iPhone 16+128GB"、"电话 +86 123"、"团队+2"
+ * 这类正文形态。{1,3} 限制数字位数，应对真实来源折叠计数。
+ */
+const COUNTER_RE = /(^|\s)\+\d{1,3}$/;
+
+/**
+ * 元素是否包含 favicon 尺寸的图片（宽高均 ≤ MAX_FAVICON_PX）。
+ * 用 img.width（CSS 渲染宽，未加载时回退 width 属性）而非
+ * getBoundingClientRect：不强制同步布局、2x retina（16 CSS px 的
+ * 32px 自然宽）仍命中、懒加载未解码的 favicon 也能按属性判定。
  */
 function hasFaviconImage(el: Element): boolean {
-  const imgs = el.querySelectorAll('img');
+  const imgs = el.getElementsByTagName('img');
   for (const img of imgs) {
-    const rect = img.getBoundingClientRect();
+    const w = img.width || img.naturalWidth;
+    const h = img.height || img.naturalHeight;
     if (
-      (rect.width > 0 && rect.width <= MAX_FAVICON_PX) ||
-      (rect.height > 0 && rect.height <= MAX_FAVICON_PX)
+      w > 0 &&
+      w <= MAX_FAVICON_PX &&
+      h > 0 &&
+      h <= MAX_FAVICON_PX
     ) {
       return true;
     }
@@ -58,8 +70,8 @@ function isGenericInlineBadge(el: Element): boolean {
   const text = el.textContent?.trim() ?? '';
   if (text.length === 0 || text.length > MAX_BADGE_TEXT) return false;
 
-  // 信号 1：以 +N 结尾（"+3"、"+5 more"、"+10条"）
-  if (/\+\d+/.test(text)) return true;
+  // 信号 1：以「行首/空白 + +N」结尾（"+3"、" +12"）
+  if (COUNTER_RE.test(text)) return true;
 
   // 信号 2：交互角色 + favicon 尺寸图片
   const hasInteractiveRole =

--- a/src/dom/compat.ts
+++ b/src/dom/compat.ts
@@ -4,6 +4,8 @@
 //
 // 补丁只做两件事：跳过(skip)、改指(take)。不在此处写翻译逻辑或 DOM 操作。
 
+import { INLINE_SET } from './classify';
+
 type CompatResult =
   | { skip: true }
   | { take: Element }
@@ -12,6 +14,62 @@ type CompatResult =
 type CompatHandler = (el: Element) => CompatResult;
 
 type OmitHandler = (el: Element) => boolean;
+
+// ---- 通用行内角标检测 ----
+
+/** Favicon 尺寸上限（像素），超过此值视为内容图片而非角标图标 */
+const MAX_FAVICON_PX = 24;
+
+/** 角标文字长度上限（字符），超过此值视为正文片段而非角标 */
+const MAX_BADGE_TEXT = 40;
+
+/**
+ * 元素是否包含 favicon 尺寸的图片（任一边 ≤ MAX_FAVICON_PX）。
+ * 来源角标通常内嵌站点 favicon，而正文内链不含此类小图。
+ */
+function hasFaviconImage(el: Element): boolean {
+  const imgs = el.querySelectorAll('img');
+  for (const img of imgs) {
+    const rect = img.getBoundingClientRect();
+    if (
+      (rect.width > 0 && rect.width <= MAX_FAVICON_PX) ||
+      (rect.height > 0 && rect.height <= MAX_FAVICON_PX)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * 通用行内来源角标识别 —— 跨站生效，不依赖类名。
+ *
+ * 识别混在正文里的角标 chip（来源链接、"YouTube +3" 等），它们不是
+ * 可翻译正文而是 UI 元数据，译文不该包含角标文字，也不应浪费引擎额度。
+ *
+ * 信号（命中任一即返回 true）：
+ * 1. 文本以 +N 结尾 —— 极强信号，正文几乎不会以 "+3" 结尾
+ * 2. 交互角色 + favicon 尺寸图片 —— 来源链接 chip 的典型结构
+ */
+function isGenericInlineBadge(el: Element): boolean {
+  const tag = el.tagName.toLowerCase();
+  if (!INLINE_SET.has(tag)) return false;
+
+  const text = el.textContent?.trim() ?? '';
+  if (text.length === 0 || text.length > MAX_BADGE_TEXT) return false;
+
+  // 信号 1：以 +N 结尾（"+3"、"+5 more"、"+10条"）
+  if (/\+\d+/.test(text)) return true;
+
+  // 信号 2：交互角色 + favicon 尺寸图片
+  const hasInteractiveRole =
+    el.matches('[role="button"], [role="link"]') || tag === 'a';
+  if (hasInteractiveRole && hasFaviconImage(el)) return true;
+
+  return false;
+}
+
+// ---- 域名精修补丁 ----
 
 /**
  * 取主域名（末两段）。
@@ -90,14 +148,22 @@ export function applyCompat(el: Element): CompatResult {
  * 文本内容 —— AI 概览的来源角标是行内元素，永远当不成单元，只能从
  * 文本层面剔除。
  *
- * 类名来自社区抓包记录而非官方文档，Google 改版可能失效 —— 失效只是
- * 噪声回退（chip 文本重新进入译文），不会翻错。
+ * 规则分两层：通用行内角标检测（isGenericInlineBadge，跨站）、
+ * 域名补丁（本表，精修层）。通用规则覆盖 Bing / DuckDuckGo / Perplexity
+ * 等未单独适配但角标形态相同的站点。
+ *
+ * 类名来自社区抓包记录而非官方文档，Google 改版可能失效 ——
+ * 失效时通用规则兜底，角标文字仍会被剔除。
  */
 const OMIT_HANDLERS: Record<string, OmitHandler> = {
   'google.com': (el: Element) => el.matches('span.wJwe6c, .WTfRgd'),
 };
 
 export function shouldOmitText(el: Element): boolean {
+  // 通用行内角标检测（跨站，不依赖类名）
+  if (isGenericInlineBadge(el)) return true;
+
+  // 域名精修补丁
   const handler = OMIT_HANDLERS[mainDomain(location.hostname)];
   if (!handler) return false;
   return handler(el);


### PR DESCRIPTION
## 修复内容

#55 将 `hasNonTextContent()` 改为位置性判定后，行内 favicon 角标不再阻止段落采集，角标文字（如 "YouTube +3"）随之进入 `translatableText()` 输出并混进译文。此前唯一防线是 `shouldOmitText()` 中针对 `google.com` 的混淆类名匹配（`span.wJwe6c, .WTfRgd`），存在三个问题：
1. 依赖 Google 编译产物的混淆类名，改版即失效
2. 仅覆盖 google.com，Bing / DuckDuckGo / Perplexity 等有同形态角标但完全无防护
3. 无通用兜底

## 修复逻辑

在 `shouldOmitText()` 中新增 **通用行内角标识别**（`isGenericInlineBadge`），跨站生效、不依赖类名。规则分两层：

| 层 | 说明 |
|---|---|
| 通用检测 | 先于域名补丁执行，覆盖所有站点 |
| 域名补丁 | 保留为精修层，追加通用规则未覆盖的形态 |

通用检测两根信号（命中任一即剔除）：

| 信号 | 判定 | 可靠性 |
|---|---|---|
| `+N` 结尾 | `/(^|\s)\+\d{1,3}$/` — 行首/空白后的 +N 位于文本末尾 | 极高 |
| Favicon + 交互角色 | `img.width \|\| naturalWidth` 两边均 ≤ 24px + `role="button"/"link"` 或 `<a>` | 高 |

安全边界：
- 仅对 `INLINE_SET` 标签生效，块级元素不参与
- 文本长度 ≤ 40 字符
- `+N` 必须前有空隔/行首、后为文本末尾，排除 "iPhone 16+128GB"、"电话 +86" 等正文
- `hasFaviconImage` 采用 AND 逻辑（宽高均 ≤ 24px）+ `img.width`（不强制同步布局、懒加载兼容）

## 受影响场景

| 场景 | 预期 |
|---|---|
| Google AI 概览来源角标 | 剔除 |
| Bing / DuckDuckGo / Perplexity 来源 chip | 剔除 |
| 模拟 Google 改版（改掉角标类名） | 仍剔除（通用规则兜底） |
| Wikipedia 正文内链 | 不受影响 |
| 正文中含 "+86"、"16+128GB"、"团队+2" | 不受影响 |

## 改动文件

- `src/dom/compat.ts` — 新增 `isGenericInlineBadge`、`hasFaviconImage`、`COUNTER_RE`，修改 `shouldOmitText` 通用优先；更新注释
- `package.json` — 版本号 0.6.20 → 0.6.21

Closes #56