### PR TITLE
fix: 超长纯文本 <pre> 按连续空行切块为独立翻译单元 (#65)

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -12,6 +12,7 @@ import { normalizeText } from '~/src/dom/normalize';
 import { translatableText, shallowTranslatableText, hasBlockTextChildren } from '~/src/dom/text';
 import { startObserver, registerHidden } from '~/src/dom/observer';
 import { render, unrender, applyMode, applyStyle } from '~/src/dom/renderer';
+import { unsplitPre } from '~/src/dom/pre-split';
 import { applyCustomCss } from '~/src/styles/custom';
 import { createBall, setBallState } from '~/src/ui/floating-ball';
 import { createParaBtn } from '~/src/ui/paragraph-btn';
@@ -240,9 +241,14 @@ export default defineContentScript({
 
       // allTranslated() 已支持 shadow 穿透（Phase 3 P3-3 修复）
       const els: Element[] = [];
+      const splitPres: Element[] = [];
       const collectFrom = (root: ParentNode) => {
         root.querySelectorAll<Element>('[data-pt="done"]').forEach((el) =>
           els.push(el),
+        );
+        // #65：收集被切分的 pre，在 unrender 后还原 DOM
+        root.querySelectorAll<Element>('[data-pt-split="1"]').forEach((el) =>
+          splitPres.push(el),
         );
         root.querySelectorAll('*').forEach((el) => {
           if ((el as Element).shadowRoot)
@@ -253,6 +259,10 @@ export default defineContentScript({
 
       for (const el of els) {
         unrender(el);
+      }
+      // #65：unrender chunk 后再还原 pre 的切分包装，将 DOM 恢复为逐字节原貌
+      for (const pre of splitPres) {
+        unsplitPre(pre);
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-"version": "0.6.23",
+"version": "0.6.24",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/classify.ts
+++ b/src/dom/classify.ts
@@ -55,9 +55,14 @@ const NON_CONTENT =
   '.navbox,.sidebar,.toc,.mw-editsection,' +
   '.vector-menu-content-list,#catlinks,#mw-hidden-catlinks,#mw-normal-catlinks';
 
-const MAX_TEXT = 3072;
+export const MAX_TEXT = 3072;
 const MAX_HTML = 4096;
 const MIN_TEXT = 3;
+
+/** pre 是否处于代码块上下文（.highlight / .notranslate 祖先）—— #64/#65 站点相关判定 */
+export function isCodeBlockPre(el: Element): boolean {
+  return el.closest('.highlight, .notranslate') !== null;
+}
 
 /** 非可见性相关的所有跳过判定。元素即便变为可见，这些条件也不会改变。 */
 export function shouldSkipNonVisual(el: Element): boolean {
@@ -66,7 +71,7 @@ export function shouldSkipNonVisual(el: Element): boolean {
 
   // pre 在代码上下文（.highlight / .notranslate 祖先）→ 跳过；
   // 纯文本文档型 pre（如 .plain > pre）则放行（#64）
-  if (tag === 'pre' && el.closest('.highlight, .notranslate')) return true;
+  if (tag === 'pre' && isCodeBlockPre(el)) return true;
 
   if (el.classList.contains('notranslate')) return true;
   if ((el as HTMLElement).isContentEditable) return true;
@@ -189,6 +194,10 @@ function isMainlyNumeric(text: string): boolean {
  */
 export function isTranslationUnit(el: Element): boolean {
   const tag = el.tagName.toLowerCase();
+
+  // #65：pre 切块包装 span —— 块本身就是翻译单元（尺寸已由 splitPre 保证）
+  if ((el as HTMLElement).dataset?.ptChunk === '1') return true;
+
   const isContainer = CONTAINER_SET.has(tag);
 
   if (isContainer && directTextLength(el) === 0) return false;

--- a/src/dom/pre-split.ts
+++ b/src/dom/pre-split.ts
@@ -1,0 +1,104 @@
+// Phase 11 — 纯文本 <pre> 按空行切块。
+//
+// #65：大型纯文本文档（如 GitHub README 的 .plain > pre）一次性文本过长，
+// 无法通过 MAX_TEXT 阈值。本模块按连续空行将其切分为多个 <span> 翻译单元，
+// 保留原始渲染逐字节不变，让现有 collect → translate → render 管道零改动复用。
+
+import { MAX_TEXT, isCodeBlockPre } from './classify';
+
+/**
+ * 装饰行：=====、-----、***** 等纯符号行 —— plain-text 文档的分节装饰。
+ * 这些行不是正文，不应独立构成翻译单元。
+ */
+function isDecorationLine(line: string): boolean {
+  const t = line.trim();
+  if (t.length === 0) return false;
+  return /^[=\-*_~#]+$/.test(t);
+}
+
+/** 文本是否超过单块上限 —— 超长块不参与翻译 */
+function isOversized(text: string): boolean {
+  return text.trim().length > MAX_TEXT;
+}
+
+/**
+ * 将超长纯文本 <pre> 按连续空行切分为块。
+ *
+ * 每块内容包装为 <span class="pt-chunk" data-pt-chunk="1">，
+ * 空行、装饰行、超长块保留为裸文本节点 —— 渲染逐字节不变，
+ * 但只有内容块会成为翻译单元。
+ *
+ * 返回切出的 span 数组；不满足切分条件时返回 null（调用方走原逻辑）。
+ */
+export function splitPre(pre: HTMLPreElement): HTMLSpanElement[] | null {
+  // 幂等：已切分过的不再处理（observer / IO / toggle 会反复 collect）
+  if (pre.hasAttribute('data-pt-split')) return null;
+
+  // 已在翻译结果内部 —— 不切
+  if (pre.closest('[data-pt="done"]')) return null;
+
+  // 代码块上下文不切（#64 通用规则）
+  if (isCodeBlockPre(pre)) return null;
+
+  // 含子元素的 pre 可能有内联标记，保持现有行为
+  if (pre.children.length > 0) return null;
+
+  const text = pre.textContent ?? '';
+  if (text.trim().length <= MAX_TEXT) return null;
+
+  // ── 按连续空行 / 装饰行切分 ──
+  const lines = text.split('\n');
+  const parts: { kind: 'raw' | 'chunk'; text: string }[] = [];
+  let cur: string[] = [];
+  let curKind: 'raw' | 'chunk' | null = null;
+
+  for (const line of lines) {
+    const kind =
+      line.trim() === '' || isDecorationLine(line) ? 'raw' : 'chunk';
+    if (kind !== curKind) {
+      if (cur.length > 0) parts.push({ kind: curKind!, text: cur.join('\n') });
+      cur = [];
+      curKind = kind;
+    }
+    cur.push(line);
+  }
+  if (cur.length > 0 && curKind) {
+    parts.push({ kind: curKind, text: cur.join('\n') });
+  }
+
+  // ── 重建 pre 内容 ──
+  pre.textContent = '';
+  const spans: HTMLSpanElement[] = [];
+
+  for (const p of parts) {
+    if (p.kind === 'chunk' && !isOversized(p.text)) {
+      const span = document.createElement('span');
+      span.className = 'pt-chunk';
+      span.setAttribute('data-pt-chunk', '1');
+      span.textContent = p.text;
+      pre.appendChild(span);
+      spans.push(span);
+    } else {
+      pre.appendChild(document.createTextNode(p.text));
+    }
+  }
+
+  if (spans.length === 0) return null;
+
+  pre.setAttribute('data-pt-split', '1');
+  return spans;
+}
+
+/**
+ * 还原 pre 切分包装：把 .pt-chunk 子元素的文本节点放回 pre 并移除包装 span。
+ * #65 的逆操作 —— 在 doRestore 中 unrender 所有 chunk 后调用，
+ * 将 DOM 恢复为切分前的逐字节原貌。
+ */
+export function unsplitPre(pre: Element): void {
+  const chunks = [...pre.querySelectorAll(':scope > .pt-chunk')];
+  for (const span of chunks) {
+    while (span.firstChild) pre.insertBefore(span.firstChild, span);
+    span.remove();
+  }
+  pre.removeAttribute('data-pt-split');
+}

--- a/src/dom/walker.ts
+++ b/src/dom/walker.ts
@@ -9,6 +9,7 @@
 
 import { SKIP_SET, shouldSkipNonVisual, isVisible, isTranslationUnit, hasNonTextContent } from './classify';
 import { applyCompat } from './compat';
+import { splitPre } from './pre-split';
 
 /**
  * 采集可翻译节点。
@@ -81,6 +82,11 @@ function walk(
         node = walker.nextNode();
         continue;
       }
+
+      // #65：超大纯文本 pre（如 GitHub README 的 .plain > pre）按空行切块，
+      // 块是独立翻译单元。切分是纯文本结构操作，无站点相关性；
+      // 代码块判定（isCodeBlockPre）是唯一站点相关部分（#64）。
+      if (el.tagName === 'PRE') splitPre(el as HTMLPreElement);
 
       // 判定顺序不能反：isTranslationUnit() 首步只是一次标签查表，而
       // shouldSkipNonVisual() 要拼 outerHTML、算 textContent。先便宜后昂贵。


### PR DESCRIPTION
## 问题

即使经过 #64 将 `<pre>` 从 `SKIP_SET` 移除，纯文本文档型 `pre`（如 GitHub `.plain > pre` README，6043 字符）依然无法翻译。三道障碍：

1. **`MAX_TEXT = 3072`** — `shouldSkipNonVisual` 直接拒收
2. **整篇文档一个单元** — 即使放行，6043 字符一次丢给引擎语义上无意义
3. **OpenAI 编号结构** — 超长文本撑破编号格式（#16 教训）

## 方案

在 `walker.ts` 采集阶段，把超长 `<pre>` 按**连续空行**切块，每块包装为 `<span class="pt-chunk" data-pt-chunk="1">`，让现有 `collect → translate → render → unrender` 管道零改动复用。

### 修改清单

| 文件 | 变更 |
|---|---|
| **`src/dom/pre-split.ts`** | **新增。** `splitPre()` 按空行/装饰行分组切块；`unsplitPre()` 在还原时逆向恢复 DOM |
| **`src/dom/classify.ts`** | 导出 `MAX_TEXT`；提取 `isCodeBlockPre()` 为共享判定；`isTranslationUnit` 识别 `data-pt-chunk` |
| **`src/dom/walker.ts`** | 在 `applyCompat` 之后、通用判定之前调用 `splitPre` |
| **`entrypoints/content.ts`** | `doRestore` 收集 `[data-pt-split]` 并调用 `unsplitPre` 还原 |
| **`package.json`** | `0.6.23` → `0.6.24` |

### 设计要点

- **ASCII 装饰行**（`====` / `----` / `***` 等）不产生独立翻译单元
- **超长单块**（>MAX\_TEXT 且无空行）保留为裸文本不翻译
- **代码块不变** — `.highlight` / `.notranslate` 上下文仍整体跳过
- **DOM 可逆** — `doRestore` 时 `unsplitPre` 将 pre 还原为逐字节原貌
- 切分后 pre 不再有直接文本（`directTextLength=0`），自然不被采集，无重复翻译

Closes #65