### PR TITLE
fix(dom): pre 列表条目行独立成翻译单元 —— 行级对照（一行原文一行译文）

### DIFF
--- a/docs/testing/e2e/core.spec.ts
+++ b/docs/testing/e2e/core.spec.ts
@@ -543,32 +543,34 @@ test.describe('Fixture: pre-blocks', () => {
     // 装饰行在译文行下方（y 更大），且不与译文行重叠
     expect(rects.decoTop!).toBeGreaterThanOrEqual(rects.transBottom!);
 
-    // ── 列表 chunk：译文必须逐行显示（normalizePreText 保留硬换行 +
-    // pre-line 渲染）。修复前输入归一化折叠 \n、white-space:normal
-    // 再折叠一次 —— 5 行列表译文显示为 1 行长文本。
-    const listChunk = page
-      .locator('pre.plain > .pt-chunk')
-      .filter({ hasText: 'New Kernel Developer' });
-    await expect(listChunk).toHaveAttribute('data-pt', 'done', { timeout: 15_000 });
-
-    const listLines = await listChunk.evaluate((el) => {
-      const trans = el.querySelector('.pt-trans.pt-pre')!;
-      const text = trans.textContent ?? '';
-      const range = document.createRange();
-      const first = trans.firstChild as Text;
-      const rows = new Set<number>();
-      for (let i = 0; i < first.length; i++) {
-        range.setStart(first, i);
-        range.setEnd(first, i + 1);
-        const r = range.getBoundingClientRect();
-        if (r.height > 0) rows.add(Math.round(r.top));
-      }
-      return { visualLines: rows.size, text };
+    // ── 列表行级对照：每条目独立成翻译单元，渲染后
+    //    一行原文紧贴一行译文交替（原文 i → 译文 i → 原文 i+1 …）。
+    //    回归背景：列表曾作为一个 chunk 整块翻译（块级对照），
+    //    也曾因输入归一化折叠成一行长文本。
+    const listLayout = await page.evaluate(() => {
+      const pre = document.querySelector('pre.plain')!;
+      const chunks = [...pre.querySelectorAll('.pt-chunk')];
+      // 列表条目 chunk：origin 文本以 '* ' 开头
+      const listChunks = chunks.filter((c) =>
+        (c.querySelector('.pt-origin')?.textContent ?? '').trimStart().startsWith('* '),
+      );
+      return listChunks.map((c) => {
+        const o = c.querySelector('.pt-origin')!.getBoundingClientRect();
+        const t = c.querySelector('.pt-trans')!.getBoundingClientRect();
+        return { oTop: o.top, oBottom: o.bottom, tTop: t.top, tBottom: t.bottom };
+      });
     });
-    // mock 译文 = 【译】+ 原文（5 行列表），逐行渲染 ≥ 4 行；
-    // 折叠成一行的回归下此处为 1
-    expect(listLines.visualLines).toBeGreaterThanOrEqual(4);
-    expect(listLines.text).toContain('\n');
+
+    // fixture 里 5 个列表条目 → 5 个独立单元
+    expect(listLayout.length).toBe(5);
+    listLayout.forEach((r, i) => {
+      // 译文行紧跟自己的原文行（y 相邻，无空行）
+      expect(r.tTop).toBeGreaterThanOrEqual(r.oBottom - 1);
+      if (i > 0) {
+        // 交错：条目 i 的原文在条目 i-1 的译文之后
+        expect(r.oTop).toBeGreaterThanOrEqual(listLayout[i - 1]!.tBottom);
+      }
+    });
   });
 });
 

--- a/docs/testing/unit/dom/pre-split.test.ts
+++ b/docs/testing/unit/dom/pre-split.test.ts
@@ -105,6 +105,38 @@ describe('splitPre', () => {
     }
   });
 
