### PR TITLE
fix(e2e): TC-E2E-29 按规格补全断言 — 锁定媒体降级行为 (#92)

### DIFF
--- a/docs/testing/e2e/core.spec.ts
+++ b/docs/testing/e2e/core.spec.ts
@@ -493,12 +493,35 @@ test.describe('Fixture: media-mix', () => {
 
     await translateAndWait(page);
 
-    // 含 img 的容器存在
-    const divImages = page.locator('div img');
-    await expect(divImages.first()).toBeVisible();
+    // 1. 行内 favicon 不阻断翻译（#55：位置性判定 —— 行内装饰不阻断）
+    const faviconP = page.locator('p:has(img[width="16"])');
+    await expect(faviconP).toHaveAttribute('data-pt', 'done');
 
-    // 独立文本段落被翻译
-    await expect(page.locator('[data-pt="done"]').first()).toBeVisible();
+    // 2. 大图容器整体不翻译，内嵌 caption p 独立翻译
+    const imageDiv = page.locator('div:has(> img[width="800"])');
+    await expect(imageDiv.locator('img').first()).toBeVisible();
+    await expect(imageDiv).not.toHaveAttribute('data-pt', 'done');
+    await expect(imageDiv.locator('p')).toHaveAttribute('data-pt', 'done');
+
+    // 3. 含 button 的 section 被降级，内嵌两段 p 各自翻译
+    const buttonSection = page.locator('section:has(button)');
+    await expect(buttonSection).not.toHaveAttribute('data-pt', 'done');
+    const sectionPs = buttonSection.locator('p');
+    await expect(sectionPs).toHaveCount(2);
+    for (let i = 0; i < 2; i++) {
+      await expect(sectionPs.nth(i)).toHaveAttribute('data-pt', 'done');
+    }
+
+    // 4. 媒体/交互控件不被藏进译文单元：done 单元不含 button，
+    //    大图不在任何 done 单元内（行内 favicon 由 #55 允许，见断言 1）
+    const mediaLeak = await page.evaluate(() => {
+      const done = [...document.querySelectorAll('[data-pt="done"]')];
+      return {
+        hasButton: done.some((el) => el.querySelector('button')),
+        bigImgInDone: done.some((el) => el.querySelector('img[width="800"]')),
+      };
+    });
+    expect(mediaLeak).toEqual({ hasButton: false, bigImgInDone: false });
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.31",
+  "version": "0.6.32",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## 概述
issue #92 的 CI 失败已由 #89/#97/#98 修复，本 PR 按规格补全 TC-E2E-29 断言锁定降级行为，关闭 #92。

## 改动
- TC-E2E-29 按 DEEP-TESTING.md §4.3 补全 4 项断言：行内 favicon 不阻断（#55）、大图容器降级 + 内嵌 p 独立翻译、button section 降级、done 单元不藏媒体/控件
- 版本 0.6.31 → 0.6.32

## 验证
- CI 全绿（unit-and-build / e2e-core / hotkeys-macos），TC-E2E-27/29 ✓
- 本地 `test:all` 全绿（单测 255/255、e2e-core 22/22）

Closes #92

Co-Authored-By: zhexuancai-uts <261878103+zhexuancai-uts@users.noreply.github.com>