### PR TITLE
fix(ci): e2e-core / hotkeys-macos 在 main push 时也运行（#96）

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,11 @@ jobs:
           path: docs/testing/logs/
           retention-days: 7
 
-  # Level 2 — PR 合并前跑（< 5min）
+  # Level 2 — PR 合并前 + main push（< 5min）
+  # #96：原来只在 pull_request 触发，push 到 main 被跳过 ——
+  # main 分支 CI 一直显示绿色但从未真正执行过 e2e-core。
   e2e-core:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     concurrency:
       group: e2e-${{ github.ref }}
@@ -71,9 +73,9 @@ jobs:
           path: docs/testing/logs/
           retention-days: 7
 
-  # macOS — 快捷键
+  # macOS — 快捷键（与 e2e-core 同触发矩阵，#96）
   hotkeys-macos:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/testing/artifacts/workflow-config.test.ts
+++ b/docs/testing/artifacts/workflow-config.test.ts
@@ -1,0 +1,68 @@
+/**
+ * CI 工作流配置断言（#96 回归）
+ *
+ * test.yml 的触发条件就是 CI 的「公共接口」。#96 的教训：e2e-core
+ * 只在 pull_request 触发，push 到 main 时被跳过 —— main 分支 CI 一直
+ * 显示绿色，但从未真正执行过 e2e-core，翻译链路在 main 上静默断裂
+ * 数日才被发现。
+ *
+ * 这些断言锁定触发矩阵：
+ * - e2e-core / hotkeys-macos：push 与 pull_request 两条路径都必须跑
+ *   （main 上的推送不再「带病绿色」）
+ * - e2e-full / smoke-real-sites：保持 schedule / workflow_dispatch 专属，
+ *   不与推送路径混用（避免定时冒烟与常规推送重复执行）
+ */
+import { describe, test, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const WORKFLOW_PATH = path.resolve('.github/workflows/test.yml');
+
+function readWorkflow(): string {
+  return fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+}
+
+/** 按 2 空格缩进切出顶层 job 定义块（下一行 2 空格缩进的键即块结束） */
+function jobBlock(yml: string, jobName: string): string | null {
+  const lines = yml.split('\n');
+  const start = lines.findIndex((l) => l === `  ${jobName}:`);
+  if (start === -1) return null;
+  const end = lines.findIndex((l, i) => i > start && /^  \S/.test(l));
+  return lines.slice(start, end === -1 ? undefined : end).join('\n');
+}
+
+/** 提取 job 内的 if: 表达式（4 空格缩进） */
+function jobIf(block: string): string | null {
+  const m = block.match(/^\s{4}if:\s*(.+)$/m);
+  return m?.[1]?.trim() ?? null;
+}
+
+describe('CI 工作流触发条件（#96 回归）', () => {
+  const yml = readWorkflow();
+
+  test('e2e-core 在 push 与 pull_request 两条路径均触发', () => {
+    const cond = jobIf(jobBlock(yml, 'e2e-core') ?? '');
+    expect(cond, 'e2e-core 的 if 条件').toContain('pull_request');
+    expect(cond, 'e2e-core 的 if 条件').toContain('push');
+  });
+
+  test('hotkeys-macos 在 push 与 pull_request 两条路径均触发', () => {
+    const cond = jobIf(jobBlock(yml, 'hotkeys-macos') ?? '');
+    expect(cond, 'hotkeys-macos 的 if 条件').toContain('pull_request');
+    expect(cond, 'hotkeys-macos 的 if 条件').toContain('push');
+  });
+
+  test('e2e-full 保持仅在 schedule / workflow_dispatch 触发', () => {
+    const cond = jobIf(jobBlock(yml, 'e2e-full') ?? '');
+    expect(cond).toContain('schedule');
+    expect(cond).toContain('workflow_dispatch');
+    expect(cond).not.toContain('push');
+  });
+
+  test('smoke-real-sites 保持仅在 schedule / workflow_dispatch 触发', () => {
+    const cond = jobIf(jobBlock(yml, 'smoke-real-sites') ?? '');
+    expect(cond).toContain('schedule');
+    expect(cond).toContain('workflow_dispatch');
+    expect(cond).not.toContain('push');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Closes #96

## Extended description

#96 有两个层面：

1. **翻译链路在 E2E 环境中不工作**（悬浮球点击后 `[data-pt="done"]` 永不出现）—— 已由 #89（SW 消息通道就绪重试 + SW 内确定性 mock）、#90（mock 自愈）、#91（批次重试）、#92、#93 系列修复。当前 main 树 e2e-core 本地 22/22 通过、CI 全绿。
2. **工作流触发缺口**（本 PR 修复）：test.yml 中 e2e-core / hotkeys-macos 仅 `if: github.event_name == 'pull_request'`，push 到 main 时被跳过 —— main 分支 CI 一直显示绿色但从未真正执行过 e2e-core，翻译链路在 main 上静默断裂数日才被发现（#96 证据点 4）。

修复：

- `test.yml`：e2e-core、hotkeys-macos 的 if 条件改为 `pull_request || push`（push 事件只对 main 生效 —— workflow 级 `branches: [main]` 过滤，特性分支推送不触发）。Level 3（e2e-full / smoke-real-sites）保持 schedule/workflow_dispatch 专属，推送路径不重复执行定时冒烟
- 新增 `workflow-config.test.ts`（TDD，修复前红 / 修复后绿）：把触发矩阵锁进配置断言 —— e2e-core 与 hotkeys-macos 必须对 push + pull_request 双路径触发；Level 3 任务必须保持 schedule/workflow_dispatch 边界

版本 bump：0.6.33 → 0.6.34。

验证：单元 265 ✓（含新 4 例）· typecheck ✓ · e2e-core 本地 22/22 ✓