### PR TITLE
fix: 修复 WXT lifecycle + allFrames 导致 iframe content script 被过早终止 (#70)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-"version": "0.6.25",
+"version": "0.6.26",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/patches/wxt@0.19.29.patch
+++ b/patches/wxt@0.19.29.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/client/content-scripts/content-script-context.mjs b/dist/client/content-scripts/content-script-context.mjs
+index 7c0e8104df2ba08266aaed517bc9b8f243f41381..4b69814d1a71a9ae2b84458793268f9abc823be8 100644
+--- a/dist/client/content-scripts/content-script-context.mjs
++++ b/dist/client/content-scripts/content-script-context.mjs
+@@ -11,7 +11,7 @@ export class ContentScriptContext {
+       this.listenForNewerScripts({ ignoreFirstEvent: true });
+       this.stopOldScripts();
+     } else {
+-      this.listenForNewerScripts();
++      this.listenForNewerScripts({ ignoreFirstEvent: true });
+     }
+   }
+   static SCRIPT_STARTED_MESSAGE_TYPE = getUniqueEventName(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  wxt@0.19.29: 495967bc71b295b9f8e549e84763d5ffc4a2071f5ec630b323c80b0fb1f9af56
+
 importers:
 
   .:
@@ -13,7 +16,7 @@ importers:
         version: 5.9.3
       wxt:
         specifier: ^0.19.0
-        version: 0.19.29(@types/node@26.1.2)(rollup@4.62.3)
+        version: 0.19.29(patch_hash=495967bc71b295b9f8e549e84763d5ffc4a2071f5ec630b323c80b0fb1f9af56)(@types/node@26.1.2)(rollup@4.62.3)
 
 packages:
 
@@ -3360,7 +3363,7 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
 
-  wxt@0.19.29(@types/node@26.1.2)(rollup@4.62.3):
+  wxt@0.19.29(patch_hash=495967bc71b295b9f8e549e84763d5ffc4a2071f5ec630b323c80b0fb1f9af56)(@types/node@26.1.2)(rollup@4.62.3):
     dependencies:
       '@1natsu/wait-element': 4.2.0
       '@aklinker1/rollup-plugin-visualizer': 5.12.0(rollup@4.62.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,5 @@
 allowBuilds:
   esbuild: true
   spawn-sync: false
+patchedDependencies:
+  wxt@0.19.29: patches/wxt@0.19.29.patch


### PR DESCRIPTION
## 修复内容

修复 issue #70：`Extension context invalidated` 错误在 `allFrames: true` 时偶尔出现。

### 根因

WXT ContentScriptContext 构造函数中，主 frame 使用 `listenForNewerScripts({ignoreFirstEvent: true})` 后调用 `stopOldScripts()` → `window.postMessage(..., "*")` 广播启动消息。但 iframe 的 `listenForNewerScripts()` 不传 `ignoreFirstEvent`，在 DOM 庞大时的时序竞争中收到广播后错误地调用 `notifyInvalidated()` 终止自己。

### 修复

通过 pnpm patch 为 iframe 的 `listenForNewerScripts` 也传入 `{ignoreFirstEvent: true}`，消除时序竞争窗口。

### 变更文件

- `patches/wxt@0.19.29.patch` — 新增 pnpm patch
- `pnpm-workspace.yaml` — 注册 patchedDependencies
- `package.json` — 版本号 0.6.25 → 0.6.26

Closes #70