### PR TITLE
fix: pre 元素从 SKIP_SET 移除，纯文本文档型 pre（.plain > pre）可被采集翻译 (#64)

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -336,7 +336,11 @@ export default defineContentScript({
       // 由这里统一向上找整段。找不到（超长 / .notranslate / 非正文区 /
       // 已翻译）则 shouldSkip 已拦下，不翻。
       const unit = closestUnit(el);
-      if (!unit) return;
+      if (!unit) {
+        console.debug('[PT] translateOne 跳过：closestUnit 返回 null', el);
+        toast(tf('toastNotTranslatable', '该区域无法单独翻译'), 'error');
+        return;
+      }
 
       const text = normalizeText(translatableText(unit));
       if (!text) return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-"version": "0.6.22",
+"version": "0.6.23",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-"version": "0.6.21",
+"version": "0.6.22",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/classify.ts
+++ b/src/dom/classify.ts
@@ -20,6 +20,7 @@ export const DIRECT_SET = new Set([
  */
 export const CONTAINER_SET = new Set([
   'div', 'section', 'article', 'main', 'figure',
+  'pre',
 ]);
 
 /**
@@ -29,7 +30,7 @@ export const CONTAINER_SET = new Set([
 export const SKIP_SET = new Set([
   'html', 'body', 'script', 'style', 'noscript',
   'input', 'textarea', 'select', 'button',
-  'code', 'pre',
+  'code',
 ]);
 
 /**
@@ -62,6 +63,11 @@ const MIN_TEXT = 3;
 export function shouldSkipNonVisual(el: Element): boolean {
   const tag = el.tagName.toLowerCase();
   if (SKIP_SET.has(tag)) return true;
+
+  // pre 在代码上下文（.highlight / .notranslate 祖先）→ 跳过；
+  // 纯文本文档型 pre（如 .plain > pre）则放行（#64）
+  if (tag === 'pre' && el.closest('.highlight, .notranslate')) return true;
+
   if (el.classList.contains('notranslate')) return true;
   if ((el as HTMLElement).isContentEditable) return true;
   if (el.closest('[data-pt="done"]')) return true;

--- a/src/dom/compat.ts
+++ b/src/dom/compat.ts
@@ -117,7 +117,6 @@ const HANDLERS: Record<string, CompatHandler> = {
           '.file-info, .file-header, ' +
           '.commit-tease-sha, ' +
           '.commit-message code, ' +
-          'pre, ' + // GitHub 的 pre 通常是代码块
           '.highlight, ' +
           '.blame-hunk, ' +
           '.text-mono',


### PR DESCRIPTION
## 变更

- **SKIP_SET 移除 `pre`**：不再无条件整树拒绝，TreeWalker 可进入 `pre` 子树
- **CONTAINER_SET 加入 `pre`**：文本型 `pre`（如 GitHub `.plain > pre` 纯文本 README）可作为翻译单元
- **`shouldSkipNonVisual` 添加条件跳过**：`pre` 在 `.highlight` / `.notranslate` 祖先中仍跳过（保护代码块），纯文本文档型 `pre` 放行
- **GitHub 补丁移除裸 `pre` 选择器**：不再由 compat 一刀切，交给通用逻辑按上下文判定

## 判据

- `.highlight` / `.notranslate` 祖先 → 代码块，跳过
- `.plain > pre` → 纯文本文档，放行（#64）
- 代码块中的 `code` 仍在 SKIP_SET，不受影响（#41 不回退）

## 验证

- [x] `npm run typecheck` 通过
- [x] 三个浏览器构建均成功
- [x] `.output/` 已生成 0.6.23 版本的 zip 包

Closes #64