### PR TITLE
fix: GitHub 用户名等标识符不翻译，通过占位符机制保留原文 (#58)

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -9,7 +9,14 @@ import '~/src/styles/presets.css';
 import { collect } from '~/src/dom/walker';
 import { closestUnit } from '~/src/dom/classify';
 import { normalizeText } from '~/src/dom/normalize';
-import { translatableText, shallowTranslatableText, hasBlockTextChildren } from '~/src/dom/text';
+import {
+  translatableText,
+  translatableTextEx,
+  shallowTranslatableText,
+  shallowTranslatableTextEx,
+  hasBlockTextChildren,
+  restorePreserves,
+} from '~/src/dom/text';
 import { startObserver, registerHidden } from '~/src/dom/observer';
 import { render, unrender, applyMode, applyStyle } from '~/src/dom/renderer';
 import { unsplitPre } from '~/src/dom/pre-split';
@@ -153,20 +160,36 @@ export default defineContentScript({
       // translatableText 剔除 .notranslate 与站点元数据（如 Google 来源角标）。
       // #23：混合内容元素（直接文本 + 块级子元素）使用 shallowTranslatableText，
       // 只提取直接文本，嵌套块级子元素由各自的翻译单元独立翻译。
-      const texts = targets.map((el) =>
-        normalizeText(
-          hasBlockTextChildren(el)
-            ? shallowTranslatableText(el)
-            : translatableText(el),
-        ),
-      );
+      // #58：translatableTextEx 同时返回 preserves 映射表（占位符 → 原文），
+      // 译文回填时替换占位符，使 GitHub 用户名等标识符保持原样。
+      const textData = targets.map((el) => {
+        const useShallow = hasBlockTextChildren(el);
+        const { text: rawText, preserves } = useShallow
+          ? shallowTranslatableTextEx(el)
+          : translatableTextEx(el);
+        return {
+          text: normalizeText(rawText),
+          preserves,
+          rawText: normalizeText(rawText),
+        };
+      });
+      const texts = textData.map((d) => d.text);
 
-      // 切分为批次
-      const batches: { texts: string[]; targets: Element[] }[] = [];
+      // 切分为批次。每批同时携带 preserves 映射表与原文，
+      // 供译文回填时 restorePreserves 校验与替换。
+      const batches: {
+        texts: string[];
+        targets: Element[];
+        preserves: Map<string, string>[];
+        rawTexts: string[];
+      }[] = [];
       for (let i = 0; i < targets.length; i += FULL_PAGE_BATCH_SIZE) {
+        const slice = textData.slice(i, i + FULL_PAGE_BATCH_SIZE);
         batches.push({
-          texts: texts.slice(i, i + FULL_PAGE_BATCH_SIZE),
+          texts: slice.map((d) => d.text),
           targets: targets.slice(i, i + FULL_PAGE_BATCH_SIZE),
+          preserves: slice.map((d) => d.preserves),
+          rawTexts: slice.map((d) => d.rawText),
         });
       }
 
@@ -177,7 +200,7 @@ export default defineContentScript({
       // 所有批次并发发送，每批返回即渲染。
       // Google Web 的并发闸门是惰性单例，所有批次共享，自然排队。
       await Promise.all(
-        batches.map(async ({ texts: batchTexts, targets: batchTargets }) => {
+        batches.map(async ({ texts: batchTexts, targets: batchTargets, preserves: batchPreserves, rawTexts: batchRawTexts }) => {
           const resp = await chrome.runtime.sendMessage({
             type: 'pt:translate',
             payload: { texts: batchTexts, from: ns.from, to: ns.to },
@@ -193,7 +216,13 @@ export default defineContentScript({
           const translations: string[] = resp.data.translations;
           for (let i = 0; i < batchTargets.length; i++) {
             try {
-              if (render(batchTargets[i]!, translations[i]!, 'page')) {
+              // #58：将占位符替换回原文（用户名等标识符不翻译但保留）
+              const restored = restorePreserves(
+                translations[i]!,
+                batchPreserves[i]!,
+                batchRawTexts[i]!,
+              );
+              if (render(batchTargets[i]!, restored, 'page')) {
                 renderSucceeded++;
               } else {
                 renderRejected++;
@@ -352,7 +381,8 @@ export default defineContentScript({
         return;
       }
 
-      const text = normalizeText(translatableText(unit));
+      const { text: rawText, preserves } = translatableTextEx(unit);
+      const text = normalizeText(rawText);
       if (!text) return;
 
       const resp = await chrome.runtime.sendMessage({
@@ -365,9 +395,16 @@ export default defineContentScript({
         return;
       }
 
+      // #58：将占位符替换回原文
+      const restored = restorePreserves(
+        resp.data.translations[0],
+        preserves,
+        text,
+      );
+
       // render() 在含媒体 / 交互控件时会拒绝渲染（#22），此时告知用户
       // 而非静默吞掉元素
-      if (!render(unit, resp.data.translations[0], 'para')) {
+      if (!render(unit, restored, 'para')) {
         toast(tf('toastNotTranslatable', '该区域无法单独翻译'), 'error');
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.28",
+  "version": "0.6.29",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/compat.ts
+++ b/src/dom/compat.ts
@@ -15,6 +15,16 @@ type CompatHandler = (el: Element) => CompatResult;
 
 type OmitHandler = (el: Element) => boolean;
 
+/**
+ * Preserve 处理器：返回要保留的原文，或 null 表示不保留。
+ * 保留文本用占位符替换后送入引擎，译文回填时再将占位符换回原文。
+ *
+ * 与 omit 的区别：
+ *   omit  — 文本完全丢弃，不进入译文（用于来源角标等 UI 元数据）
+ *   preserve — 文本不翻译，但原样保留在译文里（用于用户名等标识符）
+ */
+type PreserveHandler = (el: Element) => string | null;
+
 // ---- 通用行内角标检测 ----
 
 /** Favicon 尺寸上限（像素），超过此值视为内容图片而非角标图标 */
@@ -79,6 +89,43 @@ function isGenericInlineBadge(el: Element): boolean {
   if (hasInteractiveRole && hasFaviconImage(el)) return true;
 
   return false;
+}
+
+// ---- preserve：不翻译但保留原文（用户名等标识符） ----
+
+const PRESERVE_HANDLERS: Record<string, PreserveHandler> = {
+  'github.com': (el: Element) => {
+    // 评论正文里的 @mention（a.user-mention）：最高频场景
+    if (el.matches('a.user-mention')) {
+      return el.textContent?.trim() || null;
+    }
+
+    // hovercard 机制多年未变，覆盖几乎所有用户名链接
+    if (el.matches('[data-hovercard-url^="/users/"]')) {
+      return el.textContent?.trim() || null;
+    }
+
+    // 微数据属性：author 关联
+    if (el.matches('[rel="author"], [itemprop="author"]')) {
+      return el.textContent?.trim() || null;
+    }
+
+    return null;
+  },
+};
+
+/**
+ * 元素文本是否应保留原文、不参与翻译。
+ * 返回非 null 的保留文本，或 null 表示不保留。
+ */
+export function shouldPreserveText(el: Element): string | null {
+  // 只在内联元素上生效 —— 块级元素走 skip 路径，不在此处判定
+  const tag = el.tagName.toLowerCase();
+  if (!INLINE_SET.has(tag)) return null;
+
+  const handler = PRESERVE_HANDLERS[mainDomain(location.hostname)];
+  if (!handler) return null;
+  return handler(el);
 }
 
 // ---- 域名精修补丁 ----

--- a/src/dom/text.ts
+++ b/src/dom/text.ts
@@ -4,15 +4,55 @@
 // UI 元数据不是正文，混进译文就是「YouTube·Tech +2」这类噪声。规则分两层：
 // - .notranslate 类：HTML 标准约定（Google 翻译同样尊重），通用
 // - shouldOmitText()：域名补丁（compat.ts），站点的特定元数据
+// - shouldPreserveText()：#58 占位符机制，用户名等标识符不翻译但保留原文
 
-import { shouldOmitText } from './compat';
+import { shouldOmitText, shouldPreserveText } from './compat';
 import { INLINE_SET } from './classify';
+
+/**
+ * Preserve 占位符格式：⟦PT0⟧、⟦PT1⟧ ...
+ * 使用 U+27E6/U+27E7 数学括号 + "PT" 前缀 + 自增索引。
+ * 这些 Unicode 字符极少出现在自然文本中，各翻译引擎通常原样透传。
+ */
+const PLACEHOLDER_RE = /⟦PT\d+⟧/g;
+const PLACEHOLDER_PREFIX = '⟦PT';
+const PLACEHOLDER_SUFFIX = '⟧';
+
+interface PreserveMap {
+  placeholders: Map<string, string>; // ⟦PT0⟧ → 原文
+  nextIndex: number;
+}
+
+function makePlaceholder(idx: number): string {
+  return `${PLACEHOLDER_PREFIX}${idx}${PLACEHOLDER_SUFFIX}`;
+}
+
+/**
+ * 提取元素的全部可翻译文本（含 preserve 占位符）。
+ * 返回占位符文本与原文映射表，供译文回填时替换。
+ *
+ * 遍历逻辑与 translatableText() 相同，额外在遇到 preserve 节点时
+ * 写入占位符并记录映射。
+ */
+export function translatableTextEx(el: Element): {
+  text: string;
+  preserves: Map<string, string>;
+} {
+  const pm: PreserveMap = { placeholders: new Map(), nextIndex: 0 };
+  const text = walkTranslatable(el, pm);
+  return { text, preserves: pm.placeholders };
+}
 
 /**
  * 提取元素的全部可翻译文本：递归遍历子节点，跳过 .notranslate 与
  * 站点元数据子树。无忽略规则时与 textContent 等价。
  */
 export function translatableText(el: Element): string {
+  return walkTranslatable(el, null);
+}
+
+/** 共享遍历实现：pm 为 null 时不启用 preserve（向后兼容） */
+function walkTranslatable(el: Element, pm: PreserveMap | null): string {
   let out = '';
   const walk = (node: Node) => {
     for (const child of node.childNodes) {
@@ -20,6 +60,21 @@ export function translatableText(el: Element): string {
         out += child.textContent ?? '';
       } else if (child.nodeType === Node.ELEMENT_NODE) {
         const c = child as Element;
+
+        // #58 preserve：不翻译但保留原文（用户名等标识符）
+        if (pm) {
+          const preserved = shouldPreserveText(c);
+          if (preserved) {
+            const ph = makePlaceholder(pm.nextIndex);
+            pm.placeholders.set(ph, preserved);
+            pm.nextIndex++;
+            out += ' ';
+            out += ph;
+            out += ' ';
+            continue;
+          }
+        }
+
         if (c.classList.contains('notranslate')) continue;
         if (shouldOmitText(c)) continue;
         // 元素子节点之间补空格，防止源 HTML 中相邻元素无空白时
@@ -42,6 +97,20 @@ export function translatableText(el: Element): string {
  * 只提取"标签文字"，子条目由各自的翻译单元独立翻译，避免重复。
  */
 export function shallowTranslatableText(el: Element): string {
+  return walkShallow(el, null);
+}
+
+/** 含 preserve 的浅层提取变体 */
+export function shallowTranslatableTextEx(el: Element): {
+  text: string;
+  preserves: Map<string, string>;
+} {
+  const pm: PreserveMap = { placeholders: new Map(), nextIndex: 0 };
+  const text = walkShallow(el, pm);
+  return { text, preserves: pm.placeholders };
+}
+
+function walkShallow(el: Element, pm: PreserveMap | null): string {
   let out = '';
   for (const child of el.childNodes) {
     if (child.nodeType === Node.TEXT_NODE) {
@@ -53,10 +122,24 @@ export function shallowTranslatableText(el: Element): string {
       // 跳过块级子元素 —— 它们的文本由各自翻译单元覆盖
       if (!INLINE_SET.has(tag)) continue;
 
+      // #58 preserve
+      if (pm) {
+        const preserved = shouldPreserveText(c);
+        if (preserved) {
+          const ph = makePlaceholder(pm.nextIndex);
+          pm.placeholders.set(ph, preserved);
+          pm.nextIndex++;
+          out += ' ';
+          out += ph;
+          out += ' ';
+          continue;
+        }
+      }
+
       if (c.classList.contains('notranslate')) continue;
       if (shouldOmitText(c)) continue;
       out += ' ';
-      out += translatableText(c); // 内联元素全递归
+      out += walkTranslatable(c, pm); // 内联元素全递归
       out += ' ';
     }
   }
@@ -75,4 +158,67 @@ export function hasBlockTextChildren(el: Element): boolean {
     if (child.textContent?.trim()) return true;
   }
   return false;
+}
+
+/**
+ * 译文回填：将占位符替换回原文。
+ *
+ * 安全降级：若译文中占位符数量/序号与原文不符（引擎破坏了占位符），
+ * 返回原始文本而非含破碎占位符的译文 —— 用户绝不会见到 ⟦PT0⟧ 残留。
+ *
+ * @param translation 引擎返回的译文
+ * @param preserves 占位符 → 原文映射表
+ * @param originalText 发往引擎前的原文（含占位符），用于校验
+ * @returns 还原后的译文，或降级返回的原始无占位符文本
+ */
+export function restorePreserves(
+  translation: string,
+  preserves: Map<string, string>,
+  originalText: string,
+): string {
+  if (preserves.size === 0) return translation;
+
+  // 统计原文中的占位符
+  const origPlaceholders = originalText.match(PLACEHOLDER_RE) ?? [];
+
+  // 统计译文中的占位符
+  const transPlaceholders = translation.match(PLACEHOLDER_RE) ?? [];
+
+  // 数量或序号不一致 → 引擎破坏了占位符，降级
+  if (origPlaceholders.length !== transPlaceholders.length) {
+    console.debug(
+      '[PT] preserve 降级：占位符数量不匹配',
+      { orig: origPlaceholders, trans: transPlaceholders },
+    );
+    return restoreFallback(originalText, preserves);
+  }
+
+  for (let i = 0; i < origPlaceholders.length; i++) {
+    if (origPlaceholders[i] !== transPlaceholders[i]) {
+      console.debug(
+        '[PT] preserve 降级：占位符序号不匹配',
+        { orig: origPlaceholders[i], trans: transPlaceholders[i] },
+      );
+      return restoreFallback(originalText, preserves);
+    }
+  }
+
+  // 全部匹配 → 安全替换
+  let result = translation;
+  for (const [ph, orig] of preserves) {
+    result = result.replace(ph, orig);
+  }
+  return result;
+}
+
+/** 降级：从含占位符的原文中还原出无占位符的原始文本 */
+function restoreFallback(
+  placeholderText: string,
+  preserves: Map<string, string>,
+): string {
+  let result = placeholderText;
+  for (const [ph, orig] of preserves) {
+    result = result.replace(ph, orig);
+  }
+  return result;
 }


### PR DESCRIPTION
## 问题

GitHub 页面中的 `@mention`、用户名、显示名等标识符被翻译引擎当作普通词汇直译（`Apple` → 苹果、`Hunter` → 猎人），翻译后既搜不到、@ 不到，还对不上原页面。Closes #58。

## 方案

引入第三种文本提取语义 **preserve**（不翻译但保留原文），通过占位符机制在文本提取层实现：

### 1. 文本提取层 (compat.ts + text.ts)
- 新增 `shouldPreserveText()` — GitHub 域名处理器通过稳定语义钩子识别用户名：
  - `a.user-mention` — 评论正文 @mention（最高频场景）
  - `[data-hovercard-url^="/users/"]` — hovercard 机制多年未变
  - `[rel="author"]`、`[itemprop="author"]` — 微数据属性
- `translatableTextEx()` — 遍历时遇到 preserve 节点，写入占位符（⟦PT0⟧）并记录映射表

### 2. 译文回填层 (content.ts)
- `restorePreserves()` — 校验译文中占位符完整性
  - 数量/序号一致 → 替换回原文 ✓
  - 不一致（引擎破坏）→ 降级使用原始文本，绝不让占位符残留

### 3. 三路径统一覆盖
- 整页翻译（`doTranslate`）
- 单段翻译（`translateOne`）
- Observer 增量补翻（走同一套管道）

## 修改文件
- `src/dom/compat.ts` — 新增 `shouldPreserveText()` 与 `PRESERVE_HANDLERS`
- `src/dom/text.ts` — 占位符机制 + `translatableTextEx()` / `restorePreserves()`
- `entrypoints/content.ts` — preserve 管道接入
- `package.json` — 版本号 0.6.28 → 0.6.29