+  test('列表条目行各自独立成翻译单元（行级对照）', () => {
+    // 5 行列表条目 + 超长段落（保证全文超 MAX_TEXT 触发切分）
+    const para = 'Paragraph content. '.repeat(170);
+    const text = [
+      '* New Kernel Developer - Getting started with kernel development',
+      '* Academic Researcher - Studying kernel internals and architecture',
+      '* Security Expert - Hardening and vulnerability analysis',
+      '* Backport/Maintenance Engineer - Maintaining stable kernels',
+      '* System Administrator - Configuring and troubleshooting',
+      '',
+      `${para}`,
+    ].join('\n');
+
+    const pre = createPre(text);
+    const result = splitPre(pre);
+
+    expect(result).not.toBeNull();
+    if (result) {
+      // 每个列表条目是独立 chunk（原文以 '* ' 开头）
+      const listSpans = result.filter((s) =>
+        (s.textContent ?? '').trimStart().startsWith('* '),
+      );
+      expect(listSpans.length).toBe(5);
+      // 条目 chunk 各自只含单行文本
+      for (const span of listSpans) {
+        expect((span.textContent ?? '').trim()).not.toContain('\n');
+      }
+      // 切分后文本逐字节不变
+      expect(pre.textContent).toBe(text);
+    }
+  });
+
   test('已切分的 pre → 返回 null（幂等）', () => {
     const longText = 'a'.repeat(3100);
     const pre = createPre(longText);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.37",
+  "version": "0.6.38",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/pre-split.ts
+++ b/src/dom/pre-split.ts
@@ -45,6 +45,17 @@ function isDecorationLine(line: string): boolean {
   return /^[=\-*_~#]+$/.test(t);
 }
 
+/**
+ * 列表条目行：行首（允许缩进）为项目符号或编号标记。
+ * 条目行强制独立成翻译单元 —— 渲染后一行原文紧贴一行译文，
+ * 行级对照。非列表行保持段落块聚合（按行翻译会切断句子）。
+ */
+const LIST_MARKER_RE = /^\s*(?:[*+-]\s+|\d+\.\s+)/;
+
+function isListLine(line: string): boolean {
+  return LIST_MARKER_RE.test(line);
+}
+
 /** 文本是否超过单块上限 —— 超长块不参与翻译 */
 function isOversized(text: string): boolean {
   return text.trim().length > MAX_TEXT;
@@ -109,14 +120,20 @@ export function splitPre(pre: HTMLPreElement): HTMLSpanElement[] | null {
   }
   if (cur.length > 0) lines.push({ toks: cur, endsWithNl: false });
 
-  // ── 按行 kind 聚合为块：空行 / 装饰行 → raw，其余 → chunk ──
+  // ── 按行 kind 聚合为块：空行 / 装饰行 → raw，其余 → chunk。
+  //    列表条目行强制独立成块 —— 行级对照（一行原文一行译文）──
   const parts: { kind: 'raw' | 'chunk'; lines: Line[] }[] = [];
   for (const line of lines) {
     const lt = lineText(line).trim();
     const kind = lt === '' || isDecorationLine(lt) ? 'raw' : 'chunk';
     const last = parts[parts.length - 1];
-    if (last && last.kind === kind) last.lines.push(line);
-    else parts.push({ kind, lines: [line] });
+    if (kind === 'chunk' && isListLine(lt)) {
+      parts.push({ kind, lines: [line] });
+    } else if (last && last.kind === kind) {
+      last.lines.push(line);
+    } else {
+      parts.push({ kind, lines: [line] });
+    }
   }
 
   // ── 重建 pre 内容：按 token 顺序 append，逐字节还原 ──


### PR DESCRIPTION
## 问题

torvalds/linux README 的列表译文与原文是**块级对照**：9 行原文块 → 9 行译文块。期望排版是**一行原文一行译文**的行级交错对照：

```
* New Kernel Developer - Getting started with kernel development
* 新内核开发人员 - 内核开发入门
* Academic Researcher - Studying kernel internals and architecture
* 学术研究员 - 研究内核内部结构和架构
```

## 根因

翻译单元粒度：整个列表被 splitPre 切成一个 chunk（#65/#106 的段落块聚合逻辑），对照渲染只能是块级。

## 修复

`splitPre` 切分时列表条目行强制独立成块：

- `isListLine`：行首（允许缩进）为 `*` / `-` / `+` / `N.` 标记
- 列表行不再与相邻行聚合，每行独立成为翻译单元
- 配合 #105 的 inline + `::after` 渲染，每行原文后紧贴该行译文，条目间无空行
- **非列表行保持段落块聚合** —— 按行切会把散文句子切断，翻译质量不可接受

## 验证

- 真实站点：75 个列表条目各自成单元（README 全部列表行），截图确认逐行交错对照
- 回归：
  - pre-split 单测：5 条目 = 5 独立 chunk、单行不含 `\n`、切分后逐字节不变
  - TC-E2E-49 列表断言重写：5 个独立单元 + 交错 y 坐标顺序断言（原文 i → 译文 i → 原文 i+1，紧贴无空行）
- 全量：typecheck ✓、单测 276 ✓、e2e core 23 ✓