### PR TITLE
fix(compat): GitHub 处理器 closest() 选择器尾随逗号 → 整页采集 0 单元（#93）

### DIFF
--- a/docs/testing/unit/dom/compat-github.test.ts
+++ b/docs/testing/unit/dom/compat-github.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment jsdom
+ * @vitest-environment-options {"url": "https://github.com/anthropics/claude-code"}
+ */
+/**
+ * dom/compat.ts — github.com 域名补丁测试（#93 回归）
+ *
+ * 与 compat.test.ts 分离的原因：jsdom 的 location.hostname 默认是
+ * localhost，域名补丁不激活。本文件用文件顶部的
+ * @vitest-environment-options 把 jsdom 的 url 设为 github.com 页面，
+ * 使 applyCompat 走 github.com 处理器 —— 这是文件级选项，
+ * 不能与依赖 localhost 的用例同文件。
+ *
+ * #93：github.com 处理器第二段 el.closest() 的选择器拼接每行都带
+ * 尾随逗号（'.repository-lang-stats,'），是无效 CSS 选择器，closest()
+ * 抛 SyntaxError。walker 的 try-catch 逐元素静默吞掉后，GitHub 页面
+ * 整页采集 0 个翻译单元 —— 翻译静默失败（[data-pt="done"] 永不出现）。
+ */
+import { describe, test, expect } from 'vitest';
+import { applyCompat } from '~/src/dom/compat';
+
+function el(html: string): Element {
+  const div = document.createElement('div');
+  div.innerHTML = html.trim();
+  return div.firstElementChild!;
+}
+
+describe('applyCompat（github.com，#93 回归）', () => {
+  test('普通正文元素不抛异常并返回 null（交回通用逻辑）', () => {
+    // README 正文段落 —— 修复前此处抛 SyntaxError（无效选择器）
+    const p = el('<p>Claude Code is an agentic coding tool.</p>');
+    expect(() => applyCompat(p)).not.toThrow();
+    expect(applyCompat(p)).toBeNull();
+  });
+
+  test('.BorderGrid 内元素 → skip（贡献者面板）', () => {
+    const inner = el('<div class="BorderGrid"><p>Contributors</p></div>')
+      .querySelector('p')!;
+    expect(applyCompat(inner)).toEqual({ skip: true });
+  });
+
+  test('.repository-lang-stats 内元素 → skip（语言统计条）', () => {
+    const inner = el('<div class="repository-lang-stats"><span>Python 79.7%</span></div>')
+      .querySelector('span')!;
+    expect(applyCompat(inner)).toEqual({ skip: true });
+  });
+
+  test('.file-tree 内元素 → skip（blob 页文件树）', () => {
+    const inner = el('<div class="file-tree"><span>src</span></div>')
+      .querySelector('span')!;
+    expect(applyCompat(inner)).toEqual({ skip: true });
+  });
+
+  test('.blob-code 内元素 → skip（代码行）', () => {
+    // td 必须放在 table 上下文里 —— jsdom 会按 HTML 规范丢弃 div 中的 td
+    const table = document.createElement('table');
+    table.innerHTML = '<tr><td class="blob-code"><span>const x = 1;</span></td></tr>';
+    const inner = table.querySelector('span')!;
+    expect(applyCompat(inner)).toEqual({ skip: true });
+  });
+
+  test('含行内 code 的正文元素仍返回 null', () => {
+    const p = el('<p>Run <code>pnpm build</code> first.</p>');
+    expect(() => applyCompat(p)).not.toThrow();
+    expect(applyCompat(p)).toBeNull();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.32",
+  "version": "0.6.33",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/compat.ts
+++ b/src/dom/compat.ts
@@ -175,13 +175,20 @@ const HANDLERS: Record<string, CompatHandler> = {
     // #49：文件树侧栏（blob 页）、贡献者面板（仓库首页）均为纯 UI 而非正文。
     // 即使 #50 已在采集阶段过滤含非文本内容的容器，提前跳过整棵子树
     // 可避免无效的 translate-unit 判定。
+    //
+    // #93：此处原来用逐行字符串拼接，最后一项带尾随逗号拼出
+    // '.repository-lang-stats,' 无效选择器，closest() 抛 SyntaxError，
+    // 被 walker 静默吞掉后整页采集 0 个单元。改用数组 join 从结构上
+    // 杜绝尾随逗号。
     if (
       el.closest(
-        '.file-tree,' +            // blob 页文件树（新版）
-        '.js-file-tree,' +         // blob 页文件树（旧版 JS 挂钩）
-        '.tree-browser,' +         // blob 页文件树（旧版）
-        '.BorderGrid,' +           // 仓库首页贡献者网格
-        '.repository-lang-stats,'  // 仓库首页语言统计条
+        [
+          '.file-tree',            // blob 页文件树（新版）
+          '.js-file-tree',         // blob 页文件树（旧版 JS 挂钩）
+          '.tree-browser',         // blob 页文件树（旧版）
+          '.BorderGrid',           // 仓库首页贡献者网格
+          '.repository-lang-stats', // 仓库首页语言统计条
+        ].join(','),
       )
     ) {
       return { skip: true };


### PR DESCRIPTION
Closes #93

## Extended description

real-sites 测试中 GitHub 两个用例（README / Issue 页面）3/3 retries 全部超时，`[data-pt="done"]` 从未出现。逐层插桩定位：

- 悬浮球点击正常到达 `togglePage`，但 `collect()` 返回 **0 个翻译单元** → 走 `no-elements` 路径，球保持 idle
- walker 计数器显示 1348 个访问元素中 **1299 个在判定时抛异常**被 try-catch 静默吞掉
- 异常为 `SyntaxError: '.file-tree,.js-file-tree,.tree-browser,.BorderGrid,.repository-lang-stats,' is not a valid selector` —— `compat.ts` github.com 处理器第二段 `el.closest()` 的选择器逐行拼接时每行都带尾随逗号，最后一项拼出 `'.repository-lang-stats,'` 无效选择器
- Wikipedia/Reddit 不触发该域名处理器，所以只有 GitHub 失败

修复：改用数组 `join(',')` 拼接，从结构上杜绝尾随逗号复发。

测试（TDD，单元 + E2E 双 seam）：

- 新增 `compat-github.test.ts`：用 `@vitest-environment-options` 把 jsdom url 设为 github.com 激活域名补丁（该选项是文件级，故与依赖 localhost 的 `compat.test.ts` 分文件），覆盖「普通正文不抛异常并返回 null」与各 skip 选择器（`.BorderGrid` / `.repository-lang-stats` / `.file-tree` / `.blob-code`）。修复前 6/6 红，修复后 6/6 绿
- real-sites E2E：4/4 通过，GitHub 两用例由 30s 超时变为 4-5s 通过

版本 bump：0.6.32 → 0.6.33。

验证：单元 261 ✓ · typecheck ✓ · real-sites E2E 4/4 ✓