### PR TITLE
refactor(content): pre 归一化选择收敛到共享函数 normalizeForUnit (#117)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ Thumbs.db
 *.log
 npm-debug.log*
 pnpm-debug.log*
+.pnpm-store/

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -38,6 +38,13 @@ import {
 import type { Settings } from '~/src/storage/schema';
 import { tf } from '~/src/i18n';
 
+// pre 判定统一收敛：#117。pre 内单元（.pt-chunk / 纯文本 pre）保留硬换行，
+// pre 外折叠空白；两处采集/渲染路径共用同一判定，避免只改一处导致行为分叉。
+function normalizeForUnit(el: Element, raw: string): string {
+  const normalize = el.closest('pre') ? normalizePreText : normalizeText;
+  return normalize(raw);
+}
+
 export default defineContentScript({
   matches: ['<all_urls>'],
   allFrames: true,
@@ -177,8 +184,7 @@ export default defineContentScript({
           : translatableTextEx(el);
         // pre 内单元（.pt-chunk / 纯文本 pre）保留硬换行：
         // 列表逐行条目是文档结构，折叠成一行后译文也回不来行结构
-        const normalize = el.closest('pre') ? normalizePreText : normalizeText;
-        const text = normalize(rawText);
+        const text = normalizeForUnit(el, rawText);
         return {
           text,
           preserves,
@@ -435,8 +441,7 @@ export default defineContentScript({
       }
 
       const { text: rawText, preserves } = translatableTextEx(unit);
-      const normalize = unit.closest('pre') ? normalizePreText : normalizeText;
-      const text = normalize(rawText);
+      const text = normalizeForUnit(unit, rawText);
       if (!text) return;
 
       const resp = await translateViaBackground({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.44",
+  "version": "0.6.45",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## 问题
entrypoints/content.ts 两处（原 181 / 443 行）重复内联 `el.closest('pre') ? normalizePreText : normalizeText`，pre 判定改动时易只改一处导致行为分叉。

## 根因
pre 归一化选择逻辑未提取共享函数。

## 修复
新增 `normalizeForUnit(el, raw)` 共享函数，两处调用点统一改用；同时 bump 版本 0.6.44 → 0.6.45。

## 验证
- typecheck 通过
- 全量 vitest 286 个用例全绿（含 normalize.test.ts、pre-split.test.ts）
- `pnpm build` 构建成功