### PR TITLE
refactor(runtime): 上下文失效判定改用类型化 invalidated 标志，解除文案耦合 (#116)

### DIFF
--- a/.wxt/types/i18n.d.ts
+++ b/.wxt/types/i18n.d.ts
@@ -353,7 +353,7 @@ declare module "wxt/browser" {
       options?: GetMessageOptions,
     ): string;
     /**
-     * "点「启用」将其加入优先级列表末尾。BYOK 引擎需先填入 API key。"
+     * "点“启用”将其加入优先级列表末尾。BYOK 引擎需先填入 API key。"
      */
     getMessage(
       messageName: "cardDisabledDesc",
@@ -721,7 +721,7 @@ declare module "wxt/browser" {
       options?: GetMessageOptions,
     ): string;
     /**
-     * "与「$ACTION$」重复"
+     * "与“$ACTION$”重复"
      */
     getMessage(
       messageName: "conflictDuplicate",
@@ -1209,7 +1209,7 @@ declare module "wxt/browser" {
       options?: GetMessageOptions,
     ): string;
     /**
-     * "页面右侧的悬浮按钮「译」，点击即可翻译整页"
+     * "页面右侧的悬浮按钮“译”，点击即可翻译整页"
      */
     getMessage(
       messageName: "welcomeBallDesc",
@@ -1225,7 +1225,7 @@ declare module "wxt/browser" {
       options?: GetMessageOptions,
     ): string;
     /**
-     * "鼠标悬停在段落上时出现「译」按钮，点击翻译该段落"
+     * "鼠标悬停在段落上时出现“译”按钮，点击翻译该段落"
      */
     getMessage(
       messageName: "welcomeParaBtnDesc",
@@ -1241,7 +1241,7 @@ declare module "wxt/browser" {
       options?: GetMessageOptions,
     ): string;
     /**
-     * "选中文本后右键，点击「翻译所选文本」即可翻译选中内容"
+     * "选中文本后右键，点击“翻译所选文本”即可翻译选中内容"
      */
     getMessage(
       messageName: "welcomeSelectionDesc",

--- a/docs/testing/unit/runtime/batch-retry.test.ts
+++ b/docs/testing/unit/runtime/batch-retry.test.ts
@@ -7,6 +7,9 @@
  * #111：扩展上下文失效不可恢复 —— 必须 0 次重试立即失败，
  * 否则 toast 仍延迟约 4 秒（重试序列 [1000, 3000]ms），
  * 与 #109「立即失败」的字面承诺不符。
+ *
+ * #116：失效判定基于 messaging 透出的类型化 invalidated 标志，
+ * 与错误文案解耦 —— 文案改写不影响短路行为。
  */
 import { describe, test, expect, vi } from 'vitest';
 import {
@@ -14,7 +17,6 @@ import {
   BATCH_RETRY_LIMIT,
   BATCH_RETRY_DELAYS_MS,
 } from '~/src/runtime/batch-retry';
-import { CONTEXT_INVALIDATED_MSG } from '~/src/runtime/messaging';
 
 const noopSleep = () => Promise.resolve();
 const TRANSLATED = { translations: ['你好'] };
@@ -69,11 +71,14 @@ describe('attemptBatchWithRetry — 重试预算（#91）', () => {
   });
 });
 
-describe('attemptBatchWithRetry — 上下文失效立即失败（#111）', () => {
-  test('失效错误 → 0 次重试，invalidated=true，仅发送 1 次', async () => {
+describe('attemptBatchWithRetry — 上下文失效立即失败（#111/#116）', () => {
+  test('invalidated 标志 → 0 次重试，仅发送 1 次', async () => {
+    // #116: 判定依据是类型化 invalidated 标志而非错误文案 ——
+    // 故意用与 CONTEXT_INVALIDATED_MSG 不同的文案证明解耦
     const send = vi.fn(async () => ({
       ok: false,
-      error: CONTEXT_INVALIDATED_MSG,
+      invalidated: true,
+      error: '扩展已重载，请刷新页面',
     }));
     const result = await attemptBatchWithRetry(send, { sleep: noopSleep });
 
@@ -81,17 +86,18 @@ describe('attemptBatchWithRetry — 上下文失效立即失败（#111）', () =
     if (!result.ok) {
       expect(result.invalidated).toBe(true);
       expect(result.aborted).toBe(false);
-      expect(result.error).toContain('已失效');
+      expect(result.error).toBe('扩展已重载，请刷新页面');
     }
     // #111 关键断言：失效错误不得进入重试序列
     expect(send).toHaveBeenCalledTimes(1);
   });
 
-  test('失效错误路径不 sleep（不空等 [1000, 3000]ms）', async () => {
+  test('失效路径不 sleep（不空等 [1000, 3000]ms）', async () => {
     const sleep = vi.fn(async () => {});
     const send = vi.fn(async () => ({
       ok: false,
-      error: CONTEXT_INVALIDATED_MSG,
+      invalidated: true,
+      error: '上下文失效',
     }));
 
     await attemptBatchWithRetry(send, { sleep });

--- a/docs/testing/unit/runtime/messaging.test.ts
+++ b/docs/testing/unit/runtime/messaging.test.ts
@@ -135,6 +135,8 @@ describe('translateViaBackground — 扩展上下文失效', () => {
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
+        // #116: 类型化失效标志透出，供 batch-retry 短路而不匹配文案
+        expect(result.invalidated).toBe(true);
         expect(result.error).toContain('已失效');
         expect(result.error).toContain('刷新');
       }
@@ -157,6 +159,7 @@ describe('translateViaBackground — 扩展上下文失效', () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
+      expect(result.invalidated).toBe(true);
       expect(result.error).toContain('已失效');
     }
   });
@@ -172,7 +175,11 @@ describe('translateViaBackground — 失败语义', () => {
 
     const result = await translateViaBackground(PAYLOAD);
 
-    expect(result).toEqual({ ok: false, error: '所有引擎均失败' });
+    expect(result).toEqual({
+      ok: false,
+      error: '所有引擎均失败',
+      invalidated: false,
+    });
     // 1 ping + 1 translate，translate 没有重试
     expect(sendMessage).toHaveBeenCalledTimes(2);
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.43",
+  "version": "0.6.44",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/runtime/batch-retry.ts
+++ b/src/runtime/batch-retry.ts
@@ -11,9 +11,10 @@
 // #111：扩展上下文失效（重载 / 更新）不可恢复 —— 重试永远无意义，
 // 检测到立即失败（0 次重试），由调用方置全局短路，其余批次
 // 不再发起新尝试，toast 立即出现而非等完 [1000, 3000]ms 重试序列。
+// #116：失效判定用 messaging 透出的类型化 invalidated 标志，
+// 不匹配错误文案 —— 文案改写不影响短路行为。
 
 import type { TranslateResponse } from '~/src/engines/types';
-import { CONTEXT_INVALIDATED_MSG } from './messaging';
 
 /** #91: 批次级引擎失败最大重试次数。 */
 export const BATCH_RETRY_LIMIT = 2;
@@ -49,6 +50,8 @@ export async function attemptBatchWithRetry(
     ok: boolean;
     data?: TranslateResponse;
     error?: string;
+    /** #116: messaging 透出的类型化上下文失效标志。 */
+    invalidated?: boolean;
   }>,
   opts: BatchRetryOptions = {},
 ): Promise<BatchRetryResult> {
@@ -68,8 +71,8 @@ export async function attemptBatchWithRetry(
       return { ok: true, data: resp.data };
     }
     lastError = resp?.error ?? '未知错误';
-    // #111: 上下文失效不可恢复 —— 立即失败，不进入重试序列
-    if (lastError.includes(CONTEXT_INVALIDATED_MSG)) {
+    // #111/#116: 上下文失效是类型化标志 —— 立即失败，不进入重试序列
+    if (resp?.invalidated) {
       return { ok: false, invalidated: true, aborted: false, error: lastError };
     }
     if (attempt >= BATCH_RETRY_LIMIT) break;

--- a/src/runtime/messaging.ts
+++ b/src/runtime/messaging.ts
@@ -16,7 +16,7 @@ import type { TranslateRequest, TranslateResponse } from '~/src/engines/types';
 
 export type TranslateResult =
   | { ok: true; data: TranslateResponse }
-  | { ok: false; error: string };
+  | { ok: false; error: string; invalidated: boolean };
 
 /** SW 就绪等待预算（ping 阶段）。覆盖 CI 中 SW 冷启动的常见耗时。 */
 const READY_BUDGET_MS = 10_000;
@@ -30,9 +30,20 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/** 上下文失效错误文案。batch-retry.ts 据其短路批次重试（#111）。 */
+/** 上下文失效错误文案。 */
 export const CONTEXT_INVALIDATED_MSG =
   '[PT] 扩展上下文已失效（扩展已更新或重载），请刷新页面后重试';
+
+/**
+ * 上下文失效错误 —— 类型化错误类别（#116）。
+ * 调用方按 instanceof 判定而非匹配文案，messaging 层改写文案不影响判定。
+ */
+export class ContextInvalidatedError extends Error {
+  constructor(message: string = CONTEXT_INVALIDATED_MSG) {
+    super(message);
+    this.name = 'ContextInvalidatedError';
+  }
+}
 
 /** 不可恢复的通道错误 —— 重试永远无意义，立即失败并提示用户 */
 const FATAL_CHANNEL_RE = /Extension context invalidated|Cannot read propert/i;
@@ -68,7 +79,7 @@ async function sendWithTransportRetry(
   for (;;) {
     // 上下文失效不可恢复：立即失败并提示刷新页面，不空等重试预算
     if (isContextInvalidated()) {
-      throw new Error(CONTEXT_INVALIDATED_MSG);
+      throw new ContextInvalidatedError();
     }
 
     let resp: unknown;
@@ -78,7 +89,7 @@ async function sendWithTransportRetry(
       const msgText = e instanceof Error ? e.message : String(e);
       // 不可恢复错误（上下文失效的 TypeError / Chrome 标准错误）
       if (FATAL_CHANNEL_RE.test(msgText)) {
-        throw new Error(CONTEXT_INVALIDATED_MSG);
+        throw new ContextInvalidatedError();
       }
       lastError = msgText;
       resp = undefined;
@@ -114,8 +125,13 @@ export async function translateViaBackground(
     if (resp?.ok === true && resp.data) {
       return { ok: true, data: resp.data };
     }
-    return { ok: false, error: resp?.error ?? '未知错误' };
+    return { ok: false, error: resp?.error ?? '未知错误', invalidated: false };
   } catch (e) {
-    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+    // #116: 上下文失效以类型化标志透出，调用方无需匹配文案
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : String(e),
+      invalidated: e instanceof ContextInvalidatedError,
+    };
   }
 }


### PR DESCRIPTION
## 背景

#111 后魔法字符串从 content.ts 移入 batch-retry.ts，但 `lastError.includes(CONTEXT_INVALIDATED_MSG)` 仍靠文案隐式耦合 —— messaging 层改写文案（如加语气词）会让失效短路静默失效。

## 改动

- **`src/runtime/messaging.ts`**：新增导出 `ContextInvalidatedError` 错误类（两处失效抛出处改抛该类）；`TranslateResult` 失败分支新增 `invalidated: boolean` 类型化标志透出
- **`src/runtime/batch-retry.ts`**：失效判定改为 `resp.invalidated` 标志，删除 `includes(文案)` 匹配与常量 import —— 文案改写不再影响短路行为
- **`docs/testing/unit/runtime/batch-retry.test.ts`**：失效用例改用与真实常量不同的文案 + 标志，证明判定与文案解耦
- **`docs/testing/unit/runtime/messaging.test.ts`**：断言 `invalidated` 标志透出
- **`package.json`**：0.6.43 → 0.6.44

## 验证

- typecheck 通过；单测 286 passed
- `pnpm build` 成功

Fixes #116