### PR TITLE
test(dom): walker 异常降级与 compat 补丁分支测试覆盖 (#114)

### DIFF
--- a/docs/testing/unit/dom/compat-github.test.ts
+++ b/docs/testing/unit/dom/compat-github.test.ts
@@ -17,7 +17,7 @@
  * 整页采集 0 个翻译单元 —— 翻译静默失败（[data-pt="done"] 永不出现）。
  */
 import { describe, test, expect } from 'vitest';
-import { applyCompat } from '~/src/dom/compat';
+import { applyCompat, shouldPreserveText } from '~/src/dom/compat';
 
 function el(html: string): Element {
   const div = document.createElement('div');
@@ -63,5 +63,39 @@ describe('applyCompat（github.com，#93 回归）', () => {
     const p = el('<p>Run <code>pnpm build</code> first.</p>');
     expect(() => applyCompat(p)).not.toThrow();
     expect(applyCompat(p)).toBeNull();
+  });
+});
+
+// ---- shouldPreserveText（github.com，#114 补覆盖） ----
+
+describe('shouldPreserveText（github.com）', () => {
+  test('a.user-mention（评论 @mention）→ 保留用户名', () => {
+    const a = el('<a class="user-mention">@torvalds</a>');
+    expect(shouldPreserveText(a)).toBe('@torvalds');
+  });
+
+  test('[data-hovercard-url^="/users/"] → 保留用户名', () => {
+    const a = el('<a data-hovercard-url="/users/torvalds">torvalds</a>');
+    expect(shouldPreserveText(a)).toBe('torvalds');
+  });
+
+  test('[rel="author"] → 保留作者名', () => {
+    const a = el('<a rel="author">Linus Torvalds</a>');
+    expect(shouldPreserveText(a)).toBe('Linus Torvalds');
+  });
+
+  test('[itemprop="author"] → 保留作者名', () => {
+    const a = el('<a itemprop="author">octocat</a>');
+    expect(shouldPreserveText(a)).toBe('octocat');
+  });
+
+  test('普通链接 → null（不保留）', () => {
+    const a = el('<a href="https://github.com/foo/bar">foo/bar</a>');
+    expect(shouldPreserveText(a)).toBeNull();
+  });
+
+  test('空文本链接 → null', () => {
+    const a = el('<a class="user-mention">  </a>');
+    expect(shouldPreserveText(a)).toBeNull();
   });
 });

--- a/docs/testing/unit/dom/compat-google.test.ts
+++ b/docs/testing/unit/dom/compat-google.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @vitest-environment jsdom
+ * @vitest-environment-options {"url": "https://www.google.com/search?q=test"}
+ */
+/**
+ * dom/compat.ts — google.com OMIT_HANDLERS 精修补丁测试（#114）
+ *
+ * 覆盖此前零测试的 OMIT_HANDLERS 分支：AI 概览来源角标类名
+ * （span.wJwe6c / .WTfRgd）。jsdom 的 location.hostname 是文件级
+ * 选项，与 localhost 的 compat.test.ts 分离。
+ */
+import { describe, test, expect } from 'vitest';
+import { shouldOmitText } from '~/src/dom/compat';
+
+function el(html: string): Element {
+  const div = document.createElement('div');
+  div.innerHTML = html.trim();
+  return div.firstElementChild!;
+}
+
+describe('shouldOmitText（google.com）', () => {
+  test('span.wJwe6c（AI 概览来源角标）→ true', () => {
+    const badge = el('<span class="wJwe6c">OpenAI</span>');
+    expect(shouldOmitText(badge)).toBe(true);
+  });
+
+  test('.WTfRgd → true', () => {
+    const badge = el('<span class="WTfRgd">Meta</span>');
+    expect(shouldOmitText(badge)).toBe(true);
+  });
+
+  test('普通正文 span → false', () => {
+    const span = el('<span>plain result text</span>');
+    expect(shouldOmitText(span)).toBe(false);
+  });
+
+  test('favicon 尺寸 img 的链接 → true（通用行内角标层）', () => {
+    const a = el('<a href="#"><img width="16" height="16" alt="">YouTube</a>');
+    expect(shouldOmitText(a)).toBe(true);
+  });
+
+  test('大尺寸 img 的链接 → false（非角标）', () => {
+    const a = el('<a href="#"><img width="48" height="48" alt="">YouTube</a>');
+    expect(shouldOmitText(a)).toBe(false);
+  });
+});

