### PR TITLE
fix(dom): GitHub RST README（.plain > pre）含 autolink → splitPre 拒切，整页采集 0 单元

### DIFF
--- a/docs/testing/e2e/real-sites.spec.ts
+++ b/docs/testing/e2e/real-sites.spec.ts
@@ -46,6 +46,31 @@ test.describe('GitHub @real', () => {
     await expect(ball).toHaveAttribute('data-state', 'done');
   });
 
+  test('RST README 页面（.plain > pre）：纯文本 README 可翻译', async ({
+    page, mockGoogle, seedSettings,
+  }) => {
+    await seedSettings({ enginePriority: ['google-web'] });
+    await mockGoogle();
+
+    // torvalds/linux 的 README 是 RST 格式，GitHub 以 .plain > pre
+    // （纯文本 + autolink <a>）渲染。修复前 splitPre 因 pre 含子元素
+    // 拒切，整篇超长被跳过 —— 采集 0 单元、翻译静默失败。
+    await page.goto('https://github.com/torvalds/linux', {
+      waitUntil: 'domcontentloaded',
+    });
+
+    const ball = await waitForBall(page);
+    await ball.click();
+    await expect(page.locator('[data-pt="done"]').first()).toBeVisible({ timeout: 30_000 });
+
+    // bug 核心断言：README 内出现翻译完成的 chunk
+    const readmeDone = page.locator('div.plain > pre .pt-chunk[data-pt="done"]');
+    await expect(readmeDone.first()).toBeVisible({ timeout: 15_000 });
+
+    // 译文带 mock 前缀，原文保留在 .pt-origin 里
+    await expect(readmeDone.first().locator('.pt-trans')).toContainText('【译】');
+  });
+
   test('Issue 页面：@username 原样保留', async ({
     page, mockGoogle, seedSettings,
   }) => {

--- a/docs/testing/unit/dom/pre-split.test.ts
+++ b/docs/testing/unit/dom/pre-split.test.ts
@@ -42,6 +42,69 @@ describe('splitPre', () => {
     expect(result).toBeNull();
   });
 
+  test('含 code 子元素的超长 pre → 返回 null（代码块结构拒切）', () => {
+    const pre = document.createElement('pre');
+    const code = document.createElement('code');
+    code.textContent = 'function f() { return 1; }\n'.repeat(100);
+    pre.appendChild(code);
+
+    const result = splitPre(pre);
+    expect(result).toBeNull();
+    expect(pre.hasAttribute('data-pt-split')).toBe(false);
+  });
+
+  test('含内联 <a> 的超长 pre → 切分，链接保留在 chunk 内', () => {
+    // GitHub 对 RST README 的 .plain > pre 渲染：纯文本 + autolink <a>。
+    // 两个大段各 ~2300 字符（单段不超 MAX_TEXT，全文超 3072 触发切分）。
+    const para = 'The Linux kernel is the core of any Linux operating system. '.repeat(40);
+    const text = [
+      'Linux kernel',
+      '============',
+      '',
+      `${para}`,
+      '',
+      `${para}`,
+      '',
+      'Quick Start',
+      '-----------',
+      '',
+      '* Get the latest kernel: https://kernel.org',
+      '* Join the community: https://lore.kernel.org/',
+    ].join('\n');
+
+    const pre = document.createElement('pre');
+    pre.innerHTML = text
+      .replace(
+        'https://kernel.org',
+        '<a href="https://kernel.org" rel="nofollow">https://kernel.org</a>',
+      )
+      .replace(
+        'https://lore.kernel.org/',
+        '<a href="https://lore.kernel.org/" rel="nofollow">https://lore.kernel.org/</a>',
+      );
+
+    const originalText = pre.textContent ?? '';
+
+    const result = splitPre(pre);
+
+    expect(result).not.toBeNull();
+    if (result) {
+      expect(result.length).toBeGreaterThanOrEqual(3);
+      // 链接必须保留在切出的 chunk 里
+      const anchors = pre.querySelectorAll('a');
+      expect(anchors.length).toBe(2);
+      expect([...anchors].map((a) => a.getAttribute('href'))).toEqual([
+        'https://kernel.org',
+        'https://lore.kernel.org/',
+      ]);
+      for (const a of anchors) {
+        expect(a.closest('span.pt-chunk')).not.toBeNull();
+      }
+      // 切分后文本逐字节不变
+      expect(pre.textContent).toBe(originalText);
+    }
+  });
+
   test('已切分的 pre → 返回 null（幂等）', () => {
     const longText = 'a'.repeat(3100);
     const pre = createPre(longText);

--- a/docs/testing/unit/dom/walker-github-readme.test.ts
+++ b/docs/testing/unit/dom/walker-github-readme.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @vitest-environment jsdom
+ * @vitest-environment-options {"url": "https://github.com/torvalds/linux"}
+ */
+/**
+ * dom/walker.ts — GitHub RST README 采集回归
+ *
+ * torvalds/linux 等仓库的 README 是 RST 格式，GitHub 用
+ * .plain > pre（纯文本 + autolink <a>）渲染。修复前 splitPre 因
+ * pre 含子元素而拒切，整篇远超 MAX_TEXT / MAX_HTML，
+ * 采集 0 个翻译单元 —— 翻译静默失败（[data-pt="done"] 永不出现）。
+ *
+ * 与 compat-github.test.ts 同原因分离：jsdom 的 location.hostname
+ * 需设为 github.com 页面，@vitest-environment-options 是文件级选项。
+ */
+import { describe, test, expect } from 'vitest';
+import { collect } from '~/src/dom/walker';
+
+/**
+ * 真实 README 片段的浓缩形态（2026-08 抓取自 github.com/torvalds/linux）：
+ * 标题 + 装饰行 + 空行分隔的短段落 + RST 列表（URL 被 GitHub autolink 成 <a>）。
+ * 单段均短于 MAX_TEXT（3072），全文超过 3072 才能触发 splitPre 切分路径。
+ */
+function buildReadmeFragment(): string {
+  const para = (i: number) =>
+    `Paragraph ${i}: The Linux kernel manages hardware, system resources, ` +
+    `and provides the fundamental services for all other software running ` +
+    `on the system, including device drivers and filesystem implementations.`;
+
+  const lines = [
+    '<div class="plain"><pre style="white-space: pre-wrap">',
+    'Linux kernel',
+    '============',
+    '',
+  ];
+  for (let i = 0; i < 15; i++) {
+    lines.push(para(i), '');
+  }
+  lines.push(
+    'Quick Start',
+    '-----------',
+    '',
+    '* Report a bug: See Documentation/admin-guide/reporting-issues.rst',
+    '* Get the latest kernel: <a href="https://kernel.org" rel="nofollow">https://kernel.org</a>',
+    '* Build the kernel: See Documentation/admin-guide/quickly-build-trimmed-linux.rst',
+    '* Join the community: <a href="https://lore.kernel.org/" rel="nofollow">https://lore.kernel.org/</a>',
+    '',
+    '</pre></div>',
+  );
+  return lines.join('\n');
+}
+
+describe('collect（github.com RST README 回归）', () => {
+  test('README 正文被采集为翻译单元（修复前为 0 单元）', () => {
+    document.body.innerHTML = buildReadmeFragment();
+
+    // jsdom 里 getBoundingClientRect 默认全 0 → 全部判不可见。
+    // stub 为可见，模拟真实浏览器。
+    const proto = HTMLElement.prototype as any;
+    const orig = proto.getBoundingClientRect;
+    proto.getBoundingClientRect = function () {
+      return {
+        x: 0, y: 0, width: 100, height: 20,
+        top: 0, right: 100, bottom: 20, left: 0,
+      };
+    };
+
+    let units: Element[] = [];
+    try {
+      units = collect();
+    } finally {
+      proto.getBoundingClientRect = orig;
+    }
+
+    expect(units.length).toBeGreaterThan(0);
+
+    // 首段正文在采集结果里（段落级锚点，而非只断言数量 > 0）
+    const firstParaUnit = units.find((u) =>
+      (u.textContent ?? '').includes('Paragraph 0:'),
+    );
+    expect(firstParaUnit).toBeDefined();
+    expect(firstParaUnit!.tagName).toBe('SPAN');
+    expect(firstParaUnit!.className).toBe('pt-chunk');
+  });
+
+  test('collect 后 autolink <a> 保留在切出的 chunk 内', () => {
+    document.body.innerHTML = buildReadmeFragment();
+
+    const proto = HTMLElement.prototype as any;
+    const orig = proto.getBoundingClientRect;
+    proto.getBoundingClientRect = function () {
+      return {
+        x: 0, y: 0, width: 100, height: 20,
+        top: 0, right: 100, bottom: 20, left: 0,
+      };
+    };
+
+    try {
+      collect();
+    } finally {
+      proto.getBoundingClientRect = orig;
+    }
+
+    const anchors = document.querySelectorAll('div.plain > pre a');
+    expect(anchors.length).toBe(2);
+    expect([...anchors].map((a) => a.getAttribute('href'))).toEqual([
+      'https://kernel.org',
+      'https://lore.kernel.org/',
+    ]);
+    // 链接随所在行进入 .pt-chunk，未被丢弃
+    for (const a of anchors) {
+      expect(a.closest('span.pt-chunk')).not.toBeNull();
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.34",
+  "version": "0.6.35",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/pre-split.ts
+++ b/src/dom/pre-split.ts
@@ -3,8 +3,37 @@
 // #65：大型纯文本文档（如 GitHub README 的 .plain > pre）一次性文本过长，
 // 无法通过 MAX_TEXT 阈值。本模块按连续空行将其切分为多个 <span> 翻译单元，
 // 保留原始渲染逐字节不变，让现有 collect → translate → render 管道零改动复用。
+//
+// GitHub 对 RST README 的 .plain > pre 渲染会插入 autolink <a>。
+// 早退条件「pre.children.length > 0」把这类 pre 整棵拒切 —— 全文远超
+// MAX_TEXT / MAX_HTML，采集 0 单元（翻译静默失败）。改为仅当存在
+// 块级子元素才拒切，内联子元素随文本流切分保留。
 
-import { MAX_TEXT, isCodeBlockPre } from './classify';
+import { INLINE_SET, MAX_TEXT, isCodeBlockPre } from './classify';
+
+/** 节点流 token：行内文本片段 / 行内元素 / 换行 */
+type Tok =
+  | { kind: 'text'; text: string }
+  | { kind: 'node'; node: Node }
+  | { kind: 'nl' };
+
+/** 行内 token（nl 在行聚合时被消费，不进 Line） */
+type LineTok = Exclude<Tok, { kind: 'nl' }>;
+
+interface Line {
+  toks: LineTok[];
+  endsWithNl: boolean;
+}
+
+/** 行的纯文本（含内联节点文本），用于空行 / 装饰行判定 */
+function lineText(line: Line): string {
+  let s = '';
+  for (const t of line.toks) {
+    if (t.kind === 'text') s += t.text;
+    else if (t.kind === 'node') s += t.node.textContent ?? '';
+  }
+  return s;
+}
 
 /**
  * 装饰行：=====、-----、***** 等纯符号行 —— plain-text 文档的分节装饰。
@@ -40,46 +69,79 @@ export function splitPre(pre: HTMLPreElement): HTMLSpanElement[] | null {
   // 代码块上下文不切（#64 通用规则）
   if (isCodeBlockPre(pre)) return null;
 
-  // 含子元素的 pre 可能有内联标记，保持现有行为
-  if (pre.children.length > 0) return null;
+  // 含块级或代码语义子元素的 pre 结构复杂，保持现有行为不切；
+  // 仅纯行内文本子元素（GitHub .plain > pre 的 autolink <a>）可随文本流切分保留。
+  // <pre><code> 是经典代码块结构，code 虽在 INLINE_SET（供段落判定用），
+  // 但此处必须视为代码语义而拒切，避免纯代码 pre 被翻译。
+  const CODE_SEMANTIC = new Set(['code', 'kbd', 'samp', 'var']);
+  for (const child of pre.children) {
+    const tag = child.tagName.toLowerCase();
+    if (!INLINE_SET.has(tag) || CODE_SEMANTIC.has(tag)) return null;
+  }
 
   const text = pre.textContent ?? '';
   if (text.trim().length <= MAX_TEXT) return null;
 
-  // ── 按连续空行 / 装饰行切分 ──
-  const lines = text.split('\n');
-  const parts: { kind: 'raw' | 'chunk'; text: string }[] = [];
-  let cur: string[] = [];
-  let curKind: 'raw' | 'chunk' | null = null;
-
-  for (const line of lines) {
-    const kind =
-      line.trim() === '' || isDecorationLine(line) ? 'raw' : 'chunk';
-    if (kind !== curKind) {
-      if (cur.length > 0) parts.push({ kind: curKind!, text: cur.join('\n') });
-      cur = [];
-      curKind = kind;
+  // ── 节点流 token 化：文本节点按 '\n' 拆行片段，内联元素整体作为行内 token ──
+  const toks: Tok[] = [];
+  for (const child of [...pre.childNodes]) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      const parts = (child.textContent ?? '').split('\n');
+      parts.forEach((p, i) => {
+        if (p.length > 0) toks.push({ kind: 'text', text: p });
+        if (i < parts.length - 1) toks.push({ kind: 'nl' });
+      });
+    } else {
+      toks.push({ kind: 'node', node: child });
     }
-    cur.push(line);
-  }
-  if (cur.length > 0 && curKind) {
-    parts.push({ kind: curKind, text: cur.join('\n') });
   }
 
-  // ── 重建 pre 内容 ──
+  // ── 行聚合：行结束于换行 token（含） ──
+  const lines: Line[] = [];
+  let cur: LineTok[] = [];
+  for (const t of toks) {
+    if (t.kind === 'nl') {
+      lines.push({ toks: cur, endsWithNl: true });
+      cur = [];
+    } else {
+      cur.push(t);
+    }
+  }
+  if (cur.length > 0) lines.push({ toks: cur, endsWithNl: false });
+
+  // ── 按行 kind 聚合为块：空行 / 装饰行 → raw，其余 → chunk ──
+  const parts: { kind: 'raw' | 'chunk'; lines: Line[] }[] = [];
+  for (const line of lines) {
+    const lt = lineText(line).trim();
+    const kind = lt === '' || isDecorationLine(lt) ? 'raw' : 'chunk';
+    const last = parts[parts.length - 1];
+    if (last && last.kind === kind) last.lines.push(line);
+    else parts.push({ kind, lines: [line] });
+  }
+
+  // ── 重建 pre 内容：按 token 顺序 append，逐字节还原 ──
+  // textContent = '' 只清空 DOM 树，node token 持有的引用仍可重新挂回。
   pre.textContent = '';
   const spans: HTMLSpanElement[] = [];
+  const appendLine = (holder: Node, line: Line) => {
+    for (const t of line.toks) {
+      if (t.kind === 'text') holder.appendChild(document.createTextNode(t.text));
+      else holder.appendChild(t.node); // 原内联节点移入，属性 / 事件保留
+    }
+    if (line.endsWithNl) holder.appendChild(document.createTextNode('\n'));
+  };
 
-  for (const p of parts) {
-    if (p.kind === 'chunk' && !isOversized(p.text)) {
+  for (const part of parts) {
+    const partText = part.lines.map(lineText).join('\n');
+    if (part.kind === 'chunk' && !isOversized(partText)) {
       const span = document.createElement('span');
       span.className = 'pt-chunk';
       span.setAttribute('data-pt-chunk', '1');
-      span.textContent = p.text;
+      for (const line of part.lines) appendLine(span, line);
       pre.appendChild(span);
       spans.push(span);
     } else {
-      pre.appendChild(document.createTextNode(p.text));
+      for (const line of part.lines) appendLine(pre, line);
     }
   }
 


### PR DESCRIPTION
## 问题

https://github.com/torvalds/linux 的 README 页面无法翻译：整页不出现任何译文，且无报错 —— 静默失败。

## 根因

torvalds/linux 的 README 是 RST 格式，GitHub 用 `.plain > pre` 纯文本渲染，并把 URL autolink 成内联 `<a>`（真实页面 5 个）。

`splitPre()` 的早退条件 `pre.children.length > 0`（#65 引入，当时 README 渲染为纯文本无子元素）把这类 pre 整棵拒切。整篇 6043 字符作为单个候选单元，远超 `MAX_TEXT`（3072）/ `MAX_HTML`（4096）被 `shouldSkip` 静默跳过 —— 采集 0 个翻译单元，`[data-pt="done"]` 永不出现。

与 #93 相同症状（整页静默失败）但根因不同：#93 是 compat 选择器尾随逗号抛异常，本次是 pre 切分早退。

## 修复

`src/dom/pre-split.ts`：

- **拒切条件放宽**：仅当存在块级子元素或代码语义子元素（code/kbd/samp/var）才拒切 —— 防止 `<pre><code>` 代码块被误翻
- **切分算法升级为节点流**：文本节点按 `\n` 拆行片段，内联元素作为行内 token 随所在行进入 `.pt-chunk`；切分后 pre 文本逐字节不变，链接 href 保留

## 验证

- 反馈循环（jsdom，真实页面片段）：修复前 0 单元 → 修复后 42 单元；去掉 `<a>` 对照同样 42 单元，锁定「含子元素早退」为唯一阻断因素
- 新增回归：
  - `pre-split.test.ts`：含 `<a>` 超长 pre 切分且链接保留；含 `<code>` 超长 pre 拒切
  - `walker-github-readme.test.ts`：真实 README 形态（github.com jsdom 环境）采集产出单元
  - `real-sites.spec.ts`：torvalds/linux 真实站点点击球后 README 出现译文（@real）
- 全量单测 269 通过，typecheck 通过，e2e core 22 通过