### PR TITLE
fix(dom): pre 内列表译文折叠成一行 —— 输入归一化抹掉硬换行

### DIFF
--- a/docs/testing/e2e/core.spec.ts
+++ b/docs/testing/e2e/core.spec.ts
@@ -498,7 +498,9 @@ test.describe('Fixture: pre-blocks', () => {
       };
     });
     expect(styles.display).toBe('inline');
-    expect(styles.whiteSpace).toBe('normal');
+    // pre-line：保留引擎译文中的硬换行 —— normal 会把列表译文的
+    // 换行折叠成一行长文本
+    expect(styles.whiteSpace).toBe('pre-line');
     expect(styles.afterContent).toContain('\\a ');
     expect(styles.afterWhiteSpace).toBe('pre');
 
@@ -540,6 +542,33 @@ test.describe('Fixture: pre-blocks', () => {
     expect(rects.transTop).not.toBeNull();
     // 装饰行在译文行下方（y 更大），且不与译文行重叠
     expect(rects.decoTop!).toBeGreaterThanOrEqual(rects.transBottom!);
+
+    // ── 列表 chunk：译文必须逐行显示（normalizePreText 保留硬换行 +
+    // pre-line 渲染）。修复前输入归一化折叠 \n、white-space:normal
+    // 再折叠一次 —— 5 行列表译文显示为 1 行长文本。
+    const listChunk = page
+      .locator('pre.plain > .pt-chunk')
+      .filter({ hasText: 'New Kernel Developer' });
+    await expect(listChunk).toHaveAttribute('data-pt', 'done', { timeout: 15_000 });
+
+    const listLines = await listChunk.evaluate((el) => {
+      const trans = el.querySelector('.pt-trans.pt-pre')!;
+      const text = trans.textContent ?? '';
+      const range = document.createRange();
+      const first = trans.firstChild as Text;
+      const rows = new Set<number>();
+      for (let i = 0; i < first.length; i++) {
+        range.setStart(first, i);
+        range.setEnd(first, i + 1);
+        const r = range.getBoundingClientRect();
+        if (r.height > 0) rows.add(Math.round(r.top));
+      }
+      return { visualLines: rows.size, text };
+    });
+    // mock 译文 = 【译】+ 原文（5 行列表），逐行渲染 ≥ 4 行；
+    // 折叠成一行的回归下此处为 1
+    expect(listLines.visualLines).toBeGreaterThanOrEqual(4);
+    expect(listLines.text).toContain('\n');
   });
 });
 

--- a/docs/testing/e2e/fixtures/pre-blocks.html
+++ b/docs/testing/e2e/fixtures/pre-blocks.html
@@ -14,6 +14,12 @@
   <pre class="plain">README Title
 ============
 
+* New Kernel Developer - Getting started with kernel development
+* Academic Researcher - Studying kernel internals and architecture
+* Security Expert - Hardening and vulnerability analysis
+* Backport/Maintenance Engineer - Maintaining stable kernels
+* System Administrator - Configuring and troubleshooting
+
 This is a very long plain text document that simulates a README file or similar text content found in a pre element. It needs to be long enough to trigger the pre-split mechanism. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
 
 Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.

--- a/docs/testing/unit/dom/normalize.test.ts
+++ b/docs/testing/unit/dom/normalize.test.ts
@@ -2,7 +2,7 @@
  * dom/normalize.ts — 空白归一化 单元测试
  */
 import { describe, test, expect } from 'vitest';
