### PR TITLE
fix(runtime): 扩展上下文失效后消息通道空等 25 秒 + 误导报错

### DIFF
--- a/docs/testing/setup.ts
+++ b/docs/testing/setup.ts
@@ -137,6 +137,9 @@ vi.stubGlobal('chrome', {
     },
   },
   runtime: {
+    // 真实 content script 里 runtime.id 是扩展 id 字符串；messaging.ts
+    // 的 isContextInvalidated 以 id == null 判定上下文失效
+    id: 'mock-extension-id',
     getURL: vi.fn().mockImplementation((path: string) => `chrome-extension://mock/${path}`),
     sendMessage: vi.fn().mockResolvedValue(undefined),
     onMessage: {

--- a/docs/testing/unit/runtime/messaging.test.ts
+++ b/docs/testing/unit/runtime/messaging.test.ts
@@ -117,6 +117,51 @@ describe('translateViaBackground — SW 冷启动（#89 根因）', () => {
   });
 });
 
+describe('translateViaBackground — 扩展上下文失效', () => {
+  test('chrome.runtime 为 undefined → 立即失败并提示刷新页面，不空等重试预算', async () => {
+    // 扩展重载 / 更新后，已注入页面的 content script 上下文失效：
+    // chrome.runtime 变 undefined，且永不恢复。修复前此处被当作
+    // SW 冷启动重试 10+15 秒，最终报「消息通道不可用: Cannot read
+    // properties of undefined (reading 'sendMessage')」。
+    vi.useFakeTimers();
+    // setup.ts 用 vi.stubGlobal 挂载 chrome —— 不能用 unstubAllGlobals
+    // 恢复（会把 setup 的 mock 一并撤销），测试内手动保存 / 恢复
+    const savedChrome = (globalThis as { chrome?: unknown }).chrome;
+    (globalThis as { chrome?: unknown }).chrome = { runtime: undefined };
+    try {
+      const pending = translateViaBackground(PAYLOAD);
+      await vi.advanceTimersByTimeAsync(0);
+      const result = await pending;
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain('已失效');
+        expect(result.error).toContain('刷新');
+      }
+    } finally {
+      (globalThis as { chrome?: unknown }).chrome = savedChrome;
+    }
+  });
+
+  test('chrome.runtime.sendMessage 抛 TypeError（上下文失效形态）→ 同样立即失败', async () => {
+    vi.useFakeTimers();
+    sendMessage.mockImplementation(async () => {
+      throw new TypeError(
+        "Cannot read properties of undefined (reading 'sendMessage')",
+      );
+    });
+
+    const pending = translateViaBackground(PAYLOAD);
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await pending;
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('已失效');
+    }
+  });
+});
+
 describe('translateViaBackground — 失败语义', () => {
   test('SW 响应 {ok:false}（引擎级失败）→ 原样返回，不重试', async () => {
     sendMessage.mockImplementation(async (msg: unknown) => {

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -209,6 +209,9 @@ export default defineContentScript({
       let allFailed = true;
       let renderRejected = 0;
       let renderSucceeded = 0;
+      // 不可恢复的失败原因（如扩展上下文失效）—— 全失败时优先展示，
+      // 而不是泛化的「所有引擎均失败」
+      let fatalError: string | null = null;
 
       // #91: 批次级引擎失败有限重试。传输层失败由 translateViaBackground
       // 内部重试（重新 ping + 有界退避），这里只处理引擎级失败（{ok:false}）
@@ -268,6 +271,8 @@ export default defineContentScript({
           }
         }
         console.error('[PT] 批次翻译失败:', lastError);
+        // 扩展上下文失效（重载/更新）不可恢复 —— 记录给全失败分支展示
+        if (lastError.includes('已失效')) fatalError = lastError;
         return { rendered, rejected, failed: true };
       }
 
@@ -292,7 +297,10 @@ export default defineContentScript({
 
       if (allFailed) {
         if (isMainFrame)
-          toast(tf('toastAllEnginesFail', '所有引擎均失败'), 'error');
+          toast(
+            fatalError ?? tf('toastAllEnginesFail', '所有引擎均失败'),
+            'error',
+          );
         return 'error';
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.39",
+  "version": "0.6.40",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/runtime/messaging.ts
+++ b/src/runtime/messaging.ts
@@ -30,6 +30,27 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+const CONTEXT_INVALIDATED_MSG =
+  '[PT] 扩展上下文已失效（扩展已更新或重载），请刷新页面后重试';
+
+/** 不可恢复的通道错误 —— 重试永远无意义，立即失败并提示用户 */
+const FATAL_CHANNEL_RE = /Extension context invalidated|Cannot read propert/i;
+
+/**
+ * 扩展上下文是否已失效。重载 / 更新 / 禁用扩展后，已注入页面的
+ * content script 里 chrome.runtime 变为 undefined 且永不恢复 ——
+ * 当作 SW 冷启动重试只会空耗 ping + translate 两级预算（25 秒），
+ * 最终报出误导性的「消息通道不可用」。
+ */
+function isContextInvalidated(): boolean {
+  try {
+    return (globalThis.chrome as { runtime?: { id?: string } } | undefined)
+      ?.runtime?.id == null;
+  } catch {
+    return true; // chrome 访问本身抛异常 —— 上下文已异常
+  }
+}
+
 /**
  * 有界重试发送：只要收不到任何响应（undefined / 连接被拒），
  * 就以指数退避重发，直到预算耗尽。收到响应（无论内容）即返回。
@@ -44,11 +65,21 @@ async function sendWithTransportRetry(
   let lastError = 'background 无响应';
 
   for (;;) {
+    // 上下文失效不可恢复：立即失败并提示刷新页面，不空等重试预算
+    if (isContextInvalidated()) {
+      throw new Error(CONTEXT_INVALIDATED_MSG);
+    }
+
     let resp: unknown;
     try {
       resp = await chrome.runtime.sendMessage(msg);
     } catch (e) {
-      lastError = e instanceof Error ? e.message : String(e);
+      const msgText = e instanceof Error ? e.message : String(e);
+      // 不可恢复错误（上下文失效的 TypeError / Chrome 标准错误）
+      if (FATAL_CHANNEL_RE.test(msgText)) {
+        throw new Error(CONTEXT_INVALIDATED_MSG);
+      }
+      lastError = msgText;
       resp = undefined;
     }
     if (resp !== undefined) return resp;


### PR DESCRIPTION
## 问题

重载 / 更新扩展后，在已打开的页面（如 github.com）点翻译球，控制台报：

> [PT] 批次翻译失败: [PT] 消息通道不可用: Cannot read properties of undefined (reading 'sendMessage')

且翻译失败。用户感受到的是「翻译突然坏了」。

## 根因

扩展重载 / 更新后，已注入页面的 content script 上下文失效：`chrome.runtime` 变 `undefined` 且**永不恢复**。但消息层（#89 的 SW 冷启动健壮层）无法区分「SW 冷启动（可恢复）」与「上下文失效（不可恢复）」——ping 重试 10 秒 + 翻译重试 15 秒空耗预算，最终报出误导性的「消息通道不可用」。用户频繁重载扩展（本地迭代）时高概率命中。

## 修复

`src/runtime/messaging.ts`：

- `sendWithTransportRetry` 循环开头检测上下文失效（`chrome.runtime.id == null`，try/catch 兜底 chrome 访问异常）→ **立即失败**
- catch 到不可恢复错误（`Extension context invalidated` / 读属性 `TypeError`）同样立即失败
- 错误统一为「**扩展上下文已失效（扩展已更新或重载），请刷新页面后重试**」
- 连接类错误（`Receiving end does not exist` 等）仍视为可恢复，重试行为不变

`entrypoints/content.ts`：全批次失败时 toast 优先展示该提示，而非泛化的「所有引擎均失败」。

## 验证

- 回归（红→绿）：messaging 新增 2 用例 —— 修复前空等 25 秒 + 误导报错（复现用户报错原文）；修复后立即失败 + 错误含「已失效」「刷新」
- 顺带修正 `setup.ts` mock：runtime 补 `id` 字段（真实 content script 恒有扩展 id，检测逻辑依赖它）
- 全量：typecheck ✓、单测 278 ✓、e2e core 23 ✓