### PR TITLE
fix(e2e): 增量翻译引擎级失败批次重试 + TC-E2E-47/48 回归 (#91)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm build
-      - run: pnpm test:e2e -- --grep-invert "@real"
+      - run: pnpm test:e2e --grep-invert "@real"
       # ── 上传日志 ──
       - name: Upload full E2E logs
         if: always()
@@ -142,7 +142,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm build
-      - run: pnpm test:e2e -- --grep "@real"
+      - run: pnpm test:e2e --grep "@real"
       # ── 上传日志 ──
       - name: Upload smoke test logs
         if: always()

--- a/docs/DEEP-TESTING.md
+++ b/docs/DEEP-TESTING.md
@@ -600,6 +600,8 @@ DOM 覆盖（每 fixture 至少 1 个用例）：
   TC-E2E-29: media-mix.html → 含图片的容器被降级
   TC-E2E-30: iframe.html → 主文档翻译不影响 iframe 内
   TC-E2E-46: infinite.html → mock 丢失后增量翻译自动恢复（#90 回归）
+  TC-E2E-47: spa.html → 增量翻译瞬时失败后自动重试（#91 回归）
+  TC-E2E-48: basic.html → 多批增量翻译部分失败自动重试（#91 回归）
 ```
 
 **扩展 E2E 套件（发布前跑，~15 个）**：
@@ -892,7 +894,7 @@ __tests__/
 │   │   ├── entity.html              # 新增
 │   │   └── ...
 │   ├── fixtures.ts                  # Playwright 夹具
-│   ├── core.spec.ts                 # 核心 E2E（TC-E2E-01 ~ 30、46）
+│   ├── core.spec.ts                 # 核心 E2E（TC-E2E-01 ~ 30、46 ~ 48）
 │   ├── extended.spec.ts             # 扩展 E2E（TC-E2E-31 ~ 45）
 │   ├── perf.spec.ts                 # 性能基准
 │   ├── security.spec.ts             # 安全验证

--- a/docs/testing/e2e/core.spec.ts
+++ b/docs/testing/e2e/core.spec.ts
@@ -306,6 +306,64 @@ test.describe('Fixture: spa', () => {
     // 新内容的 3 个翻译单元（h1 + 2p）应被 observer 自动补翻
     await expect(page.locator('#view [data-pt="done"]')).toHaveCount(3, { timeout: 15_000 });
   });
+
+  test('@core TC-E2E-47: 增量翻译瞬时失败后自动重试（#91 回归）', async ({
+    page, serviceWorker, mockGoogle, seedSettings, gotoFixture,
+  }) => {
+    await seedSettings({});
+    await mockGoogle({ prefix: '[MOCK] ' });
+    await gotoFixture('spa');
+
+    await translateAndWait(page);
+
+    // 武装一次性故障：下一次翻译请求必失败（等效 CI 中 SW 实例替换
+    // 后的瞬时引擎故障）。修复前增量翻译是一次性的 —— 失败后
+    // 新内容永久漏翻，与 #91 的「Retry #1/#2」失败签名一致。
+    await mockGoogle({ failOnce: true, prefix: '[MOCK] ' });
+
+    await page.click('a[href="#page2"]');
+
+    // 故障已被触发且只触发一次（failOnceServed === 1 证明重试发生
+    // 在失败之后；failOnce 失效时计数为 0，测试不再假绿）
+    await expect(page.locator('#view [data-pt="done"]')).toHaveCount(3, { timeout: 20_000 });
+    await expect(page.locator('#view h1 .pt-trans').first()).toContainText('[MOCK]');
+    const stats = await serviceWorker.evaluate(() =>
+      (self as any).getE2EMockStats(),
+    );
+    expect(stats.failOnceServed).toBe(1);
+  });
+
+  test('@core TC-E2E-48: 多批增量翻译部分失败自动重试（#91 审查跟进）', async ({
+    page, serviceWorker, mockGoogle, seedSettings, gotoFixture,
+  }) => {
+    await seedSettings({});
+    await mockGoogle({ prefix: '[MOCK] ' });
+    await gotoFixture('basic');
+
+    await translateAndWait(page);
+    const initialDone = await page.locator('[data-pt="done"]').count();
+
+    // 一次性注入 20 段 —— 跨 FULL_PAGE_BATCH_SIZE(15) 两个批次；
+    // failOnce 只击落其中一个批次的请求，另一批正常。修复前失败
+    // 批被 allFailed 掩码（整页 status 仍是 'translated'），漏翻永
+    // 不重试；修复后批次级重试补齐。
+    await mockGoogle({ failOnce: true, prefix: '[MOCK] ' });
+    await page.evaluate(() => {
+      const frag = document.createDocumentFragment();
+      for (let i = 1; i <= 20; i++) {
+        const p = document.createElement('p');
+        p.textContent = `Paragraph ${i} added after initial translation.`;
+        frag.appendChild(p);
+      }
+      document.body.appendChild(frag);
+    });
+
+    await expect(page.locator('[data-pt="done"]')).toHaveCount(initialDone + 20, { timeout: 30_000 });
+    const stats = await serviceWorker.evaluate(() =>
+      (self as any).getE2EMockStats(),
+    );
+    expect(stats.failOnceServed).toBe(1);
+  });
 });
 
 test.describe('Fixture: hostile', () => {

--- a/docs/testing/e2e/fixtures.ts
+++ b/docs/testing/e2e/fixtures.ts
@@ -8,6 +8,7 @@
  * 4. fixture 页面通过 HTTP 提供（绕开 file:// 的 content script 限制）
  */
 import { test as base, chromium, expect, type Page, type Worker } from '@playwright/test';
+import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'node:url';
 
@@ -57,6 +58,8 @@ export const test = base.extend<
     mockGoogle: (opts?: {
       fail?: boolean;
       prefix?: string;
+      /** 一次性故障：下一次翻译请求 500，随后自动恢复（#91） */
+      failOnce?: boolean;
     }) => Promise<void>;
     seedSettings: (patch: Record<string, unknown>) => Promise<void>;
     gotoFixture: (name: FixtureName) => Promise<Page>;
@@ -72,6 +75,12 @@ export const test = base.extend<
         '.output/.playwright-profiles',
         testInfo.testId,
       );
+
+      // 每次启动前清空 profile：testId 跨运行稳定，上次运行留下的
+      // profile 里缓存着旧版 service worker 脚本 —— Chrome 会直接
+      // 复用旧脚本，扩展改动在本地迭代时「假失败」（SW 里查不到新
+      // 加的全局函数）。清空保证每个用例都从干净的扩展状态出发。
+      fs.rmSync(userDataDir, { recursive: true, force: true });
 
       const context = await chromium.launchPersistentContext(userDataDir, {
         headless: true,
@@ -114,12 +123,12 @@ export const test = base.extend<
   // SW 实例一旦被 Chrome 替换，实例内存里的 stub 会消失 —— 翻译路由
   // 前的 ensureE2EMock 从 storage 自愈重装，增量翻译不再直连真实端点。
   mockGoogle: async ({ serviceWorker }, use) => {
-    await use(async (opts: { fail?: boolean; prefix?: string } = {}) => {
-      const { fail = false, prefix = '【译】' } = opts;
+    await use(async (opts: { fail?: boolean; prefix?: string; failOnce?: boolean } = {}) => {
+      const { fail = false, prefix = '【译】', failOnce = false } = opts;
       await serviceWorker.evaluate(
-        (cfg: { fail: boolean; prefix: string }) =>
+        (cfg: { fail: boolean; prefix: string; failOnce: boolean }) =>
           (self as any).applyE2EMock(cfg),
-        { fail, prefix },
+        { fail, prefix, failOnce },
       );
     });
   },

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -5,7 +5,7 @@ import { cacheSet, cacheKey, cacheGet, cacheClear } from '~/src/storage/cache';
 import { getKey, setKey, removeKey } from '~/src/storage/keys';
 import { settingsReady, patchSettings, onSettingsChanged } from '~/src/storage/settings';
 import { route } from '~/src/engines/router';
-import { ensureE2EMock, applyE2EMock } from '~/src/engines/e2e-mock';
+import { ensureE2EMock, applyE2EMock, getE2EMockStats } from '~/src/engines/e2e-mock';
 import { initContextMenu } from '~/src/ui/context-menu';
 
 /** 将浏览器 UI 语言映射到 LANG_LIST 中可用的目标语言码 */
@@ -40,6 +40,8 @@ export default defineBackground(() => {
   (self as any).removeKey = removeKey;
   // E2E fixtures 的 mock 注入入口（#90，与上同理的调试面）
   (self as any).applyE2EMock = applyE2EMock;
+  // mock 统计探针 —— TC-E2E-47/48 断言一次性故障确实被触发（#91）
+  (self as any).getE2EMockStats = getE2EMockStats;
 
   // 右键菜单 + 首次安装引导
   chrome.runtime.onInstalled.addListener((details) => {

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -137,6 +137,14 @@ export default defineContentScript({
     // 用户在第一屏译文出现前不再需要等待全页最慢段。
     const FULL_PAGE_BATCH_SIZE = 15;
 
+    // #91: 批次级引擎失败有限重试（见 doTranslate 内 attemptBatch）。
+    const BATCH_RETRY_LIMIT = 2;
+    const BATCH_RETRY_DELAYS_MS = [1000, 3000];
+    /** 还原纪元：doRestore 递增，在飞翻译据此放弃重试与渲染。 */
+    const translateEpoch = { value: 0 };
+    const sleep = (ms: number) =>
+      new Promise<void>((resolve) => self.setTimeout(resolve, ms));
+
     async function doTranslate(
       elements?: Element[],
     ): Promise<string> {
@@ -198,45 +206,75 @@ export default defineContentScript({
       let renderRejected = 0;
       let renderSucceeded = 0;
 
-      // 所有批次并发发送，每批返回即渲染。
-      // Google Web 的并发闸门是惰性单例，所有批次共享，自然排队。
-      await Promise.all(
-        batches.map(async ({ texts: batchTexts, targets: batchTargets, preserves: batchPreserves, rawTexts: batchRawTexts }) => {
+      // #91: 批次级引擎失败有限重试。传输层失败由 translateViaBackground
+      // 内部重试（重新 ping + 有界退避），这里只处理引擎级失败（{ok:false}）
+      // —— 修复前增量翻译是一次性的：瞬时故障（CI 中 SW 冷启动/实例替换）
+      // 后新内容永久漏翻，正是 #91 的失败签名。初始翻译与增量翻译共用此
+      // 路径，部分批次失败（多批并发）与全部失败（单批）统一自愈。
+      // 文本在批次切分时捕获一次，重试复用同一份 —— 不会因 DOM 已变
+      // 而重新采集到译文本身。
+      const epochAtStart = translateEpoch.value;
+      async function attemptBatch(
+        batch: (typeof batches)[number],
+      ): Promise<{ rendered: number; rejected: number; failed: boolean }> {
+        let rendered = 0;
+        let rejected = 0;
+        let lastError = '未知错误';
+        for (let attempt = 0; ; attempt++) {
           // #89: SW 未就绪时消息会被丢弃 —— 经 translateViaBackground
           // 先 ping 确认通道就绪，传输层失败自动重试。
           const resp = await translateViaBackground({
-            texts: batchTexts,
+            texts: batch.texts,
             from: ns.from,
             to: ns.to,
           });
-
-          if (!resp?.ok) {
-            console.error('[PT] 批次翻译失败:', resp?.error ?? '未知错误');
-            return;
+          // 已还原（doRestore 递增纪元）—— 放弃渲染，不再重试
+          if (translateEpoch.value !== epochAtStart) {
+            return { rendered, rejected, failed: true };
           }
-
-          allFailed = false;
-
-          const translations: string[] = resp.data.translations;
-          for (let i = 0; i < batchTargets.length; i++) {
-            try {
-              // #58：将占位符替换回原文（用户名等标识符不翻译但保留）
-              const restored = restorePreserves(
-                translations[i]!,
-                batchPreserves[i]!,
-                batchRawTexts[i]!,
-              );
-              if (render(batchTargets[i]!, restored, 'page')) {
-                renderSucceeded++;
-              } else {
-                renderRejected++;
+          if (resp?.ok) {
+            const translations: string[] = resp.data.translations;
+            for (let i = 0; i < batch.targets.length; i++) {
+              try {
+                // #58：将占位符替换回原文（用户名等标识符不翻译但保留）
+                const restored = restorePreserves(
+                  translations[i]!,
+                  batch.preserves[i]!,
+                  batch.rawTexts[i]!,
+                );
+                if (render(batch.targets[i]!, restored, 'page')) {
+                  rendered++;
+                } else {
+                  rejected++;
+                }
+              } catch (e) {
+                throw new Error(
+                  `[render idx=${i}] ${e instanceof Error ? e.message : String(e)}`,
+                );
               }
-            } catch (e) {
-              throw new Error(
-                `[render idx=${i}] ${e instanceof Error ? e.message : String(e)}`,
-              );
             }
+            return { rendered, rejected, failed: false };
           }
+          lastError = resp?.error ?? '未知错误';
+          if (attempt >= BATCH_RETRY_LIMIT) break;
+          await sleep(BATCH_RETRY_DELAYS_MS[attempt]!);
+          // 睡眠期间被还原 —— 放弃重试
+          if (translateEpoch.value !== epochAtStart) {
+            return { rendered, rejected, failed: true };
+          }
+        }
+        console.error('[PT] 批次翻译失败:', lastError);
+        return { rendered, rejected, failed: true };
+      }
+
+      // 所有批次并发发送，每批返回即渲染。
+      // Google Web 的并发闸门是惰性单例，所有批次共享，自然排队。
+      await Promise.all(
+        batches.map(async (batch) => {
+          const r = await attemptBatch(batch);
+          renderSucceeded += r.rendered;
+          renderRejected += r.rejected;
+          if (!r.failed) allFailed = false;
         }),
       );
 
@@ -271,6 +309,10 @@ export default defineContentScript({
         stopObserving();
         stopObserving = null;
       }
+
+      // 递增还原纪元 —— 在飞翻译的批次重试检测到变化后放弃重试与
+      // 渲染，避免还原后把内容翻回来（#91）
+      translateEpoch.value++;
 
       // allTranslated() 已支持 shadow 穿透（Phase 3 P3-3 修复）
       const els: Element[] = [];

--- a/src/engines/e2e-mock.ts
+++ b/src/engines/e2e-mock.ts
@@ -16,12 +16,22 @@
 export interface E2EMockConfig {
   prefix?: string;
   fail?: boolean;
+  /** 一次性故障：下一次翻译请求返回 500，随后自动恢复（测试专用）。 */
+  failOnce?: boolean;
 }
 
 const STORAGE_KEY = 'pt-e2e-mock';
 
 /** 当前生效的 mock 配置。null = 无 mock（线上行为）。 */
 let activeCfg: E2EMockConfig | null = null;
+
+/** 已触发的一次性故障次数（测试断言用，防止 failOnce 失效导致假绿）。 */
+let failOnceServed = 0;
+
+/** 测试探针：返回 mock 统计。 */
+export function getE2EMockStats(): { failOnceServed: number } {
+  return { failOnceServed };
+}
 
 /** mock 包裹层函数：带标记字段以便幂等安装 */
 type MockFetch = ((input: any, init?: any) => Promise<Response>) & {
@@ -43,6 +53,14 @@ function installStub(): void {
       typeof input === 'string' ? input : input?.url ?? input?.href ?? '';
     if (!url.startsWith('https://translate.googleapis.com/')) {
       return realFetch(input, init);
+    }
+    if (activeCfg.failOnce) {
+      // 一次性故障：只活在实例内存里（不持久化）。消费即清除 ——
+      // 并发批次消息各自在路由前重读 storage 描述符，若 failOnce
+      // 走持久化通道，读到的旧值会重新武装，一个请求变成多个 500。
+      failOnceServed++;
+      activeCfg = { ...activeCfg, failOnce: false };
+      return new Response('Service Unavailable', { status: 500 });
     }
     if (activeCfg.fail) {
       return new Response('Service Unavailable', { status: 500 });
@@ -75,7 +93,9 @@ export async function ensureE2EMock(): Promise<void> {
   try {
     const { [STORAGE_KEY]: cfg } = await chrome.storage.local.get(STORAGE_KEY);
     if (!cfg) return;
-    activeCfg = cfg as E2EMockConfig;
+    // failOnce 是实例内存态，不随描述符持久化 —— 合并时保留在飞
+    // 的一次性开关，否则路由前的这次读取会把它清掉（#91 调查）
+    activeCfg = { ...(cfg as E2EMockConfig), failOnce: activeCfg?.failOnce };
     installStub();
   } catch (e) {
     console.warn('[PT] E2E mock 自愈失败，直连真实端点:', e);
@@ -91,7 +111,12 @@ export async function ensureE2EMock(): Promise<void> {
 export function applyE2EMock(cfg: E2EMockConfig): Promise<void> {
   activeCfg = cfg;
   installStub();
+  // failOnce 不持久化：它只在当前 SW 实例内一次性生效。
+  // SW 意外被替换时开关丢失 → 测试因 failOnceServed === 0 响亮失败，
+  // 不会假绿。
+  const persisted = { ...cfg };
+  delete persisted.failOnce;
   return new Promise<void>((resolve) => {
-    chrome.storage.local.set({ [STORAGE_KEY]: cfg }, () => resolve());
+    chrome.storage.local.set({ [STORAGE_KEY]: persisted }, () => resolve());
   });
 }


### PR DESCRIPTION
Closes #91

## Extended description

增量翻译是一次性的 —— 引擎级瞬时故障后新内容永久漏翻（#91 失败签名）；多批并发时部分失败被 `allFailed` 掩码。

修复：
- `content.ts`：批次级有限重试 ×2（1s/3s），初始与增量翻译共用；`translateEpoch` 让还原取消在飞重试
- `e2e-mock.ts`：`failOnce` 一次性故障开关（内存态，防并发重武装）+ `getE2EMockStats` 探针
- `fixtures.ts`：`mockGoogle` 透传 `failOnce`；启动前清空 profile（旧 SW 脚本缓存假失败）
- `test.yml`：修复 e2e-full/smoke-real-sites 的 `--grep` 被 `--` 吞掉
- TC-E2E-47/48 回归（修复前红、修复后绿）

验证：单元 255 ✓ · E2E core 22 ✓ · CI 三 job 全绿