-import { normalizeText } from '~/src/dom/normalize';
+import { normalizeText, normalizePreText } from '~/src/dom/normalize';
 
 describe('normalizeText', () => {
   test('\\s+ → 单个空格', () => {
@@ -47,5 +47,38 @@ describe('normalizeText', () => {
 
   test('\\r\\n Windows 换行 → 空格', () => {
     expect(normalizeText('a\r\nb')).toBe('a b');
+  });
+});
+
+describe('normalizePreText', () => {
+  test('保留硬换行，折叠行内空白', () => {
+    expect(normalizePreText('* New Kernel Developer  -  Getting started\n* Academic  Researcher - Studying')).toBe(
+      '* New Kernel Developer - Getting started\n* Academic Researcher - Studying',
+    );
+  });
+
+  test('多行列表逐行保留（RST README 形态）', () => {
+    const list = [
+      '* New Kernel Developer - Getting started with kernel development',
+      '* Academic Researcher - Studying kernel internals and architecture',
+      '* Security Expert - Hardening and vulnerability analysis',
+    ].join('\n');
+    expect(normalizePreText(list)).toBe(list);
+  });
+
+  test('连续空行折叠保留为 \\n 序列', () => {
+    expect(normalizePreText('a\n\n\nb')).toBe('a\n\n\nb');
+  });
+
+  test('行首行尾空白去除', () => {
+    expect(normalizePreText('  * item  \n  * item2  ')).toBe('* item\n* item2');
+  });
+
+  test('纯空白 → ""', () => {
+    expect(normalizePreText('   \n \n  ')).toBe('');
+  });
+
+  test('\\r\\n Windows 换行 → 统一为 \\n', () => {
+    expect(normalizePreText('a\r\nb')).toBe('a\nb');
   });
 });

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -8,7 +8,7 @@ import '~/src/styles/tokens.css';
 import '~/src/styles/presets.css';
 import { collect } from '~/src/dom/walker';
 import { closestUnit } from '~/src/dom/classify';
-import { normalizeText } from '~/src/dom/normalize';
+import { normalizeText, normalizePreText } from '~/src/dom/normalize';
 import {
   translatableText,
   translatableTextEx,
@@ -176,10 +176,14 @@ export default defineContentScript({
         const { text: rawText, preserves } = useShallow
           ? shallowTranslatableTextEx(el)
           : translatableTextEx(el);
+        // pre 内单元（.pt-chunk / 纯文本 pre）保留硬换行：
+        // 列表逐行条目是文档结构，折叠成一行后译文也回不来行结构
+        const normalize = el.closest('pre') ? normalizePreText : normalizeText;
+        const text = normalize(rawText);
         return {
-          text: normalizeText(rawText),
+          text,
           preserves,
-          rawText: normalizeText(rawText),
+          rawText: text,
         };
       });
       const texts = textData.map((d) => d.text);
@@ -428,7 +432,8 @@ export default defineContentScript({
       }
 
       const { text: rawText, preserves } = translatableTextEx(unit);
-      const text = normalizeText(rawText);
+      const normalize = unit.closest('pre') ? normalizePreText : normalizeText;
+      const text = normalize(rawText);
       if (!text) return;
 
       const resp = await translateViaBackground({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.36",
+  "version": "0.6.37",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/normalize.ts
+++ b/src/dom/normalize.ts
@@ -12,3 +12,17 @@
 export function normalizeText(s: string): string {
   return s.replace(/\s+/g, ' ').trim();
 }
+
+/**
+ * pre 上下文（.pt-chunk / 纯文本 pre）的归一化：折叠行内空白但保留
+ * 硬换行。列表逐行条目（RST 的 * item）是文档结构，normalizeText
+ * 会把整个列表折叠成一行 —— 引擎收到无结构文本，译文也回不来行结构。
+ * 逐行折叠后引擎按行切句，恰好是列表翻译期望的行为。
+ */
+export function normalizePreText(s: string): string {
+  return s
+    .split('\n')
+    .map((line) => line.replace(/[ \t]+/g, ' ').trim())
+    .join('\n')
+    .trim();
+}

--- a/src/styles/presets.css
+++ b/src/styles/presets.css
@@ -55,7 +55,10 @@
 
 /* ── pre 内译文脱离等宽约束（#66）────────────────────────── */
 .pt-trans.pt-pre {
-  white-space: normal;
+  /* pre-line：保留引擎译文中的硬换行（多行列表逐行对照原文），
+     其余空白折叠、长行自动换行 —— normal 会把列表译文的换行
+     折叠成一行长文本 */
+  white-space: pre-line;
   font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
   border-left: none;
   padding-left: 0;


### PR DESCRIPTION
## 问题

torvalds/linux README 的多行列表（`* item` 逐行条目）翻译后译文折叠成一行长文本：

> 【译】* 新内核开发人员 - 内核开发入门 * 学术研究员 - 研究内核内部和架构 * 安全专家 ...

9 行列表的译文变成一行流,对照结构完全丢失。

## 根因

**输入层为主因**：`normalizeText` 在发往引擎前把 `\s+` 全部折叠成空格（`content.ts` 整页/单段路径统一归一化）。列表的 `\n` 结构在翻译前就被抹掉 —— 引擎收到无结构文本，译文自然也回不来行结构。

`normalizeText` 折叠软换行对 HTML 段落是合理的（引擎按 `\n` 切句会拆散跨行词组、撑破 OpenAI 编号结构），但 pre 里的硬换行是文档结构。显示层 `white-space: normal` 对译文换行的再折叠只是二次伤害。

## 修复

- `normalize.ts` 新增 **`normalizePreText`**：逐行折叠行内空白（`[ \t]+` → 空格）、保留硬换行、统一 `\r\n` → `\n`
- `content.ts`：整页翻译与单段翻译按 `unit.closest('pre')` 选择归一化函数；划词翻译维持原行为（用户划的就是连续文本）
- `.pt-trans.pt-pre` 的 `white-space: normal → pre-line`：保留引擎译文中的硬换行，多行列表逐行对照原文

## 验证

- 反馈循环（真实站点）:列表 chunk 译文视觉行数 **1 → 9**（逐字符 Range 统计）
- 截图确认：9 行译文逐行对照原文条目
- 回归：
  - `normalizePreText` 单测 6 例（保留换行 / 折叠行内空白 / 统一 CRLF 等）
  - TC-E2E-49 扩展：列表 chunk 译文视觉行数 ≥ 4 且文本含 `\n`（折叠回归下为 1 行）；white-space 断言改 `pre-line`
  - fixture pre-blocks.html 增加 5 行列表形态
- 全量：typecheck ✓、单测 275 ✓、e2e core 23 ✓