### PR TITLE
fix(test): test:stubs:verify 误报 core.spec.ts 缺失 + 212 条未实现（#121）

### DIFF
--- a/docs/DEEP-TESTING.md
+++ b/docs/DEEP-TESTING.md
@@ -467,7 +467,7 @@ describe('translateViaBackground — 失败语义', () => {
 ### 3.1 翻译管道端到端（content → background → router → engine）
 
 ```
-测试文件：src/__tests__/integration/translate-pipeline.test.ts
+测试文件：docs/testing/integration/translate-pipeline.test.ts
 
 场景 1：正常整页翻译
   准备：basic.html fixture，mock Google 返回正确译文

--- a/docs/testing/generate-test-stubs.ts
+++ b/docs/testing/generate-test-stubs.ts
@@ -2,7 +2,7 @@
 /**
  * generate-test-stubs.ts
  *
- * 从 DEEP-TESTING.md 自动生成测试桩文件。
+ * 从 DEEP-TESTING.md 自动生成测试桩文件 / 校验文档与代码同步（#121）。
  *
  * 用法：
  *   pnpm tsx docs/testing/generate-test-stubs.ts           # 生成全部桩
@@ -11,13 +11,23 @@
  *
  * 工作原理：
  *   1. 解析 DEEP-TESTING.md 中描述的测试用例
- *   2. 匹配到已存在的测试文件，报告覆盖率
- *   3. 为缺失的测试用例生成桩代码（test.skip + 描述）
+ *   2. 按分层声明把用例解析到实际测试文件（unit/integration/e2e/artifacts 目录扫描）
+ *   3. 归一化标题 + 模糊匹配，区分「已实现 / 标题差异 / 缺失」
+ *   4. 为缺失的测试文件生成桩代码（test.skip + 描述）
+ *
+ * 用例→文件解析（#121 修复）：
+ *   - E2E 用例按 TC-E2E-NN 编号扫描 e2e/*.spec.ts 定位（不再硬编码 core.spec.ts）
+ *   - describe 块优先取「测试文件：」注解（相对 docs/testing 解析），
+ *     否则按模块名扫描目录中实际包含该 describe 的文件
+ *
+ * 用例匹配（#121 修复）：
+ *   - 标题归一化：去括号内容（#NN 回归等）、去 @tag/TC 编号、去标点与空白
+ *   - 依次尝试：归一化精确相等 → 包含关系 → 二元组 Jaccard 相似度
+ *   - 命中但措辞不同记「标题差异」，不再误报「未实现」
  *
  * 生成规则：
- *   - 如果对应的 .test.ts 文件已存在 → 跳过，报告"已实现"
+ *   - 如果对应的测试文件已存在 → 跳过，报告"已实现/标题差异"
  *   - 如果对应文件不存在 → 生成桩文件（所有用例标记为 test.skip）
- *   - 如果文件存在但缺少用例 → 追加缺失的 test.skip 用例
  */
 
 import fs from 'fs';
@@ -27,13 +37,12 @@ import path from 'path';
 
 const TESTING_DIR = path.resolve('docs/testing');
 const DOC_PATH = path.resolve('docs/DEEP-TESTING.md');
-const UNIT_DIR = path.join(TESTING_DIR, 'unit');
-const INTEGRATION_DIR = path.join(TESTING_DIR, 'integration');
-const E2E_DIR = path.join(TESTING_DIR, 'e2e');
-const ARTIFACTS_DIR = path.join(TESTING_DIR, 'artifacts');
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const VERIFY = process.argv.includes('--verify');
+
+/** 模糊匹配阈值：二元组 Jaccard 相似度下限 */
+const SIM_THRESHOLD = 0.4;
 
 // ---- 用例提取 ----
 
@@ -41,7 +50,111 @@ interface TestCase {
   name: string;
   module: string;
   category: 'unit' | 'integration' | 'e2e' | 'artifacts';
+  /** 相对 docs/testing 的路径；E2E 用例留空，运行期按 TC 编号定位 */
   file: string;
+  /** E2E 用例编号（TC-E2E-NN） */
+  tcNumber?: number;
+}
+
+/** 递归扫描目录下的测试文件，返回相对 TESTING_DIR 的路径 */
+function scanTestFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...scanTestFiles(p));
+    } else if (entry.name.endsWith('.test.ts') || entry.name.endsWith('.spec.ts')) {
+      out.push(path.relative(TESTING_DIR, p).replace(/\\/g, '/'));
+    }
+  }
+  return out;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** 在分类目录中查找包含 describe('module') 的测试文件 */
+function findFileByModule(module: string, category: TestCase['category']): string | null {
+  const dirName = { unit: 'unit', integration: 'integration', e2e: 'e2e', artifacts: 'artifacts' }[category];
+  const root = path.join(TESTING_DIR, dirName);
+  const re = new RegExp(`describe\\(['"]${escapeRegExp(module)}['"]`);
+  for (const rel of scanTestFiles(root)) {
+    const content = fs.readFileSync(path.join(TESTING_DIR, rel), 'utf-8');
+    if (re.test(content)) return rel;
+  }
+  return null;
+}
+
+const MODULE_FILE_MAP: Record<string, string> = {
+  parseNumbered: 'unit/engines/parseNumbered.test.ts',
+  route: 'unit/engines/router.test.ts',
+  translatableTextEx: 'unit/dom/text.test.ts',
+  shallowTranslatableTextEx: 'unit/dom/text.test.ts',
+  restorePreserves: 'unit/dom/text.test.ts',
+  hasBlockTextChildren: 'unit/dom/text.test.ts',
+  isTranslationUnit: 'unit/dom/classify.test.ts',
+  hasNonTextContent: 'unit/dom/classify.test.ts',
+  closestUnit: 'unit/dom/classify.test.ts',
+  shouldSkipNonVisual: 'unit/dom/classify.test.ts',
+  isMainlyNumeric: 'unit/dom/classify.test.ts',
+  splitPre: 'unit/dom/pre-split.test.ts',
+  unsplitPre: 'unit/dom/pre-split.test.ts',
+  normalizeText: 'unit/dom/normalize.test.ts',
+  mainDomain: 'unit/dom/compat.test.ts',
+  isGenericInlineBadge: 'unit/dom/compat.test.ts',
+  shouldPreserveText: 'unit/dom/compat.test.ts',
+  render: 'unit/dom/renderer.test.ts',
+  unrender: 'unit/dom/renderer.test.ts',
+  applyMode: 'unit/dom/renderer.test.ts',
+  applyStyle: 'unit/dom/renderer.test.ts',
+  'merge / patchSettings': 'unit/storage/settings.test.ts',
+  onSettingsChanged: 'unit/storage/settings.test.ts',
+  'cacheGet / cacheSet': 'unit/storage/cache.test.ts',
+  'LRU 淘汰': 'unit/storage/cache.test.ts',
+  '并发安全': 'unit/storage/cache.test.ts',
+  Gate: 'unit/queue/concurrency.test.ts',
+  fromEvent: 'unit/hotkeys/normalize.test.ts',
+  isTypingContext: 'unit/hotkeys/normalize.test.ts',
+  validateCustomCss: 'unit/styles/custom.test.ts',
+  applyCustomCss: 'unit/styles/custom.test.ts',
+  keys: 'unit/storage/keys.test.ts',
+  i18n: 'unit/i18n/coverage.test.ts',
+  '构建产物校验': 'artifacts/build-output.test.ts',
+};
+
+/** 解析「测试文件：」注解为相对 docs/testing 的路径；解析失败返回 null */
+function resolveAnnotation(raw: string): string | null {
+  const p = raw.replace(/^[`#*\s]+/, '').trim();
+  if (!p) return null;
+  // 已是相对 docs/testing 的路径（或全路径含 docs/testing）
+  if (p.startsWith('docs/testing/') || p.includes('/docs/testing/')) {
+    const idx = p.indexOf('docs/testing/');
+    return p.slice(idx + 'docs/testing/'.length);
+  }
+  const direct = path.join(TESTING_DIR, p);
+  if (fs.existsSync(direct)) return p.replace(/\\/g, '/');
+  // 旧式路径（如 src/__tests__/...）→ 按 basename 在 docs/testing 下查找
+  const base = path.basename(p);
+  for (const rel of scanTestFiles(TESTING_DIR)) {
+    if (path.basename(rel) === base) return rel;
+  }
+  return null;
+}
+
+/** 从模块名推断文件名：映射表 → 目录扫描 → 默认 slug */
+function inferFileName(module: string, category: TestCase['category']): string {
+  if (MODULE_FILE_MAP[module]) return MODULE_FILE_MAP[module];
+  const found = findFileByModule(module, category);
+  if (found) return found;
+  const slug = module.replace(/\s+/g, '-').toLowerCase().replace(/[/'"]/g, '');
+  return `${category}/${slug}.test.ts`;
+}
+
+/** E2E 用例按编号的兜底文件（文档 4.4 目录树：核心 01~30、46~48，扩展 31~45） */
+function e2eFallbackFile(tcNumber: number): string {
+  return tcNumber >= 31 && tcNumber <= 45 ? 'e2e/extended.spec.ts' : 'e2e/core.spec.ts';
 }
 
 /**
@@ -50,11 +163,12 @@ interface TestCase {
  * 匹配模式：
  * - describe('ModuleName', ...) 块 → module
  * - test('description') → test case
- * - TC-E2E-NN: description → E2E test case
+ * - TC-E2E-NN: description → E2E test case（按编号去重，4.3 详规标题不再重复计数）
  */
 function parseTestCases(): TestCase[] {
   const content = fs.readFileSync(DOC_PATH, 'utf-8');
   const cases: TestCase[] = [];
+  const seenTc = new Set<number>();
 
   let currentModule = '';
   let currentFile = '';
@@ -65,33 +179,49 @@ function parseTestCases(): TestCase[] {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
 
-    // 检测 describe block
+    // 分类标题
+    if (line.includes('## 二、单元测试')) currentCategory = 'unit';
+    if (line.includes('## 三、集成测试')) currentCategory = 'integration';
+    if (line.includes('## 四、E2E')) currentCategory = 'e2e';
+    if (line.includes('## 五、构建产物')) currentCategory = 'artifacts';
+
+    // describe 块：重置文件推断（#121：修复 currentFile 跨模块残留）
     const descMatch = line.match(/describe\('([^']+)'/);
     if (descMatch) {
       currentModule = descMatch[1]!;
-      // 从前面的注释或路径推断文件
+      currentFile = '';
       const prevLines = lines.slice(Math.max(0, i - 10), i);
       for (const pl of prevLines.reverse()) {
         const fileMatch = pl.match(/(?:测试文件[：:]|文件[：:])\s*(\S+)/);
         if (fileMatch) {
-          currentFile = fileMatch[1]!;
-          break;
+          currentFile = resolveAnnotation(fileMatch[1]!) ?? '';
+          if (currentFile) break;
         }
       }
-      // 从模块名推断文件
       if (!currentFile) {
         currentFile = inferFileName(currentModule, currentCategory);
       }
       continue;
     }
 
-    // 检测分类标题
-    if (line.includes('## 二、单元测试')) currentCategory = 'unit';
-    if (line.includes('## 三、集成测试')) currentCategory = 'integration';
-    if (line.includes('## 四、E2E')) currentCategory = 'e2e';
-    if (line.includes('## 五、构建产物')) currentCategory = 'artifacts';
+    // E2E 用例：TC-E2E-NN: 描述（按编号去重）
+    const e2eMatch = line.match(/TC-E2E-(\d+):\s*(.+)/);
+    if (e2eMatch) {
+      const num = Number(e2eMatch[1]);
+      if (!seenTc.has(num)) {
+        seenTc.add(num);
+        cases.push({
+          name: e2eMatch[2]!.trim(),
+          module: 'E2E',
+          category: 'e2e',
+          file: '',
+          tcNumber: num,
+        });
+      }
+      continue;
+    }
 
-    // 检测 test case
+    // 普通 test case
     const testMatch = line.match(/test\('([^']+)'/);
     if (testMatch && currentModule) {
       cases.push({
@@ -101,124 +231,169 @@ function parseTestCases(): TestCase[] {
         file: currentFile || inferFileName(currentModule, currentCategory),
       });
     }
-
-    // 检测 E2E TC 编号
-    const e2eMatch = line.match(/TC-E2E-\d+:\s*(.+)/);
-    if (e2eMatch) {
-      cases.push({
-        name: e2eMatch[1]!.trim(),
-        module: 'E2E',
-        category: 'e2e',
-        file: 'core.spec.ts',
-      });
-    }
   }
 
   return cases;
 }
 
-/** 从模块名推断文件名 */
-function inferFileName(
-  module: string,
-  category: TestCase['category'],
-): string {
-  const map: Record<string, string> = {
-    parseNumbered: 'unit/engines/parseNumbered.test.ts',
-    route: 'unit/engines/router.test.ts',
-    translatableTextEx: 'unit/dom/text.test.ts',
-    shallowTranslatableTextEx: 'unit/dom/text.test.ts',
-    restorePreserves: 'unit/dom/text.test.ts',
-    hasBlockTextChildren: 'unit/dom/text.test.ts',
-    isTranslationUnit: 'unit/dom/classify.test.ts',
-    hasNonTextContent: 'unit/dom/classify.test.ts',
-    closestUnit: 'unit/dom/classify.test.ts',
-    shouldSkipNonVisual: 'unit/dom/classify.test.ts',
-    isMainlyNumeric: 'unit/dom/classify.test.ts',
-    splitPre: 'unit/dom/pre-split.test.ts',
-    unsplitPre: 'unit/dom/pre-split.test.ts',
-    normalizeText: 'unit/dom/normalize.test.ts',
-    mainDomain: 'unit/dom/compat.test.ts',
-    isGenericInlineBadge: 'unit/dom/compat.test.ts',
-    shouldPreserveText: 'unit/dom/compat.test.ts',
-    render: 'unit/dom/renderer.test.ts',
-    unrender: 'unit/dom/renderer.test.ts',
-    applyMode: 'unit/dom/renderer.test.ts',
-    applyStyle: 'unit/dom/renderer.test.ts',
-    'merge / patchSettings': 'unit/storage/settings.test.ts',
-    onSettingsChanged: 'unit/storage/settings.test.ts',
-    'cacheGet / cacheSet': 'unit/storage/cache.test.ts',
-    'LRU 淘汰': 'unit/storage/cache.test.ts',
-    '并发安全': 'unit/storage/cache.test.ts',
-    Gate: 'unit/queue/concurrency.test.ts',
-    fromEvent: 'unit/hotkeys/normalize.test.ts',
-    isTypingContext: 'unit/hotkeys/normalize.test.ts',
-    validateCustomCss: 'unit/styles/custom.test.ts',
-    applyCustomCss: 'unit/styles/custom.test.ts',
-    keys: 'unit/storage/keys.test.ts',
-    i18n: 'unit/i18n/coverage.test.ts',
-    '构建产物校验': 'artifacts/build-output.test.ts',
-  };
+// ---- 归一化与模糊匹配 ----
 
-  if (map[module]) return map[module];
+/** 去掉括号内容（（…）与 (…)）—— 用例名中的 #NN 回归、补充说明等 */
+function stripParentheticals(s: string): string {
+  return s.replace(/（[^（）]*）/g, '').replace(/\([^()]*\)/g, '');
+}
 
-  // 默认推断
-  const slug = module.replace(/\s+/g, '-').toLowerCase().replace(/[/']/g, '');
-  return `${category}/${slug}.test.ts`;
+/** 标题归一化：小写、去 @tag、去 TC 编号、去括号内容、去引号与标点、折叠空白 */
+function normalizeTitle(s: string): string {
+  return stripParentheticals(s)
+    .toLowerCase()
+    .replace(/@[\w-]+/g, ' ')
+    .replace(/tc-e2e-?\d+/g, ' ')
+    .replace(/['"“”‘’`]/g, ' ')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function bigrams(s: string): Set<string> {
+  const out = new Set<string>();
+  for (let i = 0; i < s.length - 1; i++) out.add(s.slice(i, i + 2));
+  return out;
+}
+
+/** 二元组 Jaccard 相似度（0~1） */
+function jaccard(a: string, b: string): number {
+  if (a === b) return 1;
+  const A = bigrams(a);
+  const B = bigrams(b);
+  if (A.size === 0 || B.size === 0) return 0;
+  let inter = 0;
+  for (const g of A) if (B.has(g)) inter++;
+  return inter / (A.size + B.size - inter);
+}
+
+interface FileTests {
+  titles: string[];
+  normalized: string[];
+  tcNumbers: Set<number>;
+}
+
+/** 提取文件内所有测试标题（含 test.skip）与 TC 编号 */
+function loadFileTests(file: string): FileTests | null {
+  const filePath = path.join(TESTING_DIR, file);
+  if (!fs.existsSync(filePath)) return null;
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const titles: string[] = [];
+  const tcNumbers = new Set<number>();
+  const re = /test(?:\.\w+)?\(\s*'([^']*)'/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    titles.push(m[1]!);
+    const tc = m[1]!.match(/TC-E2E-(\d+)/);
+    if (tc) tcNumbers.add(Number(tc[1]));
+  }
+  return { titles, normalized: titles.map(normalizeTitle), tcNumbers };
+}
+
+type MatchResult = 'exact' | 'fuzzy' | null;
+
+/** 判断文档用例是否被文件内测试覆盖 */
+function matchCase(tc: TestCase, fileTests: FileTests): MatchResult {
+  // E2E：按 TC 编号精确匹配
+  if (tc.tcNumber !== undefined) {
+    return fileTests.tcNumbers.has(tc.tcNumber) ? 'exact' : null;
+  }
+
+  const doc = normalizeTitle(tc.name);
+  if (!doc) return null;
+
+  // 1) 归一化精确相等
+  if (fileTests.normalized.includes(doc)) return 'exact';
+
+  // 2) 包含关系（短边 ≥ 5 字符）
+  for (const n of fileTests.normalized) {
+    const [shorter, longer] = n.length <= doc.length ? [n, doc] : [doc, n];
+    if (shorter.length >= 5 && longer.includes(shorter)) return 'fuzzy';
+  }
+
+  // 3) 二元组 Jaccard 相似度
+  for (const n of fileTests.normalized) {
+    if (jaccard(doc, n) >= SIM_THRESHOLD) return 'fuzzy';
+  }
+
+  return null;
+}
+
+/** 为缺失用例找最接近的候选标题（用于给「改名 or 改文档」建议） */
+function nearestTitles(tc: TestCase, fileTests: FileTests, limit = 2): string[] {
+  const doc = normalizeTitle(tc.name);
+  return fileTests.titles
+    .map((title, i) => ({ title, score: jaccard(doc, fileTests.normalized[i]!) }))
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map((x) => x.title);
 }
 
 // ---- 同步检查 ----
 
+interface MissingEntry {
+  file: string;
+  cases: { name: string; tcNumber?: number; suggestions: string[] }[];
+}
+
 interface SyncReport {
   total: number;
   implemented: number;
-  stubbed: number;
-  missing: { file: string; cases: string[] }[];
-  stale: { file: string; cases: string[] }[];
+  titleDiff: number;
+  missing: MissingEntry[];
 }
 
 /** 检查文档与代码同步状态 */
 function verifySync(cases: TestCase[]): SyncReport {
-  const report: SyncReport = {
-    total: cases.length,
-    implemented: 0,
-    stubbed: 0,
-    missing: [],
-    stale: [],
-  };
+  const report: SyncReport = { total: cases.length, implemented: 0, titleDiff: 0, missing: [] };
 
-  // 按文件分组
+  // 按文件分组（E2E 用例先按 TC 编号定位实际 spec 文件）
   const byFile = new Map<string, TestCase[]>();
+  const e2eTcFile = new Map<number, string>();
+  for (const rel of scanTestFiles(path.join(TESTING_DIR, 'e2e'))) {
+    const ft = loadFileTests(rel);
+    if (!ft) continue;
+    for (const n of ft.tcNumbers) if (!e2eTcFile.has(n)) e2eTcFile.set(n, rel);
+  }
+
   for (const tc of cases) {
-    const list = byFile.get(tc.file) || [];
+    const file = tc.tcNumber !== undefined ? (e2eTcFile.get(tc.tcNumber) ?? e2eFallbackFile(tc.tcNumber)) : tc.file;
+    const list = byFile.get(file) || [];
     list.push(tc);
-    byFile.set(tc.file, list);
+    byFile.set(file, list);
   }
 
   for (const [file, tcs] of byFile) {
-    const filePath = path.join(TESTING_DIR, file);
-    if (!fs.existsSync(filePath)) {
+    const fileTests = loadFileTests(file);
+
+    if (!fileTests) {
       report.missing.push({
         file,
-        cases: tcs.map((t) => t.name),
+        cases: tcs.map((t) => ({ name: t.name, tcNumber: t.tcNumber, suggestions: [] })),
       });
       continue;
     }
 
-    const content = fs.readFileSync(filePath, 'utf-8');
-    let missingCases: string[] = [];
-
+    const missCases: MissingEntry['cases'] = [];
     for (const tc of tcs) {
-      // 简单检查：文件是否包含用例描述
-      if (content.includes(tc.name)) {
+      const result = matchCase(tc, fileTests);
+      if (result === 'exact') {
         report.implemented++;
+      } else if (result === 'fuzzy') {
+        report.titleDiff++;
       } else {
-        missingCases.push(tc.name);
-        report.stubbed++;
+        missCases.push({ name: tc.name, tcNumber: tc.tcNumber, suggestions: nearestTitles(tc, fileTests) });
       }
     }
 
-    if (missingCases.length > 0) {
-      report.missing.push({ file, cases: missingCases });
+    if (missCases.length > 0) {
+      report.missing.push({ file, cases: missCases });
     }
   }
 
@@ -234,22 +409,32 @@ function main(): void {
   if (VERIFY) {
     console.log('📋 文档-代码同步验证\n');
     const report = verifySync(cases);
+    const missingFiles = report.missing.filter((m) => !fs.existsSync(path.join(TESTING_DIR, m.file)));
+    const missingCases = report.missing.filter((m) => fs.existsSync(path.join(TESTING_DIR, m.file)));
+
     console.log(`  总用例数:  ${report.total}`);
     console.log(`  已实现:    ${report.implemented}`);
-    console.log(`  未实现:    ${report.stubbed}`);
-    console.log(`  缺失文件:  ${report.missing.filter((m) => !fs.existsSync(path.join(TESTING_DIR, m.file))).length}`);
-    console.log(`  缺失用例:  ${report.missing.filter((m) => fs.existsSync(path.join(TESTING_DIR, m.file))).length}`);
+    console.log(`  标题差异:  ${report.titleDiff}（模糊匹配命中，措辞与文档不同）`);
+    console.log(`  未实现:    ${report.missing.reduce((n, m) => n + m.cases.length, 0)}`);
+    console.log(`  缺失文件:  ${missingFiles.length}`);
+    console.log(`  用例失配:  ${missingCases.reduce((n, m) => n + m.cases.length, 0)}（文件存在但用例缺失）`);
 
     if (report.missing.length > 0) {
       console.log('\n📝 缺失详情:');
       for (const m of report.missing) {
         const exists = fs.existsSync(path.join(TESTING_DIR, m.file));
-        console.log(`\n  ${exists ? '⚠' : '✗'} ${m.file}${exists ? ' (文件存在，缺失用例)' : ' (文件不存在)'}`);
-        for (const c of m.cases.slice(0, 5)) {
-          console.log(`    - ${c}`);
+        console.log(`\n  ${exists ? '⚠' : '✗'} ${m.file}${exists ? `（文件存在，缺失 ${m.cases.length} 个用例）` : `（文件不存在，含 ${m.cases.length} 个用例）`}`);
+        for (const c of m.cases.slice(0, 8)) {
+          console.log(`    - ${c.tcNumber !== undefined ? `TC-E2E-${String(c.tcNumber).padStart(2, '0')}: ` : ''}${c.name}`);
+          for (const s of c.suggestions.slice(0, 1)) {
+            console.log(`      → 最接近: ${s}（可改名对齐或更新文档措辞）`);
+          }
         }
-        if (m.cases.length > 5) {
-          console.log(`    … 还有 ${m.cases.length - 5} 个`);
+        if (m.cases.length > 8) {
+          console.log(`    … 还有 ${m.cases.length - 8} 个`);
+        }
+        if (!exists) {
+          console.log(`      → 建议: 运行 pnpm test:stubs 生成桩文件，或修正文档中该文件的路径`);
         }
       }
     }
@@ -263,7 +448,8 @@ function main(): void {
   const report = verifySync(cases);
   console.log(`  总用例数: ${report.total}`);
   console.log(`  已实现:   ${report.implemented}`);
-  console.log(`  待生成:   ${report.stubbed}`);
+  console.log(`  标题差异: ${report.titleDiff}`);
+  console.log(`  待生成:   ${report.missing.reduce((n, m) => n + m.cases.length, 0)}`);
   console.log();
 
   // 为缺失文件生成桩
@@ -277,13 +463,12 @@ function main(): void {
     console.log(`${DRY_RUN ? '📝 将生成' : '✅ 已生成'} ${m.file}（${m.cases.length} 个桩用例）`);
     if (DRY_RUN) continue;
 
-    // 生成桩文件
     const dir = path.dirname(filePath);
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
     }
 
-    const testContent = generateStubFile(m.file, m.cases);
+    const testContent = generateStubFile(m.file, m.cases.map((c) => c.name));
     fs.writeFileSync(filePath, testContent, 'utf-8');
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.49",
+  "version": "0.6.50",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.50",
+  "version": "0.6.51",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Closes #121

## 问题
`pnpm test:stubs:verify` 误报 `core.spec.ts 文件不存在`（实际在 `docs/testing/e2e/`），212 条用例「未实现」但多数实际已存在同名/近名用例。

## 根因
1. **文件归属错误**：`currentFile` 在 describe 块间不重置，全部单元用例错误归入首个模块文件；E2E 硬编码 `core.spec.ts`。
2. **精确字符串匹配**：标题措辞一变即失配，无法区分「真缺用例」与「标题差异」。

## 修复（docs/testing/generate-test-stubs.ts）
- describe 块重置文件推断；「测试文件：」注解按 docs/testing 相对路径解析（含旧式 src/__tests__ 路径按 basename 兜底），否则按模块名扫描 unit/integration 目录定位实际文件。
- E2E 用例按 TC-E2E-NN 编号扫描 `e2e/*.spec.ts` 定位（不再硬编码），并按编号去重（4.3 详规标题不重复计数）。
- 匹配：归一化（去括号内容/@tag/TC 编号/标点）→ 精确相等 → 包含关系 → 二元组 Jaccard 相似度（≥0.4），区分「已实现 / 标题差异 / 未实现」。
- 缺失用例输出最接近标题建议（改名 or 改文档）；缺失文件提示生成桩。
- 修正 DEEP-TESTING.md 中过时的集成测试路径。

## 验证
- `未实现`: 212 → **40**（<50），`缺失文件`: 0（core.spec.ts 误报消失）
- 仍能捕获真实缺失：isMainlyNumeric 6 例、LRU 淘汰 4 例、TC-E2E-06~10/13/14/17~19 共 10 例等如实标红
- `pnpm typecheck` ✓，`pnpm test` 321/321 ✓，`pnpm build` ✓