### PR TITLE
fix: 修复 E2E 核心翻译在 CI 中不工作 — SW 消息通道就绪重试 + SW 内确定性 mock (#89)

### DIFF
--- a/docs/DEEP-TESTING.md
+++ b/docs/DEEP-TESTING.md
@@ -435,6 +435,31 @@ describe('applyStyle', () => {
 })
 ```
 
+### 2.15 `runtime/messaging.ts` — content → background 消息通道健壮性（#89）
+
+测试文件：unit/runtime/messaging.test.ts
+
+```typescript
+// #89：MV3 headless 下 SW 未就绪时 pt:translate 被丢弃。
+// 契约：ping 预热 + 传输层重试；引擎级失败不重试；永不抛出。
+
+describe('translateViaBackground — SW 就绪时', () => {
+  test('ping 一次 + translate 一次，直接返回译文')
+})
+
+describe('translateViaBackground — SW 冷启动（#89 根因）', () => {
+  test('ping 前两次无响应，第三次就绪后翻译成功')
+  test('translate 首次无响应（SW 在 ping 后失联）→ 自动重试成功')
+  test('sendMessage reject（Receiving end does not exist）→ 重试成功')
+})
+
+describe('translateViaBackground — 失败语义', () => {
+  test('SW 响应 {ok:false}（引擎级失败）→ 原样返回，不重试')
+  test('SW 始终无响应：ping 预算耗尽 → {ok:false}，不发送 translate')
+  test('translate 持续无响应：重试预算耗尽 → {ok:false}')
+})
+```
+
 ## 三、集成测试用例
 
 集成测试在扩展的真实上下文（chrome.storage、chrome.runtime.sendMessage）中运行，mock 翻译端点的 fetch。

--- a/docs/testing/e2e/core.spec.ts
+++ b/docs/testing/e2e/core.spec.ts
@@ -67,6 +67,9 @@ test.describe('入口：快捷键', () => {
   test('@core TC-E2E-03: Mod+Shift+Y → 翻译 (Linux/Windows)', async ({
     page, mockGoogle, seedSettings, gotoFixture,
   }) => {
+    // Mod 在 macOS 上是 Meta（⌘），Control 变体在 mac 上不触发 ——
+    // mac 平台由 TC-E2E-03-Mac 覆盖
+    test.skip(process.platform === 'darwin', 'macOS 用 Meta 键（见 TC-E2E-03-Mac）');
     await seedSettings({});
     await mockGoogle();
     await gotoFixture('basic');
@@ -79,6 +82,9 @@ test.describe('入口：快捷键', () => {
   test('@core @mac TC-E2E-03-Mac: Mod+Shift+Y → 翻译 (macOS)', async ({
     page, mockGoogle, seedSettings, gotoFixture,
   }) => {
+    // fromEvent 在 Linux 上忽略 metaKey，Meta 变体在 Linux 不触发 ——
+    // Linux/Windows 平台由 TC-E2E-03 覆盖
+    test.skip(process.platform === 'linux', 'Linux 无 Meta 语义（见 TC-E2E-03）');
     await seedSettings({});
     await mockGoogle();
     await gotoFixture('basic');
@@ -91,6 +97,7 @@ test.describe('入口：快捷键', () => {
   test('@core TC-E2E-04: Mod+Shift+M → 切换显示模式', async ({
     page, mockGoogle, seedSettings, gotoFixture,
   }) => {
+    test.skip(process.platform === 'darwin', 'macOS 上 Mod=Meta，Control 变体不触发');
     await seedSettings({});
     await mockGoogle();
     await gotoFixture('basic');
@@ -215,15 +222,15 @@ test.describe('Fixture: nested', () => {
     const doneCount = await page.locator('[data-pt="done"]').count();
     expect(doneCount).toBeGreaterThan(0);
 
-    // 验证没有重复翻译（同一元素内无嵌套 data-pt="done"）
-    const nestedDone = await page.evaluate(() => {
-      const all = document.querySelectorAll('[data-pt="done"]');
-      for (const el of all) {
-        if (el.parentElement?.closest('[data-pt="done"]')) return true;
-      }
-      return false;
-    });
-    expect(nestedDone).toBe(false);
+    // 验证没有重复文本（#23：混合内容元素只翻直接文本，块级子元素独立
+    // 翻译 —— 父译文不得吞掉子段落内容；父子均为 done 是预期结构，
+    // 判定重复的标准是译文内容而非 DOM 嵌套）
+    const mixedDiv = page.locator('div').first();
+    const divTrans = mixedDiv.locator(':scope > .pt-trans');
+    await expect(divTrans).toContainText('Direct text in div');
+    await expect(divTrans).not.toContainText('block-level child paragraph');
+    // 子段落独立成翻译单元
+    await expect(page.locator('p').first()).toHaveAttribute('data-pt', 'done');
   });
 });
 
@@ -425,9 +432,7 @@ test.describe('引擎', () => {
     page, mockGoogle, seedSettings, gotoFixture,
   }) => {
     await seedSettings({ enginePriority: ['google-web'] });
-    await mockGoogle({
-      translation: (q) => `[GOOGLE] ${q}`,
-    });
+    await mockGoogle({ prefix: '[GOOGLE] ' });
     await gotoFixture('basic');
 
     await translateAndWait(page);
@@ -438,32 +443,35 @@ test.describe('引擎', () => {
   });
 
   test('@core TC-E2E-16: Bing mock 返回译文', async ({
-    page, mockGoogle, seedSettings, gotoFixture, context,
+    page, serviceWorker, seedSettings, gotoFixture,
   }) => {
-    // Mock Bing 的两个端点
-    await context.route('https://edge.microsoft.com/translate/auth', (route) => {
-      route.fulfill({
-        status: 200,
-        contentType: 'text/plain',
-        body: 'mock-jwt-token',
-      });
+    // #89: 在 SW 内 stub Bing 的两个端点（CDP route 对 SW 请求拦截不确定）
+    await serviceWorker.evaluate(() => {
+      const realFetch = self.fetch.bind(self);
+      (self as any).fetch = async (input: any, init?: any) => {
+        const url =
+          typeof input === 'string' ? input : input?.url ?? input?.href ?? '';
+        if (url.startsWith('https://edge.microsoft.com/translate/auth')) {
+          return new Response('mock-jwt-token', { status: 200 });
+        }
+        if (
+          url.startsWith('https://api-edge.cognitive.microsofttranslator.com/')
+        ) {
+          const body = JSON.parse((init?.body ?? '[]') as string) as Array<{
+            Text: string;
+          }>;
+          return new Response(
+            JSON.stringify(
+              body.map((t) => ({
+                translations: [{ text: `[BING] ${t.Text}` }],
+              })),
+            ),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          );
+        }
+        return realFetch(input, init);
+      };
     });
-    await context.route(
-      'https://api-edge.cognitive.microsofttranslator.com/translate**',
-      (route) => {
-        const body = route.request().postDataJSON();
-        const texts: Array<{ Text: string }> = body ?? [];
-        route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(
-            texts.map((t: { Text: string }) => ({
-              translations: [{ text: `[BING] ${t.Text}` }],
-            })),
-          ),
-        });
-      },
-    );
 
     await seedSettings({ enginePriority: ['bing-edge'] });
     await gotoFixture('basic');

--- a/docs/testing/e2e/fixtures.ts
+++ b/docs/testing/e2e/fixtures.ts
@@ -3,7 +3,7 @@
  *
  * 关键设计:
  * 1. persistent context + --load-extension 加载扩展
- * 2. context.route mock 翻译 API（已验证可拦截 SW 请求）
+ * 2. mockGoogle 在 SW 内 stub fetch（#89：CDP route 对 SW 请求拦截不可靠）
  * 3. seedSettings 写入 chrome.storage.sync 并等待生效
  * 4. fixture 页面通过 HTTP 提供（绕开 file:// 的 content script 限制）
  */
@@ -51,27 +51,12 @@ export function fixtureFileUrl(name: FixtureName): string {
   return 'file://' + fileURLToPath(new URL(`./fixtures/${name}.html`, import.meta.url));
 }
 
-// ── Google Translate API 响应形状 ──
-interface GoogleResponse {
-  0: Array<[string, string, null, null, number]>;
-}
-
-function googleBody(translation: string): [GoogleResponse, null, string] {
-  return [
-    {
-      0: [[translation, '', null, null, 1]],
-    },
-    null,
-    'en',
-  ];
-}
-
 export const test = base.extend<
   {
     serviceWorker: Worker;
     mockGoogle: (opts?: {
       fail?: boolean;
-      translation?: (q: string) => string;
+      prefix?: string;
     }) => Promise<void>;
     seedSettings: (patch: Record<string, unknown>) => Promise<void>;
     gotoFixture: (name: FixtureName) => Promise<Page>;
@@ -121,26 +106,42 @@ export const test = base.extend<
   },
 
   // ── Mock Google Translate ──
-  mockGoogle: async ({ context }, use) => {
-    await use(async (opts = {}) => {
-      const { fail = false, translation } = opts;
-      await context.route('https://translate.googleapis.com/**', (route) => {
-        if (fail) {
-          return route.fulfill({
-            status: 500,
-            contentType: 'text/plain',
-            body: 'Service Unavailable',
-          });
-        }
-        const q = new URL(route.request().url()).searchParams.get('q') ?? '';
-        const t = translation ? translation(q) : `【译】${q}`;
-        const body = JSON.stringify(googleBody(t));
-        route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body,
-        });
-      });
+  // #89: 在 SW 内 stub fetch（引擎运行处），而不是 context.route ——
+  // CDP 对 SW 发起的请求拦截不可靠：部分请求绕过时，本地恰好直连真实
+  // Google 而「假绿」，CI 无外网则必失败。SW 侧 stub 完全确定性。
+  mockGoogle: async ({ serviceWorker }, use) => {
+    await use(async (opts: { fail?: boolean; prefix?: string } = {}) => {
+      const { fail = false, prefix = '【译】' } = opts;
+      await serviceWorker.evaluate(
+        (cfg: { fail: boolean; prefix: string }) => {
+          const realFetch = self.fetch.bind(self);
+          (self as any).fetch = async (input: any, init?: any) => {
+            const url =
+              typeof input === 'string'
+                ? input
+                : input?.url ?? input?.href ?? '';
+            if (!url.startsWith('https://translate.googleapis.com/')) {
+              return realFetch(input, init);
+            }
+            if (cfg.fail) {
+              return new Response('Service Unavailable', { status: 500 });
+            }
+            const q = new URL(url).searchParams.get('q') ?? '';
+            // 与真实端点同形：data[0] 是分句数组，每项 [0] 为译文。
+            // 注意必须是 [[[...]]] —— {0: [...]} 序列化后是对象，引擎解析抛错。
+            const body = JSON.stringify([
+              [[cfg.prefix + q, '', null, null, 1]],
+              null,
+              'en',
+            ]);
+            return new Response(body, {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            });
+          };
+        },
+        { fail, prefix },
+      );
     });
   },
 

--- a/docs/testing/unit/runtime/messaging.test.ts
+++ b/docs/testing/unit/runtime/messaging.test.ts
@@ -1,0 +1,170 @@
+/**
+ * runtime/messaging.ts — content → background 消息通道健壮性 单元测试
+ *
+ * #89：Chrome MV3 headless 下 SW 冷启动/监听器未注册时，
+ * content script 发出的 pt:translate 会被丢弃（sendMessage 解析为
+ * undefined 或 reject "Receiving end does not exist"）。
+ *
+ * translateViaBackground 的公开契约：
+ * 1. 发送前先 ping（pt:ping）确认 SW 消息通道就绪，有界重试
+ * 2. pt:translate 在传输层失败（无响应/连接被拒）时有界重试
+ * 3. SW 已响应的 {ok:false}（引擎级失败）不重试，原样返回
+ * 4. 预算耗尽返回 {ok:false} + 错误说明，永不抛出
+ */
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { translateViaBackground } from '~/src/runtime/messaging';
+
+const sendMessage = vi.mocked(chrome.runtime.sendMessage);
+
+afterEach(() => {
+  vi.useRealTimers();
+  sendMessage.mockReset();
+});
+
+const PAYLOAD = { texts: ['Hello'], from: 'en', to: 'zh-CN' };
+
+describe('translateViaBackground — SW 就绪时', () => {
+  test('ping 一次 + translate 一次，直接返回译文', async () => {
+    sendMessage.mockImplementation(async (msg: unknown) => {
+      const m = msg as { type?: string; payload?: unknown };
+      if (m.type === 'pt:ping') return { ok: true };
+      return { ok: true, data: { translations: ['你好'] } };
+    });
+
+    const result = await translateViaBackground(PAYLOAD);
+
+    expect(result).toEqual({ ok: true, data: { translations: ['你好'] } });
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage).toHaveBeenNthCalledWith(1, { type: 'pt:ping' });
+    expect(sendMessage).toHaveBeenNthCalledWith(2, {
+      type: 'pt:translate',
+      payload: PAYLOAD,
+    });
+  });
+});
+
+describe('translateViaBackground — SW 冷启动（#89 根因）', () => {
+  test('ping 前两次无响应，第三次就绪后翻译成功', async () => {
+    vi.useFakeTimers();
+    let pings = 0;
+    sendMessage.mockImplementation(async (msg: unknown) => {
+      const m = msg as { type?: string };
+      if (m.type === 'pt:ping') {
+        pings++;
+        return pings >= 3 ? { ok: true } : undefined;
+      }
+      return { ok: true, data: { translations: ['就绪后译文'] } };
+    });
+
+    const pending = translateViaBackground(PAYLOAD);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(pings).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(pings).toBe(2);
+
+    await vi.advanceTimersByTimeAsync(500);
+    const result = await pending;
+
+    expect(result).toEqual({ ok: true, data: { translations: ['就绪后译文'] } });
+    // 3 次 ping + 1 次 translate
+    expect(sendMessage).toHaveBeenCalledTimes(4);
+  });
+
+  test('translate 首次无响应（SW 在 ping 后失联）→ 自动重试成功', async () => {
+    vi.useFakeTimers();
+    let translates = 0;
+    sendMessage.mockImplementation(async (msg: unknown) => {
+      const m = msg as { type?: string };
+      if (m.type === 'pt:ping') return { ok: true };
+      translates++;
+      return translates >= 2
+        ? { ok: true, data: { translations: ['重试后译文'] } }
+        : undefined;
+    });
+
+    const pending = translateViaBackground(PAYLOAD);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(translates).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(250);
+    const result = await pending;
+
+    expect(result).toEqual({ ok: true, data: { translations: ['重试后译文'] } });
+  });
+
+  test('sendMessage reject（Receiving end does not exist）→ 重试成功', async () => {
+    vi.useFakeTimers();
+    let translates = 0;
+    sendMessage.mockImplementation(async (msg: unknown) => {
+      const m = msg as { type?: string };
+      if (m.type === 'pt:ping') return { ok: true };
+      translates++;
+      if (translates === 1) {
+        throw new Error(
+          'Could not establish connection. Receiving end does not exist.',
+        );
+      }
+      return { ok: true, data: { translations: ['连接恢复'] } };
+    });
+
+    const pending = translateViaBackground(PAYLOAD);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(250);
+    const result = await pending;
+
+    expect(result).toEqual({ ok: true, data: { translations: ['连接恢复'] } });
+  });
+});
+
+describe('translateViaBackground — 失败语义', () => {
+  test('SW 响应 {ok:false}（引擎级失败）→ 原样返回，不重试', async () => {
+    sendMessage.mockImplementation(async (msg: unknown) => {
+      const m = msg as { type?: string };
+      if (m.type === 'pt:ping') return { ok: true };
+      return { ok: false, error: '所有引擎均失败' };
+    });
+
+    const result = await translateViaBackground(PAYLOAD);
+
+    expect(result).toEqual({ ok: false, error: '所有引擎均失败' });
+    // 1 ping + 1 translate，translate 没有重试
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  test('SW 始终无响应：ping 预算耗尽 → {ok:false}，不发送 translate', async () => {
+    vi.useFakeTimers();
+    sendMessage.mockImplementation(async () => undefined);
+
+    const pending = translateViaBackground(PAYLOAD);
+    await vi.advanceTimersByTimeAsync(15_000);
+    const result = await pending;
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('无响应');
+    }
+    // translate 从未发送 —— 通道未就绪就不浪费引擎配额
+    const translateCalls = sendMessage.mock.calls.filter(
+      ([m]) => (m as { type?: string })?.type === 'pt:translate',
+    );
+    expect(translateCalls).toHaveLength(0);
+  });
+
+  test('translate 持续无响应：重试预算耗尽 → {ok:false}', async () => {
+    vi.useFakeTimers();
+    sendMessage.mockImplementation(async (msg: unknown) => {
+      const m = msg as { type?: string };
+      return m.type === 'pt:ping' ? { ok: true } : undefined;
+    });
+
+    const pending = translateViaBackground(PAYLOAD);
+    await vi.advanceTimersByTimeAsync(20_000);
+    const result = await pending;
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('无响应');
+    }
+  });
+});

--- a/docs/testing/vitest.config.ts
+++ b/docs/testing/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
         'src/hotkeys/**',
         'src/styles/**',
         'src/queue/**',
+        'src/runtime/**',
       ],
       thresholds: {
         'src/engines': { lines: 85 },
@@ -35,6 +36,7 @@ export default defineConfig({
         'src/hotkeys': { lines: 85 },
         'src/styles': { lines: 85 },
         'src/queue': { lines: 85 },
+        'src/runtime': { lines: 85 },
       },
       // 覆盖率报告也写到 logs 目录
       reportsDirectory: `${LOGS_DIR}/coverage`,

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -26,6 +26,7 @@ import { createParaBtn } from '~/src/ui/paragraph-btn';
 import { toast } from '~/src/ui/toast';
 import { startHotkeys } from '~/src/hotkeys/listener';
 import { startSelectionDrag } from '~/src/ui/selection-drag';
+import { translateViaBackground } from '~/src/runtime/messaging';
 import { detectOS } from '~/src/hotkeys/platform';
 import {
   settingsReady,
@@ -201,9 +202,12 @@ export default defineContentScript({
       // Google Web 的并发闸门是惰性单例，所有批次共享，自然排队。
       await Promise.all(
         batches.map(async ({ texts: batchTexts, targets: batchTargets, preserves: batchPreserves, rawTexts: batchRawTexts }) => {
-          const resp = await chrome.runtime.sendMessage({
-            type: 'pt:translate',
-            payload: { texts: batchTexts, from: ns.from, to: ns.to },
+          // #89: SW 未就绪时消息会被丢弃 —— 经 translateViaBackground
+          // 先 ping 确认通道就绪，传输层失败自动重试。
+          const resp = await translateViaBackground({
+            texts: batchTexts,
+            from: ns.from,
+            to: ns.to,
           });
 
           if (!resp?.ok) {
@@ -385,9 +389,10 @@ export default defineContentScript({
       const text = normalizeText(rawText);
       if (!text) return;
 
-      const resp = await chrome.runtime.sendMessage({
-        type: 'pt:translate',
-        payload: { texts: [text], from: ns.from, to: ns.to },
+      const resp = await translateViaBackground({
+        texts: [text],
+        from: ns.from,
+        to: ns.to,
       });
 
       if (!resp?.ok) {
@@ -397,7 +402,7 @@ export default defineContentScript({
 
       // #58：将占位符替换回原文
       const restored = restorePreserves(
-        resp.data.translations[0],
+        resp.data.translations[0]!,
         preserves,
         text,
       );
@@ -416,9 +421,10 @@ export default defineContentScript({
       const ns = getSettings();
       if (!ns.enabled) return;
 
-      const resp = await chrome.runtime.sendMessage({
-        type: 'pt:translate',
-        payload: { texts: [text], from: ns.from, to: ns.to },
+      const resp = await translateViaBackground({
+        texts: [text],
+        from: ns.from,
+        to: ns.to,
       });
 
       if (!resp?.ok) {
@@ -426,7 +432,7 @@ export default defineContentScript({
         return;
       }
 
-      toast(resp.data.translations[0]);
+      toast(resp.data.translations[0]!);
     }
 
     // ── 监听 popup / background 消息 ──

--- a/src/runtime/messaging.ts
+++ b/src/runtime/messaging.ts
@@ -1,0 +1,89 @@
+// content → background 消息通道健壮层。
+//
+// #89：Chrome MV3 的 service worker 在 headless/冷启动场景下，
+// onMessage 监听器未必已注册 —— content script 此时发出的
+// chrome.runtime.sendMessage 要么解析为 undefined（无监听器），
+// 要么 reject "Could not establish connection. Receiving end does not exist."。
+// 直接当作最终失败会让整页翻译静默失败（[data-pt="done"] 永不出现）。
+//
+// translateViaBackground 是 content script 三个翻译入口共用的通道：
+// 1. 先 ping（pt:ping）确认 SW 消息通道就绪，有界重试
+// 2. 再发 pt:translate；传输层失败（无响应/连接被拒）有界重试
+// 3. SW 已响应的 {ok:false} 是引擎级失败（router 已做过引擎降级），不重试
+// 4. 预算耗尽返回 {ok:false} + 错误说明，永不抛出 —— 调用方按原约定处理
+
+import type { TranslateRequest, TranslateResponse } from '~/src/engines/types';
+
+export type TranslateResult =
+  | { ok: true; data: TranslateResponse }
+  | { ok: false; error: string };
+
+/** SW 就绪等待预算（ping 阶段）。覆盖 CI 中 SW 冷启动的常见耗时。 */
+const READY_BUDGET_MS = 10_000;
+/** 翻译消息传输层重试预算。 */
+const SEND_BUDGET_MS = 15_000;
+/** 退避起点（毫秒），每次翻倍，上限 2s。 */
+const BACKOFF_INITIAL_MS = 250;
+const BACKOFF_MAX_MS = 2000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * 有界重试发送：只要收不到任何响应（undefined / 连接被拒），
+ * 就以指数退避重发，直到预算耗尽。收到响应（无论内容）即返回。
+ * 预算耗尽时抛出最后一次失败原因。
+ */
+async function sendWithTransportRetry(
+  msg: unknown,
+  budgetMs: number,
+): Promise<unknown> {
+  const deadline = Date.now() + budgetMs;
+  let delay = BACKOFF_INITIAL_MS;
+  let lastError = 'background 无响应';
+
+  for (;;) {
+    let resp: unknown;
+    try {
+      resp = await chrome.runtime.sendMessage(msg);
+    } catch (e) {
+      lastError = e instanceof Error ? e.message : String(e);
+      resp = undefined;
+    }
+    if (resp !== undefined) return resp;
+    if (Date.now() >= deadline) break;
+    await sleep(delay);
+    delay = Math.min(delay * 2, BACKOFF_MAX_MS);
+  }
+
+  throw new Error(`[PT] 消息通道不可用: ${lastError}`);
+}
+
+/**
+ * 通过 background 翻译文本。
+ *
+ * 永不抛出 —— 通道彻底不可用时返回 {ok:false, error}，
+ * 与 SW 的 pt:translate 失败响应同构，调用方无需区分。
+ */
+export async function translateViaBackground(
+  payload: TranslateRequest,
+): Promise<TranslateResult> {
+  try {
+    // 1) SW 就绪等待：任何 ping 响应都证明消息通道已注册监听器。
+    await sendWithTransportRetry({ type: 'pt:ping' }, READY_BUDGET_MS);
+
+    // 2) 发送翻译消息，传输层失败重试。
+    const resp = (await sendWithTransportRetry(
+      { type: 'pt:translate', payload },
+      SEND_BUDGET_MS,
+    )) as { ok?: boolean; data?: TranslateResponse; error?: string };
+
+    if (resp?.ok === true && resp.data) {
+      return { ok: true, data: resp.data };
+    }
+    return { ok: false, error: resp?.error ?? '未知错误' };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}


### PR DESCRIPTION
## 摘要

Closes #89 —— CI e2e-core / hotkeys-macos 中 13 个核心测试超时的根因不止一处，本 PR 逐层修复。

## 根因（按发现顺序）

1. **产品 — SW 消息通道竞态（#83）**：content script 的 `chrome.runtime.sendMessage` 在 SW 冷启动 / 监听器未注册时被静默丢弃（Promise 解析为 `undefined` 或 reject "Receiving end does not exist"），翻译请求一次失败即放弃，`[data-pt="done"]` 永不出现。
2. **测试基础设施 — mock 响应体形状错误**：`googleBody` 返回 `[{0: [...]}, null, 'en']`，JSON 序列化后 `{0: ...}` 是**对象而非数组**；引擎 `google-web.ts` 的 `data[0]` 拿到对象后 `for...of` 抛 TypeError —— 被拦截的请求 100% 失败。此形状自测试基础设施引入起就存在。
3. **测试基础设施 — CDP 拦截不确定**：`context.route` 对 SW 发起的 fetch 存在部分绕过（实测 10 个请求仅 4 个被拦截）。本地绕过时直连真实 Google 恰好「假绿」，CI 无外网必失败 —— 这正是 issue 中「本地与 CI 表现不一致」的来源。
4. **平台不匹配**：TC-E2E-03/04 在 macOS 上按 Control 变体（mac 上 Mod=Meta），TC-E2E-03-Mac 在 Linux 上无 Meta 语义 —— 跨平台 CI job 必挂。
5. **断言与设计矛盾**：TC-E2E-21 断言「无嵌套 done」，但 #23 混合内容设计下父 div（直接文本）与子 p（块级单元）均为 done 是预期结构。

## 修复

### 产品（TDD：红 → 绿）
- 新增 `src/runtime/messaging.ts` — `translateViaBackground(payload)`：
  - 发送前先 `pt:ping` 确认 SW 就绪（有界重试，10s 预算）
  - `pt:translate` 传输层失败（无响应 / 连接被拒）有界重试（15s 预算）
  - 引擎级 `{ok:false}` 不重试（router 已做引擎降级）；预算耗尽返回 `{ok:false}`，永不抛出
- content.ts 三个翻译入口（整页 / 单段 / 选区）统一接入
- 单元测试 `docs/testing/unit/runtime/messaging.test.ts`：7 个用例覆盖 ping 重试、传输层重试、引擎失败不重试、预算耗尽；`src/runtime` 覆盖率 100% 行 / 85.7% 分支，纳入 85% 阈值

### 测试基础设施
- `mockGoogle` 改为在 **SW 内 stub fetch**（引擎运行处，完全确定性，不受 CDP 拦截影响）；响应体修正为 `[[[...]]]` 真实形状
- TC-E2E-16 Bing mock 同样移入 SW
- TC-E2E-03/03-Mac/04 按平台 skip；TC-E2E-21 断言改为「译文无重复文本」

## 验证

- `pnpm typecheck` ✓
- `pnpm test`：255/255 ✓
- `pnpm test:verify-build` ✓
- `pnpm test:e2e:core`（macOS 本地）：**18 通过 / 2 跳过（macOS 平台 skip）/ 1 失败**

剩余 1 个失败为 TC-E2E-27 的 `.plain pre` fixture 断言（fixture 把 `plain` 类挂在 pre 上而非包裹层、pre 内含 `<code>` 且文本未超 3072 阈值，三重不匹配）——归 #92 独立修复；其 translateAndWait 部分（#89 范围）已修复。