--- a/docs/testing/unit/dom/compat-youtube.test.ts
+++ b/docs/testing/unit/dom/compat-youtube.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment jsdom
+ * @vitest-environment-options {"url": "https://www.youtube.com/watch?v=test"}
+ */
+/**
+ * dom/compat.ts — youtube.com 域名补丁测试（#114）
+ *
+ * 此前 YouTube 处理器（skip 分支）零覆盖。jsdom 的 location.hostname
+ * 是文件级选项，与 localhost / github.com 的测试文件分离。
+ */
+import { describe, test, expect } from 'vitest';
+import { applyCompat, mainDomain } from '~/src/dom/compat';
+
+function el(html: string): Element {
+  const div = document.createElement('div');
+  div.innerHTML = html.trim();
+  return div.firstElementChild!;
+}
+
+describe('mainDomain', () => {
+  test('www.youtube.com → youtube.com', () => {
+    expect(mainDomain('www.youtube.com')).toBe('youtube.com');
+  });
+});
+
+describe('applyCompat（youtube.com）', () => {
+  test('时长角标 → skip', () => {
+    const badge = el(
+      '<ytd-thumbnail-overlay-time-status-renderer class="ytd-thumbnail-overlay-time-status-renderer">12:34</ytd-thumbnail-overlay-time-status-renderer>',
+    );
+    expect(applyCompat(badge)).toEqual({ skip: true });
+  });
+
+  test('#metadata-line span（播放量/发布时间）→ skip', () => {
+    const inner = el('<div id="metadata-line"><span>1.2M views</span></div>').querySelector('span')!;
+    expect(applyCompat(inner)).toEqual({ skip: true });
+  });
+
+  test('.ytd-video-meta-block ytd-badge-supported-renderer → skip', () => {
+    const badge = el(
+      '<div class="ytd-video-meta-block"><ytd-badge-supported-renderer>CC</ytd-badge-supported-renderer></div>',
+    ).querySelector('ytd-badge-supported-renderer')!;
+    expect(applyCompat(badge)).toEqual({ skip: true });
+  });
+
+  test('.ytd-channel-name yt-formatted-string（频道名）→ skip', () => {
+    const name = el(
+      '<div class="ytd-channel-name"><yt-formatted-string>Channel Name</yt-formatted-string></div>',
+    ).querySelector('yt-formatted-string')!;
+    expect(applyCompat(name)).toEqual({ skip: true });
+  });
+
+  test('普通正文元素 → null（交回通用逻辑）', () => {
+    const p = el('<p>This video explains the basics.</p>');
+    expect(applyCompat(p)).toBeNull();
+  });
+});

