### PR TITLE
fix(e2e): __dirname 在 ESM 中不存在 — 改用 import.meta.url 推导 fixture 路径 (#88)

### DIFF
--- a/docs/testing/e2e/extended.spec.ts
+++ b/docs/testing/e2e/extended.spec.ts
@@ -5,7 +5,7 @@
  *       样式切换、自定义 CSS、禁用扩展、BYOK key 无效、
  *       响应不足、中途切语言、悬浮球钳制、超长段落、RTL 全文
  */
-import { test, expect } from './fixtures';
+import { test, expect, fixtureFileUrl } from './fixtures';
 
 test.describe('故障切换 @extended', () => {
   test('TC-E2E-31: mock Google 500 → 自动切 Bing', async ({ page }) => {
@@ -70,7 +70,7 @@ test.describe('边界情况 @extended', () => {
   });
 
   test('TC-E2E-44: 超长段落 5000 字符 → 被跳过不发送请求', async ({ page }) => {
-    await page.goto('file://' + __dirname + '/fixtures/basic.html');
+    await page.goto(fixtureFileUrl('basic'));
     // 注入超长段落
     await page.evaluate(() => {
       const p = document.createElement('p');
@@ -84,7 +84,7 @@ test.describe('边界情况 @extended', () => {
   });
 
   test('TC-E2E-45: RTL 页面全文翻译 → 段落按钮在正确位置', async ({ page }) => {
-    await page.goto('file://' + __dirname + '/fixtures/rtl.html');
+    await page.goto(fixtureFileUrl('rtl'));
     const dir = await page.evaluate(() => document.documentElement.dir);
     expect(dir).toBe('rtl');
     test.skip(true, '需要扩展环境验证段落按钮 RTL 定位');

--- a/docs/testing/e2e/fixtures.ts
+++ b/docs/testing/e2e/fixtures.ts
@@ -9,6 +9,7 @@
  */
 import { test as base, chromium, expect, type Page, type Worker } from '@playwright/test';
 import path from 'path';
+import { fileURLToPath } from 'node:url';
 
 const EXTENSION_PATH = path.resolve('.output/chrome-mv3');
 const FIXTURES_BASE = 'http://localhost:4173';
@@ -36,6 +37,18 @@ export type FixtureName = (typeof FIXTURES)[number];
 /** 获取 fixture 页面的 HTTP URL（content script 通过 <all_urls> 注入） */
 export function fixtureUrl(name: FixtureName): string {
   return `${FIXTURES_BASE}/${name}.html`;
+}
+
+/**
+ * 获取 fixture 页面的 file:// URL（#88）。
+ *
+ * 用于不需要 content script 注入的自包含用例（如纯 DOM 逻辑验证）：
+ * 经 HTTP 加载时 content script 会注入并可能干扰页面 DOM 计数等断言，
+ * 因此这类用例直接以 file:// 打开本地 fixture。
+ * spec 以 ES module 运行，__dirname 不存在，须用 import.meta.url 推导目录。
+ */
+export function fixtureFileUrl(name: FixtureName): string {
+  return 'file://' + fileURLToPath(new URL(`./fixtures/${name}.html`, import.meta.url));
 }
 
 // ── Google Translate API 响应形状 ──

--- a/docs/testing/e2e/perf.spec.ts
+++ b/docs/testing/e2e/perf.spec.ts
@@ -6,7 +6,7 @@
  * - DOM 节点增长
  * - 内存使用
  */
-import { test, expect } from './fixtures';
+import { test, expect, fixtureFileUrl } from './fixtures';
 
 test.describe('性能基准 @perf', () => {
   test('PERF-01: 200 段整页翻译总耗时 < 30s', async ({ page }) => {
@@ -14,7 +14,7 @@ test.describe('性能基准 @perf', () => {
   });
 
   test('PERF-02: 翻译-还原循环 ×100 后 DOM 节点数无增长', async ({ page }) => {
-    await page.goto('file://' + __dirname + '/fixtures/basic.html');
+    await page.goto(fixtureFileUrl('basic'));
 
     const countBefore = await page.evaluate(() => document.querySelectorAll('*').length);
 

--- a/docs/testing/e2e/security.spec.ts
+++ b/docs/testing/e2e/security.spec.ts
@@ -3,7 +3,7 @@
  *
  * API key 隔离、导出不含 key、禁用后零请求、XSS 阻止
  */
-import { test, expect } from './fixtures';
+import { test, expect, fixtureFileUrl } from './fixtures';
 
 test.describe('安全验证 @security', () => {
   test('SEC-01: 禁用扩展后零翻译请求', async ({ page }) => {
@@ -11,7 +11,7 @@ test.describe('安全验证 @security', () => {
   });
 
   test('SEC-02: 自定义 CSS XSS 阻止', async ({ page }) => {
-    await page.goto('file://' + __dirname + '/fixtures/basic.html');
+    await page.goto(fixtureFileUrl('basic'));
 
     // 验证非法 CSS 注入被阻止（模拟 validateCustomCss 逻辑）
     const results = await page.evaluate(() => {


### PR DESCRIPTION
## 问题

#88：extended/perf/security 三个 E2E spec 以 ES module 运行，`__dirname` 不存在，TC-E2E-44/45、PERF-02、SEC-02 全部以 `ReferenceError: __dirname is not defined` 失败。

## 修复

- 在 `fixtures.ts` 新增 `fixtureFileUrl()`：`fileURLToPath(new URL('./fixtures/…', import.meta.url))`
- 4 处 `file://` 导航统一改为 `fixtureFileUrl('basic' | 'rtl')`
- 保持 file:// 加载不变：这些用例是自包含的 DOM 逻辑验证（DOM 计数、CSS 校验、段落注入），经 HTTP 加载时 content script 会注入页面并干扰 DOM 计数断言

## 验证

- 修复前（red）：4 个测试全部 `ReferenceError: __dirname is not defined`
- 修复后（green）：3 passed、1 skipped（TC-E2E-45 完成 dir=rtl 断言后按设计跳过）
- `pnpm typecheck` 通过

Fixes #88