### PR TITLE
fix(runtime): 批次重试层短路上下文失效 —— 立即失败，0 次重试 (#111)

### DIFF
--- a/docs/testing/unit/runtime/batch-retry.test.ts
+++ b/docs/testing/unit/runtime/batch-retry.test.ts
@@ -1,0 +1,132 @@
+/**
+ * runtime/batch-retry.ts — 批次级「发送 → 失败重试」策略 单元测试
+ *
+ * #91：引擎级失败有界重试（LIMIT=2，延迟 [1000, 3000]ms），
+ * 初始翻译与增量翻译共用，瞬时故障后自愈。
+ *
+ * #111：扩展上下文失效不可恢复 —— 必须 0 次重试立即失败，
+ * 否则 toast 仍延迟约 4 秒（重试序列 [1000, 3000]ms），
+ * 与 #109「立即失败」的字面承诺不符。
+ */
+import { describe, test, expect, vi } from 'vitest';
+import {
+  attemptBatchWithRetry,
+  BATCH_RETRY_LIMIT,
+  BATCH_RETRY_DELAYS_MS,
+} from '~/src/runtime/batch-retry';
+import { CONTEXT_INVALIDATED_MSG } from '~/src/runtime/messaging';
+
+const noopSleep = () => Promise.resolve();
+const TRANSLATED = { translations: ['你好'] };
+
+describe('attemptBatchWithRetry — 成功路径', () => {
+  test('首次发送即成功 → ok，发送 1 次', async () => {
+    const send = vi.fn(async () => ({ ok: true, data: TRANSLATED }));
+    const result = await attemptBatchWithRetry(send);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data).toEqual(TRANSLATED);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  test('引擎级失败后重试成功（#91 自愈）', async () => {
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, error: '引擎 A 失败' })
+      .mockResolvedValueOnce({ ok: true, data: TRANSLATED });
+    const result = await attemptBatchWithRetry(send, { sleep: noopSleep });
+
+    expect(result.ok).toBe(true);
+    // 1 次失败 + 1 次重试成功
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('attemptBatchWithRetry — 重试预算（#91）', () => {
+  test(`持续引擎级失败 → 共发送 ${BATCH_RETRY_LIMIT + 1} 次后失败，invalidated=false`, async () => {
+    const send = vi.fn(async () => ({ ok: false, error: '所有引擎均失败' }));
+    const result = await attemptBatchWithRetry(send, { sleep: noopSleep });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.invalidated).toBe(false);
+      expect(result.aborted).toBe(false);
+      expect(result.error).toBe('所有引擎均失败');
+    }
+    expect(send).toHaveBeenCalledTimes(BATCH_RETRY_LIMIT + 1);
+  });
+
+  test('重试退避按 BATCH_RETRY_DELAYS_MS 序列推进', async () => {
+    const sleeps: number[] = [];
+    const send = vi.fn(async () => ({ ok: false, error: '引擎失败' }));
+    const sleep = async (ms: number) => {
+      sleeps.push(ms);
+    };
+
+    await attemptBatchWithRetry(send, { sleep });
+
+    expect(sleeps).toEqual(BATCH_RETRY_DELAYS_MS.slice(0, BATCH_RETRY_LIMIT));
+  });
+});
+
+describe('attemptBatchWithRetry — 上下文失效立即失败（#111）', () => {
+  test('失效错误 → 0 次重试，invalidated=true，仅发送 1 次', async () => {
+    const send = vi.fn(async () => ({
+      ok: false,
+      error: CONTEXT_INVALIDATED_MSG,
+    }));
+    const result = await attemptBatchWithRetry(send, { sleep: noopSleep });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.invalidated).toBe(true);
+      expect(result.aborted).toBe(false);
+      expect(result.error).toContain('已失效');
+    }
+    // #111 关键断言：失效错误不得进入重试序列
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  test('失效错误路径不 sleep（不空等 [1000, 3000]ms）', async () => {
+    const sleep = vi.fn(async () => {});
+    const send = vi.fn(async () => ({
+      ok: false,
+      error: CONTEXT_INVALIDATED_MSG,
+    }));
+
+    await attemptBatchWithRetry(send, { sleep });
+
+    expect(sleep).not.toHaveBeenCalled();
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('attemptBatchWithRetry — 中止（还原 / 全局短路）', () => {
+  test('shouldAbort 在发送前命中 → aborted，不发送', async () => {
+    const send = vi.fn(async () => ({ ok: true, data: TRANSLATED }));
+    const result = await attemptBatchWithRetry(send, {
+      shouldAbort: () => true,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      invalidated: false,
+      aborted: true,
+      error: '',
+    });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  test('shouldAbort 在发送后命中 → aborted，不渲染、不再重试', async () => {
+    const send = vi.fn(async () => ({ ok: false, error: '引擎失败' }));
+    let calls = 0;
+    const result = await attemptBatchWithRetry(send, {
+      sleep: noopSleep,
+      shouldAbort: () => ++calls > 1, // 第一次尝试前不中止，发送后中止
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.aborted).toBe(true);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -27,6 +27,7 @@ import { toast } from '~/src/ui/toast';
 import { startHotkeys } from '~/src/hotkeys/listener';
 import { startSelectionDrag } from '~/src/ui/selection-drag';
 import { translateViaBackground } from '~/src/runtime/messaging';
+import { attemptBatchWithRetry } from '~/src/runtime/batch-retry';
 import { detectOS } from '~/src/hotkeys/platform';
 import {
   settingsReady,
@@ -137,9 +138,7 @@ export default defineContentScript({
     // 用户在第一屏译文出现前不再需要等待全页最慢段。
     const FULL_PAGE_BATCH_SIZE = 15;
 
-    // #91: 批次级引擎失败有限重试（见 doTranslate 内 attemptBatch）。
-    const BATCH_RETRY_LIMIT = 2;
-    const BATCH_RETRY_DELAYS_MS = [1000, 3000];
+    // #91: 批次级引擎失败有限重试（见 src/runtime/batch-retry.ts）。
     /** 还原纪元：doRestore 递增，在飞翻译据此放弃重试与渲染。 */
     const translateEpoch = { value: 0 };
     const sleep = (ms: number) =>
@@ -212,68 +211,64 @@ export default defineContentScript({
       // 不可恢复的失败原因（如扩展上下文失效）—— 全失败时优先展示，
       // 而不是泛化的“所有引擎均失败”
       let fatalError: string | null = null;
-
-      // #91: 批次级引擎失败有限重试。传输层失败由 translateViaBackground
-      // 内部重试（重新 ping + 有界退避），这里只处理引擎级失败（{ok:false}）
-      // —— 修复前增量翻译是一次性的：瞬时故障（CI 中 SW 冷启动/实例替换）
-      // 后新内容永久漏翻，正是 #91 的失败签名。初始翻译与增量翻译共用此
-      // 路径，部分批次失败（多批并发）与全部失败（单批）统一自愈。
-      // 文本在批次切分时捕获一次，重试复用同一份 —— 不会因 DOM 已变
-      // 而重新采集到译文本身。
+      // #111: 上下文失效全局短路 —— 任一批判失效后，其余批次不再发起新尝试
+      let invalidated = false;
       const epochAtStart = translateEpoch.value;
+
       async function attemptBatch(
         batch: (typeof batches)[number],
       ): Promise<{ rendered: number; rejected: number; failed: boolean }> {
+        // 重试策略（#91 有界重试 / #111 失效立即失败）集中在
+        // batch-retry.ts，此处只负责渲染与全局短路标记。
+        const result = await attemptBatchWithRetry(
+          () =>
+            translateViaBackground({
+              texts: batch.texts,
+              from: ns.from,
+              to: ns.to,
+            }),
+          {
+            sleep,
+            // 还原（纪元递增）或他批已判失效 → 放弃本次尝试与重试
+            shouldAbort: () =>
+              invalidated || translateEpoch.value !== epochAtStart,
+          },
+        );
+        if (!result.ok) {
+          if (result.invalidated) {
+            // 扩展上下文失效（重载/更新）不可恢复 —— 记录给全失败
+            // 分支优先展示，并置全局短路，其余批次与重试全部跳过
+            invalidated = true;
+            fatalError = result.error;
+          }
+          if (!result.aborted) {
+            console.error('[PT] 批次翻译失败:', result.error);
+          }
+          return { rendered: 0, rejected: 0, failed: true };
+        }
         let rendered = 0;
         let rejected = 0;
-        let lastError = '未知错误';
-        for (let attempt = 0; ; attempt++) {
-          // #89: SW 未就绪时消息会被丢弃 —— 经 translateViaBackground
-          // 先 ping 确认通道就绪，传输层失败自动重试。
-          const resp = await translateViaBackground({
-            texts: batch.texts,
-            from: ns.from,
-            to: ns.to,
-          });
-          // 已还原（doRestore 递增纪元）—— 放弃渲染，不再重试
-          if (translateEpoch.value !== epochAtStart) {
-            return { rendered, rejected, failed: true };
-          }
-          if (resp?.ok) {
-            const translations: string[] = resp.data.translations;
-            for (let i = 0; i < batch.targets.length; i++) {
-              try {
-                // #58：将占位符替换回原文（用户名等标识符不翻译但保留）
-                const restored = restorePreserves(
-                  translations[i]!,
-                  batch.preserves[i]!,
-                  batch.rawTexts[i]!,
-                );
-                if (render(batch.targets[i]!, restored, 'page')) {
-                  rendered++;
-                } else {
-                  rejected++;
-                }
-              } catch (e) {
-                throw new Error(
-                  `[render idx=${i}] ${e instanceof Error ? e.message : String(e)}`,
-                );
-              }
+        const translations = result.data.translations;
+        for (let i = 0; i < batch.targets.length; i++) {
+          try {
+            // #58：将占位符替换回原文（用户名等标识符不翻译但保留）
+            const restored = restorePreserves(
+              translations[i]!,
+              batch.preserves[i]!,
+              batch.rawTexts[i]!,
+            );
+            if (render(batch.targets[i]!, restored, 'page')) {
+              rendered++;
+            } else {
+              rejected++;
             }
-            return { rendered, rejected, failed: false };
-          }
-          lastError = resp?.error ?? '未知错误';
-          if (attempt >= BATCH_RETRY_LIMIT) break;
-          await sleep(BATCH_RETRY_DELAYS_MS[attempt]!);
-          // 睡眠期间被还原 —— 放弃重试
-          if (translateEpoch.value !== epochAtStart) {
-            return { rendered, rejected, failed: true };
+          } catch (e) {
+            throw new Error(
+              `[render idx=${i}] ${e instanceof Error ? e.message : String(e)}`,
+            );
           }
         }
-        console.error('[PT] 批次翻译失败:', lastError);
-        // 扩展上下文失效（重载/更新）不可恢复 —— 记录给全失败分支展示
-        if (lastError.includes('已失效')) fatalError = lastError;
-        return { rendered, rejected, failed: true };
+        return { rendered, rejected, failed: false };
       }
 
       // 所有批次并发发送，每批返回即渲染。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.42",
+  "version": "0.6.43",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/runtime/batch-retry.ts
+++ b/src/runtime/batch-retry.ts
@@ -1,0 +1,79 @@
+// 批次级「发送 → 失败重试」循环（content script 整页翻译专用）。
+//
+// 与 messaging.ts 的分工：messaging 负责消息通道的传输层重试
+// （ping + 有界退避）；本模块负责引擎级失败（{ok:false}）的批次重试。
+//
+// #91：传输层成功后引擎仍可能失败（CI 中 SW 冷启动/实例替换），
+// 修复前增量翻译是一次性的，瞬时故障后新内容永久漏翻。这里按
+// BATCH_RETRY_DELAYS_MS 有界重试，文本在批次切分时已捕获一次，
+// 重试复用同一份 —— 不会因 DOM 已变而重新采集到译文本身。
+//
+// #111：扩展上下文失效（重载 / 更新）不可恢复 —— 重试永远无意义，
+// 检测到立即失败（0 次重试），由调用方置全局短路，其余批次
+// 不再发起新尝试，toast 立即出现而非等完 [1000, 3000]ms 重试序列。
+
+import type { TranslateResponse } from '~/src/engines/types';
+import { CONTEXT_INVALIDATED_MSG } from './messaging';
+
+/** #91: 批次级引擎失败最大重试次数。 */
+export const BATCH_RETRY_LIMIT = 2;
+/** #91: 重试退避序列（毫秒）。 */
+export const BATCH_RETRY_DELAYS_MS = [1000, 3000];
+
+export type BatchRetryResult =
+  | { ok: true; data: TranslateResponse }
+  | {
+      ok: false;
+      /** 上下文失效（不可恢复）—— 未重试（#111）。 */
+      invalidated: boolean;
+      /** 中止（还原 / 其他批次已判失效）—— 未完成。 */
+      aborted: boolean;
+      error: string;
+    };
+
+export interface BatchRetryOptions {
+  /** 注入 sleep 以便测试推进虚拟时钟；默认 setTimeout。 */
+  sleep?: (ms: number) => Promise<void>;
+  /** 每次尝试前后检查；返回 true 则立即中止剩余重试。 */
+  shouldAbort?: () => boolean;
+}
+
+/**
+ * 发送一批文本直至成功或重试预算耗尽。
+ * - ok 响应立即返回（调用方负责渲染）
+ * - 引擎级失败按 BATCH_RETRY_DELAYS_MS 有界重试（#91）
+ * - 上下文失效立即返回 invalidated，0 次重试（#111）
+ */
+export async function attemptBatchWithRetry(
+  send: () => Promise<{
+    ok: boolean;
+    data?: TranslateResponse;
+    error?: string;
+  }>,
+  opts: BatchRetryOptions = {},
+): Promise<BatchRetryResult> {
+  const sleep =
+    opts.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  let lastError = '未知错误';
+  for (let attempt = 0; ; attempt++) {
+    if (opts.shouldAbort?.()) {
+      return { ok: false, invalidated: false, aborted: true, error: '' };
+    }
+    const resp = await send();
+    if (opts.shouldAbort?.()) {
+      return { ok: false, invalidated: false, aborted: true, error: '' };
+    }
+    if (resp?.ok && resp.data) {
+      return { ok: true, data: resp.data };
+    }
+    lastError = resp?.error ?? '未知错误';
+    // #111: 上下文失效不可恢复 —— 立即失败，不进入重试序列
+    if (lastError.includes(CONTEXT_INVALIDATED_MSG)) {
+      return { ok: false, invalidated: true, aborted: false, error: lastError };
+    }
+    if (attempt >= BATCH_RETRY_LIMIT) break;
+    await sleep(BATCH_RETRY_DELAYS_MS[attempt]!);
+  }
+  return { ok: false, invalidated: false, aborted: false, error: lastError };
+}

--- a/src/runtime/messaging.ts
+++ b/src/runtime/messaging.ts
@@ -30,7 +30,8 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-const CONTEXT_INVALIDATED_MSG =
+/** 上下文失效错误文案。batch-retry.ts 据其短路批次重试（#111）。 */
+export const CONTEXT_INVALIDATED_MSG =
   '[PT] 扩展上下文已失效（扩展已更新或重载），请刷新页面后重试';
 
 /** 不可恢复的通道错误 —— 重试永远无意义，立即失败并提示用户 */


### PR DESCRIPTION
## 背景

#109 后 messaging 层已立即失败，但批次重试层未短路：`entrypoints/content.ts` 的 `attemptBatch` 仍按 `LIMIT=2`、延迟 `[1000, 3000]ms` 重试失效错误 —— 重载扩展后点翻译，toast 仍延迟约 4 秒。

## 改动

- **`src/runtime/batch-retry.ts`（新）**：批次级「发送 → 失败重试」策略从 content.ts 抽出，`CONTEXT_INVALIDATED_MSG` 命中即返回 `invalidated`，0 次重试、不 sleep
- **`src/runtime/messaging.ts`**：导出 `CONTEXT_INVALIDATED_MSG` 常量供短路判定复用
- **`entrypoints/content.ts`**：`attemptBatch` 改用 `attemptBatchWithRetry`；全局 `invalidated` 标记 —— 任一批判失效后，其余批次与重试全部跳过，立即进入全失败分支（toast 优先展示失效文案）
- **`docs/testing/unit/runtime/batch-retry.test.ts`（新）**：锁定「失效错误 → 发送 1 次 / 不 sleep / invalidated=true」；同时覆盖 #91 重试预算、退避序列与还原中止
- **`package.json`**：0.6.42 → 0.6.43

## 验证

- 单测：286 通过（新增 8 例）
- typecheck 通过；`pnpm build` 成功

Fixes #111