### PR TITLE
fix(dom): pre 归一化保留行首缩进 —— 嵌套列表译文列丢失层级（#141）

### DIFF
--- a/docs/testing/unit/dom/normalize.test.ts
+++ b/docs/testing/unit/dom/normalize.test.ts
@@ -70,8 +70,27 @@ describe('normalizePreText', () => {
     expect(normalizePreText('a\n\n\nb')).toBe('a\n\n\nb');
   });
 
-  test('行首行尾空白去除', () => {
-    expect(normalizePreText('  * item  \n  * item2  ')).toBe('* item\n* item2');
+  test('行首缩进保留、行尾空白去除（#141）', () => {
+    expect(normalizePreText('  * item  \n  * item2  ')).toBe('  * item\n  * item2');
+  });
+
+  test('嵌套列表缩进保留（#141 决策）', () => {
+    const input = [
+      '* Install the package:',
+      '',
+      '  - Use a virtual environment',
+      '  - Verify the version',
+      '',
+      '* Report a bug:',
+      '',
+      '  - Open an issue',
+      '  - Attach logs',
+    ].join('\n');
+    expect(normalizePreText(input)).toBe(input);
+  });
+
+  test('整块首行缩进同样保留、块尾换行去除（#141）', () => {
+    expect(normalizePreText('  first line\n  second line\n')).toBe('  first line\n  second line');
   });
 
   test('纯空白 → ""', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.52",
+  "version": "0.6.53",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/normalize.ts
+++ b/src/dom/normalize.ts
@@ -18,11 +18,20 @@ export function normalizeText(s: string): string {
  * 硬换行。列表逐行条目（RST 的 * item）是文档结构，normalizeText
  * 会把整个列表折叠成一行 —— 引擎收到无结构文本，译文也回不来行结构。
  * 逐行折叠后引擎按行切句，恰好是列表翻译期望的行为。
+ *
+ * #141：行首缩进必须保留 —— RST 嵌套列表靠缩进表达层级，逐行对照时
+ * 译文列若丢失缩进，行首与原文对不齐、嵌套结构消失。因此只折叠
+ * 行内（缩进之后）的连续空白、去除行尾空白，缩进原样保留；
+ * 整块只去除尾部空白/换行，首行缩进同样保留。
  */
 export function normalizePreText(s: string): string {
   return s
     .split('\n')
-    .map((line) => line.replace(/[ \t]+/g, ' ').trim())
+    .map((line) => {
+      if (line.trim() === '') return '';
+      const indent = /^[ \t]*/.exec(line)?.[0] ?? '';
+      return indent + line.slice(indent.length).replace(/[ \t]+/g, ' ').trimEnd();
+    })
     .join('\n')
-    .trim();
+    .trimEnd();
 }


### PR DESCRIPTION
## 问题
#106 修复后 `normalizePreText` 每行 trim 把行首缩进删掉：RST 嵌套列表（GitHub README `.plain > pre`）译文列丢失缩进层级，对照模式行首与原文对不齐。规格（#106）只要求「逐行折叠行内空白、保留硬换行」，删缩进超出规格；且行为被测试锁定（normalize.test.ts「行首行尾空白去除」断言删除），偏差不可见。

## 根因
`src/dom/normalize.ts` `normalizePreText`：`line.replace(/[ \t]+/g, ' ').trim()` —— 每行 trim 连同缩进一起删；整块 `.trim()` 再删首行缩进与块尾换行。决策（#141）：**保留缩进**，译文列与原文行首对齐、嵌套结构不丢。

## 修复
- `normalizePreText`：只折叠缩进**之后**的连续空白（`[ \t]+` → 空格）、去行尾空白；行首缩进原样保留；整块只 `trimEnd()`（首行缩进保留、块尾换行去除）
- 函数注释补充设计意图（#141）
- 测试：原「行首行尾空白去除」改为断言缩进保留；新增「嵌套列表缩进保留」「整块首行缩进/块尾换行」2 条用例

## 验证
- vitest：**324/324 通过**（322 + 新增 2，无其他模块依赖旧行为）
- `pnpm test:all` 全绿
- 版本：0.6.52 → 0.6.53

Closes #141