--- a/docs/testing/unit/dom/walker-compat.test.ts
+++ b/docs/testing/unit/dom/walker-compat.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @vitest-environment jsdom
+ * @vitest-environment-options {"url": "https://github.com/anthropics/claude-code"}
+ */
+/**
+ * dom/walker.ts × dom/compat.ts — 真实补丁在采集器里的优先级（#114）
+ *
+ * 与 walker.test.ts 分离：后者 mock 掉 applyCompat 只测 walker 对
+ * 补丁结果的消费；本文件用真实 github.com 处理器验证“skip 优先于
+ * 通用判定”的端到端形态 —— .BorderGrid 内本可成单元的元素被跳过，
+ * 而普通正文照常采集。
+ */
+import { describe, test, expect } from 'vitest';
+import { mockAllBoundingRects } from '../../setup';
+import { collect } from '~/src/dom/walker';
+
+describe('collect × applyCompat（github.com 真实补丁）', () => {
+  test('.BorderGrid 内元素被 compat skip 优先拦截', () => {
+    const restore = mockAllBoundingRects();
+    try {
+      document.body.innerHTML =
+        '<div class="BorderGrid"><p id="panel">Contributors</p></div>' +
+        '<p id="body">Claude Code is an agentic coding tool.</p>';
+      const units = collect();
+      // panel 文本完整且可见，通用判定本会采集；compat skip 优先，只剩正文
+      expect(units.map((u) => u.id)).toEqual(['body']);
+    } finally {
+      restore();
+    }
+  });
+
+  test('blob 代码行内元素同样被 skip（PRE 入口之前生效）', () => {
+    const restore = mockAllBoundingRects();
+    try {
+      document.body.innerHTML =
+        '<div class="blob-code"><pre id="code">const x = 1;</pre></div>' +
+        '<p id="body">README text.</p>';
+      const units = collect();
+      expect(units.map((u) => u.id)).toEqual(['body']);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/docs/testing/unit/dom/walker.test.ts
+++ b/docs/testing/unit/dom/walker.test.ts
@@ -1,0 +1,263 @@
+/**
+ * dom/walker.ts — 采集器单元测试（#114）
+ *
+ * 覆盖此前零测试的路径：
+ * - Web Components 节点访问 textContent / compat 判定抛 DOMException →
+ *   不崩溃、跳过该节点、其余节点继续采集（#54）
+ * - compat 补丁 skip/take 优先于通用判定（take 分支此前完全不可达）
+ * - 含媒体/交互控件的容器跳过自身、子元素仍可翻译（#50，#55 行内不阻断）
+ * - 不可见单元记入 onHidden 回调（#23）
+ * - shadowRoot 递归穿透、pt-ui 拒绝、SKIP_SET 拒绝、pre 切分入口
+ *
+ * applyCompat 在本文件统一 mock：compat 自身的各站点逻辑由
+ * compat.test.ts / compat-github.test.ts / compat-youtube.test.ts /
+ * compat-google.test.ts 覆盖，这里只测 walker 对补丁结果的消费。
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { mockAllBoundingRects, mockBoundingRect } from '../../setup';
+import { collect } from '~/src/dom/walker';
+import { applyCompat } from '~/src/dom/compat';
+
+vi.mock('~/src/dom/compat', () => ({
+  applyCompat: vi.fn(),
+}));
+
+const mockedCompat = vi.mocked(applyCompat);
+
+function setBody(html: string): void {
+  document.body.innerHTML = html;
+}
+
+describe('collect（walker 基础路径）', () => {
+  beforeEach(() => {
+    setBody('');
+    mockedCompat.mockReset();
+    mockedCompat.mockReturnValue(null);
+  });
+
+  test('p / li 等翻译单元被采集，行内元素不采集', () => {
+    const restore = mockAllBoundingRects();
+    try {
+      setBody('<p id="a">alpha</p><li id="b">beta</li><span id="c">gamma</span>');
+      const units = collect();
+      expect(units.map((u) => u.id)).toEqual(['a', 'b']);
+    } finally {
+      restore();
+    }
+  });
+
+  test('data-pt-ui="1" 扩展自身 UI：整棵子树拒绝（acceptNode REJECT）', () => {
+    const restore = mockAllBoundingRects();
+    try {
+      setBody('<div data-pt-ui="1"><p id="ui">extension ui</p></div><p id="ok">regular text</p>');
+      const units = collect();
+      expect(units.map((u) => u.id)).toEqual(['ok']);
+    } finally {
+      restore();
+    }
+  });
+
+  test('SKIP_SET（button）整棵子树拒绝', () => {
+    const restore = mockAllBoundingRects();
+    try {
+      setBody('<button><span id="label">click me</span></button><p id="ok">regular text</p>');
+      const units = collect();
+      expect(units.map((u) => u.id)).toEqual(['ok']);
+    } finally {
+      restore();
+    }
+  });
+
+  test('shadow host 递归穿透 shadowRoot，light + shadow 单元都采集', () => {
+    const restore = mockAllBoundingRects();
+    try {
+      setBody('<div id="host"><p id="light">light text</p></div>');
+      const host = document.getElementById('host')!;
+      const shadow = host.attachShadow({ mode: 'open' });
+      shadow.innerHTML = '<p id="shadow">shadow text</p>';
+
+      const units = collect();
+      expect(units.map((u) => u.id).sort()).toEqual(['light', 'shadow']);
+    } finally {
+      restore();
+    }
+  });
+
+  test('pre 走 splitPre 入口，短文本 pre 自身仍是翻译单元', () => {
+    const restore = mockAllBoundingRects();
+    try {
+      setBody('<pre id="p">short pre text</pre>');
+      const units = collect();
+      expect(units.map((u) => u.id)).toEqual(['p']);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('collect（#54：Web Components 异常降级）', () => {
+  beforeEach(() => {
+    setBody('');
+    mockedCompat.mockReset();
+    mockedCompat.mockReturnValue(null);
+  });
+
+  test('applyCompat 抛 DOMException → 跳过该节点，其余继续采集', () => {
+    mockedCompat.mockImplementation((el) => {
+      if (el.classList.contains('wc')) {
+        throw new DOMException('blocked', 'InvalidStateError');
+      }
+      return null;
+    });
+
+    const restore = mockAllBoundingRects();
+    try {
+      setBody('<p id="a">first</p><p class="wc" id="wc">bad node</p><p id="b">second</p>');
+      expect(() => collect()).not.toThrow();
+      const units = collect();
+      expect(units.map((u) => u.id)).toEqual(['a', 'b']);
+    } finally {
+      restore();
+    }
+  });
+
+  test('单元自身 textContent 访问抛 DOMException → 跳过，不崩溃（#54 形态）', () => {
+    const restore = mockAllBoundingRects();
+    try {
+      setBody('<p id="a">first</p><p id="wc">web component text</p><p id="b">second</p>');
+      const wc = document.getElementById('wc')!;
+      Object.defineProperty(wc, 'textContent', {
+        get() {
+          throw new DOMException('blocked', 'InvalidStateError');
+        },
+      });
+
+      expect(() => collect()).not.toThrow();
+      const units = collect();
+      expect(units.map((u) => u.id)).toEqual(['a', 'b']);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('collect（compat 补丁优先于通用判定）', () => {
+  beforeEach(() => {
+    setBody('');
+    mockedCompat.mockReset();
+    mockedCompat.mockReturnValue(null);
+  });
+
+  test('skip 优先：本可成为翻译单元的元素被补丁跳过', () => {
+    mockedCompat.mockImplementation((el) =>
+      el.classList.contains('compat-skip') ? { skip: true } : null,
+    );
+
+    const restore = mockAllBoundingRects();
+    try {
+      setBody('<p class="compat-skip" id="s">ui metadata</p><p id="ok">real text</p>');
+      const units = collect();
+      expect(units.map((u) => u.id)).toEqual(['ok']);
+    } finally {
+      restore();
+    }
+  });
+
+  test('take 优先：行内非单元元素被补丁直接收为单元', () => {
+    mockedCompat.mockImplementation((el) =>
+      el.id === 't' ? { take: el } : null,
+    );
+
+    const restore = mockAllBoundingRects();
+    try {
+      setBody('<div><em id="t">inline but taken</em></div>');
+      const units = collect();
+      expect(units.map((u) => u.id)).toEqual(['t']);
+    } finally {
+      restore();
+    }
+  });
+
+  test('take 自身后继续遍历：seen 去重同一元素，后续单元照常采集', () => {
+    // take 分支 seen.add(el) + out.push(patched.take)：真实补丁 take 恒等于 el。
+    // 元素经 take 入列后，同一 collect 内不会再被通用判定重复采集。
+    mockedCompat.mockImplementation((el) =>
+      el.id === 'a' ? { take: el } : null,
+    );
+
+    const restore = mockAllBoundingRects();
+    try {
+      setBody('<p id="a">alpha</p><p id="b">beta</p>');
+      const units = collect();
+      expect(units.map((u) => u.id)).toEqual(['a', 'b']);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('collect（#50 / #55：非文本内容容器）', () => {
+  beforeEach(() => {
+    setBody('');
+    mockedCompat.mockReset();
+    mockedCompat.mockReturnValue(null);
+  });
+
+  test('含 video 的容器跳过自身，子元素仍可翻译', () => {
+    const restore = mockAllBoundingRects();
+    try {
+      setBody(
+        '<div id="box">direct text<video></video><p id="child">child paragraph</p></div>',
+      );
+      const units = collect();
+      expect(units.map((u) => u.id)).toEqual(['child']);
+    } finally {
+      restore();
+    }
+  });
+
+  test('行内 img 不阻断：段落照常采集（#55 位置性判定）', () => {
+    const restore = mockAllBoundingRects();
+    try {
+      setBody('<p id="p">text <img src="icon.png" alt=""> more</p>');
+      const units = collect();
+      expect(units.map((u) => u.id)).toEqual(['p']);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('collect（#23：不可见单元 → onHidden）', () => {
+  beforeEach(() => {
+    setBody('');
+    mockedCompat.mockReset();
+    mockedCompat.mockReturnValue(null);
+  });
+
+  test('不可见单元不入列、记入 onHidden；可见单元正常采集', () => {
+    setBody('<p id="vis">visible text</p><p id="hid">hidden text</p>');
+    mockAllBoundingRects();
+    mockBoundingRect(document.getElementById('hid')!, { width: 0, height: 0 });
+
+    const onHidden = vi.fn();
+    const units = collect(document.body, onHidden);
+
+    expect(units.map((u) => u.id)).toEqual(['vis']);
+    expect(onHidden).toHaveBeenCalledTimes(1);
+    expect(onHidden.mock.calls[0]![0]).toBe(document.getElementById('hid'));
+  });
+
+  test('shouldSkipNonVisual 跳过的单元（notranslate）静默跳过，不进 onHidden', () => {
+    const restore = mockAllBoundingRects();
+    try {
+      setBody('<p class="notranslate" id="nt">skip me please</p><p id="ok">regular text</p>');
+      const onHidden = vi.fn();
+      const units = collect(document.body, onHidden);
+      expect(units.map((u) => u.id)).toEqual(['ok']);
+      expect(onHidden).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.45",
+  "version": "0.6.46",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## 做了什么

新增 `docs/testing/unit/dom/walker.test.ts`，mock applyCompat 覆盖 walker 全部决策路径：

- **#54 异常降级**：applyCompat 抛 DOMException、单元自身 textContent 访问抛 DOMException → 不崩溃、跳过该节点、其余继续采集
- **compat skip/take 优先于通用判定**：skip 拦截本可成单元的节点；take 直接收行内元素为单元；take 后继续遍历
- **#50**：含 video 容器跳过自身、子元素仍可翻译；**#55** 行内 img 不阻断
- **#23**：不可见单元记入 onHidden 回调
- shadowRoot 递归穿透、data-pt-ui / SKIP_SET 整棵子树拒绝、pre splitPre 入口

配套覆盖：

- `walker-compat.test.ts`：github.com 真实补丁在采集器里的 skip 优先级（端到端）
- `compat-youtube.test.ts`：YouTube 处理器全部 skip 分支（此前零覆盖）
- `compat-google.test.ts`：OMIT_HANDLERS 角标类名分支（此前零覆盖）
- `compat-github.test.ts`：补 shouldPreserveText 全部保留分支

## 验证

- walker.ts 分支覆盖 **47.61% → 100%**（要求 ≥85%），语句/行/函数均 100%
- compat.ts 语句覆盖 **61.9% → 100%**，分支 88.88%
- typecheck ✓、全量 vitest 319 通过 ✓
- 版本 0.6.45 → 0.6.46

Closes #114