### PR TITLE
fix(styles): pre 内译文块级换行产生空行 + 装饰行错位 —— README 译文排版修复

### DIFF
--- a/docs/testing/e2e/core.spec.ts
+++ b/docs/testing/e2e/core.spec.ts
@@ -466,6 +466,81 @@ test.describe('Fixture: pre-blocks', () => {
     expect(await chunks.count()).toBeGreaterThanOrEqual(2);
     await expect(chunks.first()).toHaveAttribute('data-pt', 'done');
   });
+
+  test('@core TC-E2E-49: pre 内译文行内贴合原文，与装饰行视觉分行', async ({
+    page, mockGoogle, seedSettings, gotoFixture,
+  }) => {
+    await seedSettings({});
+    await mockGoogle();
+    await gotoFixture('pre-blocks');
+
+    await translateAndWait(page);
+
+    // 翻译并发乱序，不能取「第一个 trans」——定位标题 chunk（原文含
+    // README Title）的译文，它与装饰行的位置关系才是本用例的断言对象。
+    const titleChunk = page
+      .locator('pre.plain > .pt-chunk')
+      .filter({ hasText: 'README Title' });
+    const titleTrans = titleChunk.locator('.pt-trans.pt-pre');
+    await expect(titleTrans).toBeVisible();
+
+    // ── 机制：译文必须行内显示（display:inline），否则块级换行 +
+    // 原文行尾 \n 会在原文与译文之间制造空行、把装饰行挤离标题。
+    // ::after 补行尾硬换行，隔开后续装饰行。
+    const styles = await titleTrans.evaluate((el) => {
+      const cs = getComputedStyle(el);
+      const after = getComputedStyle(el, '::after');
+      return {
+        display: cs.display,
+        whiteSpace: cs.whiteSpace,
+        afterContent: after.content,
+        afterWhiteSpace: after.whiteSpace,
+      };
+    });
+    expect(styles.display).toBe('inline');
+    expect(styles.whiteSpace).toBe('normal');
+    expect(styles.afterContent).toContain('\\a ');
+    expect(styles.afterWhiteSpace).toBe('pre');
+
+    // ── 行为：标题译文行与装饰行「============」必须视觉分行
+    // （::after 失效时会粘成同一行「【译】README Title============」）。
+    // 装饰行是 chunk 之外的 raw 文本节点，用 Range 定位取 y 坐标。
+    const rects = await page.evaluate(() => {
+      const pre = document.querySelector('pre.plain')!;
+      // 标题 chunk 的译文（与 Playwright 侧 titleTrans 同一元素）
+      const titleChunk = [...pre.querySelectorAll('.pt-chunk')].find((c) =>
+        (c.textContent ?? '').includes('README Title'),
+      );
+      const trans = titleChunk?.querySelector('.pt-trans.pt-pre') ?? null;
+      const walker = document.createTreeWalker(pre, NodeFilter.SHOW_TEXT);
+      // currentNode 初始是 root（pre 自身，textContent 含装饰行会误命中），
+      // 必须先 nextNode() 进入遍历
+      let node: Node | null = walker.nextNode();
+      let decoTop: number | null = null;
+      while (node) {
+        if ((node.textContent ?? '').includes('============')) {
+          // Range.selectNodeContents() 返回 undefined，不能链式调用
+          const range = document.createRange();
+          range.selectNodeContents(node);
+          decoTop = range.getBoundingClientRect().top;
+          break;
+        }
+        node = walker.nextNode();
+      }
+      const transRect = trans?.getBoundingClientRect();
+      return {
+        transFound: trans !== null,
+        decoTop,
+        transTop: transRect?.top ?? null,
+        transBottom: transRect?.bottom ?? null,
+      };
+    });
+    expect(rects.transFound).toBe(true);
+    expect(rects.decoTop).not.toBeNull();
+    expect(rects.transTop).not.toBeNull();
+    // 装饰行在译文行下方（y 更大），且不与译文行重叠
+    expect(rects.decoTop!).toBeGreaterThanOrEqual(rects.transBottom!);
+  });
 });
 
 test.describe('Fixture: rtl', () => {

--- a/docs/testing/e2e/fixtures/pre-blocks.html
+++ b/docs/testing/e2e/fixtures/pre-blocks.html
@@ -8,8 +8,13 @@
 
   <!-- 超大纯文本 pre: 应被切分翻译。
        必须直接持有文本（无子元素）且超过 MAX_TEXT —— 修复前此处文本
-       裹在 <code> 里且不足 3072 字符，splitPre 永远不触发 -->
-  <pre class="plain">This is a very long plain text document that simulates a README file or similar text content found in a pre element. It needs to be long enough to trigger the pre-split mechanism. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+       裹在 <code> 里且不足 3072 字符，splitPre 永远不触发。
+       开头的「标题 + 装饰行」形态用于 TC-E2E-49 的排版回归：
+       装饰行是 raw，标题是 chunk，译文必须与装饰行视觉分行。 -->
+  <pre class="plain">README Title
+============
+
+This is a very long plain text document that simulates a README file or similar text content found in a pre element. It needs to be long enough to trigger the pre-split mechanism. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
 
 Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.35",
+  "version": "0.6.36",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/styles/presets.css
+++ b/src/styles/presets.css
@@ -59,4 +59,11 @@
   font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
   border-left: none;
   padding-left: 0;
+  /* inline：译文紧贴原文块尾换行，不产生块级换行 + 空行框。
+     ::after 补行尾硬换行，隔开后面的装饰行 / 下一块原文 */
+  display: inline;
+}
+.pt-trans.pt-pre::after {
+  content: '\A';
+  white-space: pre;
 }


### PR DESCRIPTION
## 问题

#104 修复后 torvalds/linux README 可以翻译了，但译文排版破碎：每个翻译块变成「原文 → 空行 → 译文 → 空行 → 装饰行」，标题装饰行（`============`）被译文挤离标题，README 高度暴涨近一倍。

## 根因

`render()` 对 pre 内译文加 `pt-pre` 类（脱离等宽字体，#66），但译文保持 `display: block`。块级元素插在行内上下文（`.pt-chunk` span）里，与原文块尾的 `\n` 叠加：原文行尾换行 + 块级换行之间产生空行框；装饰行是切分后的 raw 文本节点（chunk 之外），被译文块挤到下方，标题与装饰行的视觉结构断裂。

## 修复

`src/styles/presets.css`（纯 CSS，零 DOM 改动）：

- `.pt-trans.pt-pre` 改 `display: inline` —— 译文紧跟原文块尾换行，消除块级换行 + 空行框
- `::after { content: '\A'; white-space: pre }` —— 补行尾硬换行，隔开后续装饰行；`::after` 是伪元素，`unrender` 时随 trans 一并移除，不破坏还原对称性

修复后视觉：标题 → 译文 → 装饰行紧贴，段落间保留原始空行，对照阅读节奏恢复。

## 验证

- 真实站点：torvalds/linux 截图确认排版恢复（标题/译文/装饰行紧贴，无多余空行）
- 新回归 **TC-E2E-49**（e2e core，随 PR 跑）：
  - 机制断言：`display: inline`、`white-space: normal`、`::after` 的 `'\A'` + `pre`
  - 行为断言：标题译文与装饰行视觉分行（Range 定位装饰行文本节点比较 y 坐标）——`::after` 失效时装饰行与译文粘成同一行，此断言红
- fixture：pre-blocks.html 增加「标题 + 装饰行」形态
- 全量：typecheck ✓、单测 269 ✓、e2e core 23 ✓