### PR TITLE
fix: translateOne 在 closestUnit 返回 null 时给出 toast 反馈，不再静默 (#57)

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -336,7 +336,11 @@ export default defineContentScript({
       // 由这里统一向上找整段。找不到（超长 / .notranslate / 非正文区 /
       // 已翻译）则 shouldSkip 已拦下，不翻。
       const unit = closestUnit(el);
-      if (!unit) return;
+      if (!unit) {
+        console.debug('[PT] translateOne 跳过：closestUnit 返回 null', el);
+        toast(tf('toastNotTranslatable', '该区域无法单独翻译'), 'error');
+        return;
+      }
 
       const text = normalizeText(translatableText(unit));
       if (!text) return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-"version": "0.6.21",
+"version": "0.6.22",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## 修复内容

`translateOne()` 在 `closestUnit()` 返回 `null` 时完全静默：快捷键无反应、无提示、无日志。用户无从判断是"该区域不支持翻译""扩展坏了"还是"我操作错了"。#55 让这条路径变成了高频路径 —— 一整页 AI 概览段落全部静默无响应。

## 修复逻辑

在 `translateOne()` 的 `closestUnit` null 分支补上反馈：

- **toast** — 复用已有的 `toastNotTranslatable`（"该区域无法单独翻译"），三语齐备
- **console.debug** — 记录跳过原因，便于报障时自查

悬停按钮路径不受影响：
- 按钮只在 `closestUnit` 成功后浮出，划过空白/不可翻译区域时按钮不出现（合理的静默反馈）
- 按钮点击时 `target` 已经过验证，`closestUnit` 应始终返回有效单元，不会误弹 toast

## 受影响的入口

| 入口 | 之前 | 之后 |
|---|---|---|
| 快捷键（`translate-paragraph`） | 静默无反应 | toast "该区域无法单独翻译" |
| 悬停按钮 | 按钮不浮出（不变） | 不变 |
| 可翻译区域 | 正常翻译 | 不变 |

## 改动文件

- `entrypoints/content.ts` — `translateOne()` closestUnit null 分支 +3 行（toast + debug）
- `package.json` — 版本号 0.6.21 → 0.6.22

Closes #57