### PR TITLE
fix: <pre> 内译文脱离等宽约束，按普通段落排版 (#66)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-"version": "0.6.24",
+"version": "0.6.25",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/renderer.ts
+++ b/src/dom/renderer.ts
@@ -46,6 +46,12 @@ export function render(
   trans.className = 'pt-trans';
   trans.textContent = translation;
 
+  // #66：pre 内译文需要脱离等宽约束，按普通段落排版。
+  // closest 从自身沿祖先链向上匹配，覆盖两种场景：
+  // 1. pre 自身是翻译单元（短文本，未被 splitPre 切分）
+  // 2. .pt-chunk 包装 span 是翻译单元（#65 切分后的块）
+  if (el.closest('pre')) trans.classList.add('pt-pre');
+
   el.appendChild(origin);
   el.appendChild(trans);
   el.setAttribute('data-pt', 'done');

--- a/src/styles/presets.css
+++ b/src/styles/presets.css
@@ -52,3 +52,11 @@
 .pt-style-fade .pt-trans {
   opacity: 0.6;
 }
+
+/* ── pre 内译文脱离等宽约束（#66）────────────────────────── */
+.pt-trans.pt-pre {
+  white-space: normal;
+  font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
+  border-left: none;
+  padding-left: 0;
+}


### PR DESCRIPTION
## 问题

Fixes #66

`<pre>` 内插入译文（`.pt-origin` + `.pt-trans`）会破坏预格式化文本的空白语义与 ASCII 对齐：

1. **块级 `.pt-trans` 在 pre 内改变空白流** — pre 中元素间的换行/缩进本身就是内容
2. **default 样式的 `border-left` + `padding-left`** 破坏等宽列对齐
3. **中文全角字符与 ASCII 排版不兼容** — 下划线 `====`、列表缩进对不上

## 方案

采用方案 A（侵入性最小）：pre 内 `.pt-trans` 脱离等宽约束，按普通段落排版。

### 修改点

- **`src/dom/renderer.ts`**：`render()` 检测 pre 上下文（`el.closest('pre')`），给 `.pt-trans` 追加 `.pt-pre` 类
- **`src/styles/presets.css`**：新增 `.pt-trans.pt-pre` 规则，覆盖 `white-space: normal`、`font-family` 回退到正文字体、清除 border/padding

### 6 种样式预设兼容性

- **default**：`border-left` / `padding-left` 被覆盖（同特异性，源顺序优先）
- **dim / underline / bold / italic / fade**：无冲突，各自效果正常生效

## 验证

- [x] 原文 `====` 下划线、`*` 列表缩进与翻译前逐字符一致（`.pt-origin` 继承 pre 的等宽/保留空白）
- [x] 译文按普通段落排版，中文自动换行，不产生横向滚动条
- [x] `unrender()` 可原样还原 —— DOM 结构未变，仅 CSS 类被移除
- [x] 6 种样式预设逐一切换，无破坏原文对齐
- [x] 版本号迭代至 0.6.25，三平台（Chrome/Firefox/Edge）构建打包通过