### PR TITLE
test(engines): 真实引擎 HTTP 路径 fetch-stub 单测，行覆盖 45%→95%+（#135）

### DIFF
--- a/docs/testing/unit/engines/bing-edge-http.test.ts
+++ b/docs/testing/unit/engines/bing-edge-http.test.ts
@@ -1,0 +1,232 @@
+/**
+ * engines/bing-edge.ts — 真实 HTTP 路径单元测试（#135）
+ *
+ * fetch stub 断言：JWT 获取与缓存 / 过期重取 / 401 清缓存、
+ * 翻译 POST 的 URL / 头 / 体、响应解析、非 200 降级。
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const AUTH_URL = 'https://edge.microsoft.com/translate/auth';
+const TRANS_URL = 'https://api-edge.cognitive.microsofttranslator.com/translate';
+
+/** 构造 payload 可控的假 JWT */
+function fakeJwt(exp: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ exp })).toString('base64url');
+  return `${header}.${payload}.sig`;
+}
+
+const futureJwt = fakeJwt(Math.floor(Date.now() / 1000) + 3600);
+const expiredJwt = fakeJwt(Math.floor(Date.now() / 1000) - 3600);
+
+const okTrans = (translations: string[], lang?: string) => {
+  const rows: Array<Record<string, unknown>> = translations.map((text) => ({
+    translations: [{ text }],
+  }));
+  if (lang) rows[0] = { ...rows[0]!, detectedLanguage: { language: lang } };
+  return new Response(JSON.stringify(rows), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+};
+
+/** 按调用序号编排响应的 fetch stub（每次调用返回全新 Response，避免 body 复用） */
+function scriptedFetch(
+  script: Array<(call: number, url: string) => Response>,
+): ReturnType<typeof vi.fn> {
+  let n = 0;
+  return vi.fn().mockImplementation(async (url: string) => {
+    const handler = script[Math.min(n, script.length - 1)]!;
+    n++;
+    return handler(n, String(url));
+  });
+}
+
+describe('bing-edge HTTP 路径', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  test('成功：先取 JWT，再 POST 翻译（URL / 头 / 体断言）', async () => {
+    const fetchMock = scriptedFetch([
+      () => new Response(futureJwt, { status: 200 }),
+      () => okTrans(['你好', '世界'], 'en'),
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { bingEdge } = await import('~/src/engines/bing-edge');
+    const resp = await bingEdge.translate({ texts: ['Hello', 'World'], from: 'en', to: 'zh-CN' });
+
+    expect(resp.translations).toEqual(['你好', '世界']);
+    expect(resp.detectedFrom).toBe('en');
+
+    // auth 请求：GET 无头
+    expect(String(fetchMock.mock.calls[0]![0])).toBe(AUTH_URL);
+    // 翻译请求
+    const [transUrl, transInit] = fetchMock.mock.calls[1]!;
+    const url = new URL(String(transUrl));
+    expect(`${url.origin}${url.pathname}`).toBe(TRANS_URL);
+    expect(url.searchParams.get('from')).toBe('en');
+    expect(url.searchParams.get('to')).toBe('zh-CN');
+    expect(url.searchParams.get('api-version')).toBe('3.0');
+    expect(url.searchParams.get('textType')).toBe('html');
+    expect((transInit as RequestInit).method).toBe('POST');
+    expect((transInit as RequestInit).headers).toMatchObject({
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${futureJwt}`,
+    });
+    expect(JSON.parse((transInit as RequestInit).body as string)).toEqual([
+      { Text: 'Hello' },
+      { Text: 'World' },
+    ]);
+  });
+
+  test('from=auto → from 参数为空字符串', async () => {
+    const fetchMock = scriptedFetch([
+      () => new Response(futureJwt, { status: 200 }),
+      () => okTrans(['你好']),
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { bingEdge } = await import('~/src/engines/bing-edge');
+    await bingEdge.translate({ texts: ['Hello'], from: 'auto', to: 'zh' });
+
+    const url = new URL(String(fetchMock.mock.calls[1]![0]));
+    expect(url.searchParams.get('from')).toBe('');
+    expect(url.searchParams.has('from')).toBe(true);
+  });
+
+  test('JWT 缓存：两次翻译只取一次 auth', async () => {
+    const fetchMock = scriptedFetch([
+      () => new Response(futureJwt, { status: 200 }),
+      () => okTrans(['甲']),
+      () => okTrans(['乙']),
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { bingEdge } = await import('~/src/engines/bing-edge');
+    await bingEdge.translate({ texts: ['a'], from: 'auto', to: 'zh' });
+    await bingEdge.translate({ texts: ['b'], from: 'auto', to: 'zh' });
+
+    expect(String(fetchMock.mock.calls[0]![0])).toBe(AUTH_URL);
+    expect(String(fetchMock.mock.calls[1]![0])).toContain('/translate');
+    expect(String(fetchMock.mock.calls[2]![0])).toContain('/translate');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  test('JWT 过期（服务端下发过期 JWT，缓存后重取）→ 再次翻译重新取 auth', async () => {
+    // 首次 getJwt 不做有效期校验（校验只在命中缓存时发生），
+    // 过期 JWT 靠翻译 401 兜底。此处直接验证缓存命中过期 JWT → 重取。
+    const fetchMock = scriptedFetch([
+      () => new Response(expiredJwt, { status: 200 }),
+      () => okTrans(['甲']),
+      () => new Response(futureJwt, { status: 200 }),
+      () => okTrans(['乙']),
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { bingEdge } = await import('~/src/engines/bing-edge');
+    // 第一次：拿到过期 JWT（引擎不校验新取的值），翻译成功
+    await bingEdge.translate({ texts: ['a'], from: 'auto', to: 'zh' });
+    // 第二次：缓存命中过期 JWT → isExpired=true → 重新取 auth
+    await bingEdge.translate({ texts: ['b'], from: 'auto', to: 'zh' });
+
+    const authCalls = fetchMock.mock.calls.filter((c) => String(c[0]) === AUTH_URL);
+    expect(authCalls).toHaveLength(2);
+  });
+
+  test('服务端返回过期 JWT → 翻译 401 → 清缓存 → 下次重取恢复', async () => {
+    const fetchMock = scriptedFetch([
+      () => new Response(expiredJwt, { status: 200 }),
+      () => new Response('Unauthorized', { status: 401 }),
+      () => new Response(futureJwt, { status: 200 }),
+      () => okTrans(['你好']),
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { bingEdge } = await import('~/src/engines/bing-edge');
+    await expect(
+      bingEdge.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({ retryable: true, message: 'HTTP 401' });
+    const resp = await bingEdge.translate({ texts: ['a'], from: 'auto', to: 'zh' });
+    expect(resp.translations).toEqual(['你好']);
+
+    const authCalls = fetchMock.mock.calls.filter((c) => String(c[0]) === AUTH_URL);
+    expect(authCalls).toHaveLength(2);
+  });
+
+  test('翻译 401 → 清空 JWT 缓存，下次重新取 auth', async () => {
+    const fetchMock = scriptedFetch([
+      () => new Response(futureJwt, { status: 200 }),
+      () => new Response('Unauthorized', { status: 401 }),
+      () => new Response(futureJwt, { status: 200 }),
+      () => okTrans(['你好']),
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { bingEdge } = await import('~/src/engines/bing-edge');
+    await expect(
+      bingEdge.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({ name: 'EngineError', retryable: true, message: 'HTTP 401' });
+    // 缓存已清 → 第二次翻译重新取 auth
+    const resp = await bingEdge.translate({ texts: ['a'], from: 'auto', to: 'zh' });
+    expect(resp.translations).toEqual(['你好']);
+
+    const authCalls = fetchMock.mock.calls.filter((c) => String(c[0]) === AUTH_URL);
+    expect(authCalls).toHaveLength(2);
+  });
+
+  test('auth 非 200 → EngineError（retryable）', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('err', { status: 500 })));
+    const { bingEdge } = await import('~/src/engines/bing-edge');
+    await expect(
+      bingEdge.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({ engineId: 'bing-edge', retryable: true, message: 'auth HTTP 500' });
+  });
+
+  test('翻译非 200 → EngineError（retryable）', async () => {
+    const fetchMock = scriptedFetch([
+      () => new Response(futureJwt, { status: 200 }),
+      () => new Response('err', { status: 429 }),
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { bingEdge } = await import('~/src/engines/bing-edge');
+    await expect(
+      bingEdge.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({ retryable: true, message: 'HTTP 429' });
+  });
+
+  test('坏 JSON → 抛错', async () => {
+    const fetchMock = scriptedFetch([
+      () => new Response(futureJwt, { status: 200 }),
+      () => new Response('not json', { status: 200 }),
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { bingEdge } = await import('~/src/engines/bing-edge');
+    await expect(
+      bingEdge.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toThrow();
+  });
+
+  test('坏 JWT 入缓存 → 下次翻译 isExpired 判定过期重取', async () => {
+    // 'not-a-jwt' 无法解析 exp → isExpired 走 catch 返回 true（视为过期）
+    const fetchMock = scriptedFetch([
+      () => new Response('not-a-jwt', { status: 200 }),
+      () => okTrans(['甲']),
+      () => new Response(futureJwt, { status: 200 }),
+      () => okTrans(['乙']),
+    ]);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { bingEdge } = await import('~/src/engines/bing-edge');
+    await bingEdge.translate({ texts: ['a'], from: 'auto', to: 'zh' });
+    await bingEdge.translate({ texts: ['b'], from: 'auto', to: 'zh' });
+
+    const authCalls = fetchMock.mock.calls.filter((c) => String(c[0]) === AUTH_URL);
+    expect(authCalls).toHaveLength(2);
+  });
+});

--- a/docs/testing/unit/engines/deepl-http.test.ts
+++ b/docs/testing/unit/engines/deepl-http.test.ts
@@ -1,0 +1,122 @@
+/**
+ * engines/deepl.ts — 真实 HTTP 路径单元测试（#135）
+ *
+ * fetch stub 断言：free/pro 端点选择（:fx 后缀）、form 请求体、
+ * 401/403 key 无效、非 200 降级、响应解析。
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('~/src/storage/keys', () => ({
+  getKey: vi.fn(),
+}));
+
+const okResp = (texts: string[], sourceLang?: string) => {
+  const translations = texts.map((text) => ({
+    text,
+    ...(sourceLang ? { detected_source_language: sourceLang } : {}),
+  }));
+  return new Response(JSON.stringify({ translations }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+};
+
+describe('deepl HTTP 路径', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  test('未配置 key → EngineError（retryable=false）', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue(undefined);
+    const { deepl } = await import('~/src/engines/deepl');
+    await expect(
+      deepl.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({ engineId: 'deepl', retryable: false, message: '未配置 API key' });
+    expect(getKey).toHaveBeenCalledWith('deepl');
+  });
+
+  test('免费 key（:fx）→ api-free 端点；请求体断言', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('abc:fx');
+    const fetchMock = vi.fn().mockResolvedValue(okResp(['你好'], 'EN'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { deepl } = await import('~/src/engines/deepl');
+    const resp = await deepl.translate({ texts: ['Hello', 'World'], from: 'en', to: 'zh-CN' });
+
+    expect(resp.translations).toEqual(['你好']);
+    expect(resp.detectedFrom).toBe('EN');
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe('https://api-free.deepl.com/v2/translate');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: 'DeepL-Auth-Key abc:fx',
+      'Content-Type': 'application/x-www-form-urlencoded',
+    });
+    const body = new URLSearchParams((init as RequestInit).body as string);
+    expect(body.get('target_lang')).toBe('ZH-CN');
+    expect(body.get('source_lang')).toBe('EN');
+    expect(body.getAll('text')).toEqual(['Hello', 'World']);
+  });
+
+  test('普通 key → api.deepl.com 端点', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('pro-key');
+    const fetchMock = vi.fn().mockResolvedValue(okResp(['你好']));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { deepl } = await import('~/src/engines/deepl');
+    await deepl.translate({ texts: ['Hello'], from: 'auto', to: 'zh' });
+    expect(String(fetchMock.mock.calls[0]![0])).toBe('https://api.deepl.com/v2/translate');
+  });
+
+  test('from=auto → 不发送 source_lang；语言码大写化', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+    const fetchMock = vi.fn().mockResolvedValue(okResp(['你好']));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { deepl } = await import('~/src/engines/deepl');
+    await deepl.translate({ texts: ['Hello'], from: 'auto', to: 'en-gb' });
+    const body = new URLSearchParams((fetchMock.mock.calls[0]![1] as RequestInit).body as string);
+    expect(body.get('target_lang')).toBe('EN-GB');
+    expect(body.has('source_lang')).toBe(false);
+  });
+
+  test('401 / 403 → EngineError（retryable=false，key 无效）', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('bad');
+    for (const status of [401, 403]) {
+      vi.resetModules();
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('err', { status })));
+      const { deepl } = await import('~/src/engines/deepl');
+      await expect(
+        deepl.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+      ).rejects.toMatchObject({ retryable: false, message: 'API key 无效' });
+    }
+  });
+
+  test('其他非 200 → EngineError（retryable）', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('err', { status: 456 })));
+    const { deepl } = await import('~/src/engines/deepl');
+    await expect(
+      deepl.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({ retryable: true, message: 'HTTP 456' });
+  });
+
+  test('坏 JSON → 抛错', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('oops', { status: 200 })));
+    const { deepl } = await import('~/src/engines/deepl');
+    await expect(
+      deepl.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toThrow();
+  });
+});

--- a/docs/testing/unit/engines/e2e-mock.test.ts
+++ b/docs/testing/unit/engines/e2e-mock.test.ts
@@ -1,0 +1,146 @@
+/**
+ * engines/e2e-mock.ts — mock 包裹层单元测试（#135）
+ *
+ * 验证：描述符安装 / 幂等包裹、各类故障模式（failOnce / fail /
+ * failTexts）、echoTargetLang、delayMs、非 Google URL 透传、
+ * storage 自愈路径（ensureE2EMock）。
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const G_URL =
+  'https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=zh&q=Hello';
+const OTHER_URL = 'https://example.com/x';
+
+/** 本地 storage 替代实现（setup 的 set 不回调，applyE2EMock 会挂起） */
+function installStorageStub(): Map<string, unknown> {
+  const store = new Map<string, unknown>();
+  const area = chrome.storage.local as unknown as {
+    get: (keys: string) => Promise<Record<string, unknown>>;
+    set: (
+      items: Record<string, unknown>,
+      cb?: () => void,
+    ) => Promise<void>;
+  };
+  area.get = vi.fn((keys: string) => Promise.resolve({ [keys]: store.get(keys) }));
+  area.set = vi.fn((items: Record<string, unknown>, cb?: () => void) => {
+    for (const [k, v] of Object.entries(items)) store.set(k, v);
+    cb?.();
+    return Promise.resolve();
+  });
+  return store;
+}
+
+describe('e2e-mock', () => {
+  let realFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    installStorageStub();
+    realFetch = vi.fn().mockResolvedValue(new Response('real', { status: 200 }));
+    (self as unknown as { fetch: unknown }).fetch = realFetch;
+  });
+
+  afterEach(() => {
+    // 注意：不能用 vi.unstubAllGlobals() —— 会连 setup.ts stub 的 chrome 一起清掉
+    delete (self as unknown as { fetch?: unknown }).fetch;
+  });
+
+  test('未配置 mock → ensureE2EMock 不安装包裹层，请求透传', async () => {
+    const { ensureE2EMock } = await import('~/src/engines/e2e-mock');
+    await ensureE2EMock();
+    const resp = await fetch(G_URL);
+    expect(resp.status).toBe(200);
+    expect(realFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('applyE2EMock → Google URL 命中 mock，其他 URL 透传', async () => {
+    const { applyE2EMock } = await import('~/src/engines/e2e-mock');
+    await applyE2EMock({ prefix: '【译】' });
+
+    const resp = await fetch(G_URL);
+    const body = await resp.json();
+    expect(body[0][0][0]).toBe('【译】Hello');
+    expect(realFetch).not.toHaveBeenCalled();
+
+    await fetch(OTHER_URL);
+    expect(realFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('failOnce：首次 500，之后自动恢复', async () => {
+    const { applyE2EMock, getE2EMockStats } = await import('~/src/engines/e2e-mock');
+    await applyE2EMock({ failOnce: true });
+
+    const r1 = await fetch(G_URL);
+    expect(r1.status).toBe(500);
+    const r2 = await fetch(G_URL);
+    expect(r2.status).toBe(200);
+    expect(getE2EMockStats().failOnceServed).toBe(1);
+  });
+
+  test('fail：全部请求 500，计数可断言', async () => {
+    const { applyE2EMock, getE2EMockStats } = await import('~/src/engines/e2e-mock');
+    await applyE2EMock({ fail: true });
+
+    const r1 = await fetch(G_URL);
+    const r2 = await fetch(G_URL);
+    expect(r1.status).toBe(500);
+    expect(r2.status).toBe(500);
+    expect(getE2EMockStats().failServed).toBe(2);
+  });
+
+  test('failTexts：命中文本 500，其余正常', async () => {
+    const { applyE2EMock, getE2EMockStats } = await import('~/src/engines/e2e-mock');
+    await applyE2EMock({ failTexts: ['Hello'] });
+
+    const bad = await fetch(G_URL);
+    expect(bad.status).toBe(500);
+    const ok = await fetch(
+      'https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=zh&q=World',
+    );
+    expect(ok.status).toBe(200);
+    expect(getE2EMockStats().failTextsServed).toBe(1);
+  });
+
+  test('echoTargetLang：响应带 [tl=] 标记', async () => {
+    const { applyE2EMock } = await import('~/src/engines/e2e-mock');
+    await applyE2EMock({ echoTargetLang: true });
+
+    const resp = await fetch(G_URL);
+    const body = await resp.json();
+    expect(body[0][0][0]).toBe('【译】Hello [tl=zh]');
+  });
+
+  test('delayMs：响应延迟生效', async () => {
+    const { applyE2EMock } = await import('~/src/engines/e2e-mock');
+    await applyE2EMock({ delayMs: 60 });
+
+    const t0 = Date.now();
+    await fetch(G_URL);
+    expect(Date.now() - t0).toBeGreaterThanOrEqual(50);
+  });
+
+  test('重复安装幂等：包裹层不叠加', async () => {
+    const { applyE2EMock } = await import('~/src/engines/e2e-mock');
+    await applyE2EMock({ prefix: 'A' });
+    await applyE2EMock({ prefix: 'B' });
+
+    const resp = await fetch(G_URL);
+    const body = await resp.json();
+    expect(body[0][0][0]).toBe('BHello');
+    expect(realFetch).not.toHaveBeenCalled();
+  });
+
+  test('ensureE2EMock：从 storage 读取描述符并安装（SW 自愈路径）', async () => {
+    const { ensureE2EMock, applyE2EMock } = await import('~/src/engines/e2e-mock');
+    // 模拟 fixture 已把描述符写入 storage
+    await applyE2EMock({ prefix: '【存】' });
+    // 模拟 SW 实例被替换：fetch 还原为真实 fetch，activeCfg 丢失
+    delete (self as unknown as { fetch?: unknown }).fetch;
+    (self as unknown as { fetch: unknown }).fetch = realFetch;
+
+    await ensureE2EMock();
+    const resp = await fetch(G_URL);
+    const body = await resp.json();
+    expect(body[0][0][0]).toBe('【存】Hello');
+    expect(realFetch).not.toHaveBeenCalled();
+  });
+});

--- a/docs/testing/unit/engines/gemini-http.test.ts
+++ b/docs/testing/unit/engines/gemini-http.test.ts
@@ -1,0 +1,125 @@
+/**
+ * engines/gemini.ts — 真实 HTTP 路径单元测试（#135）
+ *
+ * fetch stub 断言：端点 / 请求头 / 请求体、编号 prompt、
+ * 400/403 key 无效、非 200 降级、响应解析。
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('~/src/storage/settings', () => ({
+  getSettings: vi.fn(() => ({ models: { gemini: 'gemini-2.5-flash' } })),
+}));
+
+vi.mock('~/src/storage/keys', () => ({
+  getKey: vi.fn(),
+}));
+
+const okResp = (text: string) =>
+  new Response(JSON.stringify({ candidates: [{ content: { parts: [{ text }] } }] }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+
+describe('gemini HTTP 路径', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  test('未配置 key → EngineError（retryable=false）', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue(undefined);
+    const { gemini } = await import('~/src/engines/gemini');
+    await expect(
+      gemini.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({ engineId: 'gemini', retryable: false, message: '未配置 API key' });
+    expect(getKey).toHaveBeenCalledWith('gemini');
+  });
+
+  test('成功：端点 / 头 / 体断言 + 编号解析', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('test-key');
+    const fetchMock = vi.fn().mockResolvedValue(okResp('1. 你好\n2. 世界'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { gemini } = await import('~/src/engines/gemini');
+    const resp = await gemini.translate({ texts: ['Hello', 'World'], from: 'en', to: 'zh-CN' });
+
+    expect(resp.translations).toEqual(['你好', '世界']);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent',
+    );
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({
+      'Content-Type': 'application/json',
+      'x-goog-api-key': 'test-key',
+    });
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.contents[0].parts[0].text).toContain('1. Hello');
+    expect(body.contents[0].parts[0].text).toContain('2. World');
+    expect(body.contents[0].parts[0].text).toContain('源语言：en');
+    expect(body.generationConfig).toEqual({ temperature: 0 });
+  });
+
+  test('from=auto → prompt 不带源语言', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+    const fetchMock = vi.fn().mockResolvedValue(okResp('1. 你好'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { gemini } = await import('~/src/engines/gemini');
+    await gemini.translate({ texts: ['Hello'], from: 'auto', to: 'zh' });
+    const body = JSON.parse((fetchMock.mock.calls[0]![1] as RequestInit).body as string);
+    expect(body.contents[0].parts[0].text).not.toContain('源语言');
+  });
+
+  test('400 / 403 → EngineError（retryable=false，key 无效）', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('bad');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('err', { status: 400 })));
+    const { gemini } = await import('~/src/engines/gemini');
+    await expect(
+      gemini.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({ retryable: false, message: 'API key 无效' });
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('err', { status: 403 })));
+    const { gemini: gemini2 } = await import('~/src/engines/gemini');
+    await expect(
+      gemini2.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({ retryable: false, message: 'API key 无效' });
+  });
+
+  test('其他非 200 → EngineError（retryable）', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('err', { status: 503 })));
+    const { gemini } = await import('~/src/engines/gemini');
+    await expect(
+      gemini.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({ retryable: true, message: 'HTTP 503' });
+  });
+
+  test('空 candidates → 长度一致的空白译文数组', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
+    );
+    const { gemini } = await import('~/src/engines/gemini');
+    const resp = await gemini.translate({ texts: ['a', 'b'], from: 'auto', to: 'zh' });
+    expect(resp.translations).toEqual(['', '']);
+  });
+
+  test('坏 JSON → 抛错', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('oops', { status: 200 })));
+    const { gemini } = await import('~/src/engines/gemini');
+    await expect(
+      gemini.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toThrow();
+  });
+});

--- a/docs/testing/unit/engines/google-web-http.test.ts
+++ b/docs/testing/unit/engines/google-web-http.test.ts
@@ -1,0 +1,159 @@
+/**
+ * engines/google-web.ts — 真实 HTTP 路径单元测试（#135）
+ *
+ * 用 fetch stub 断言：请求 URL / query 参数、分句响应解析、
+ * 非 200 / 坏 JSON 降级、部分失败槽位、并发闸门。
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('~/src/storage/settings', () => ({
+  getSettings: vi.fn(() => ({ maxConcurrency: 6 })),
+  onSettingsChanged: vi.fn(() => () => {}),
+}));
+
+const G_API = 'https://translate.googleapis.com/translate_a/single';
+
+function okResponse(segments: unknown[][]): Response {
+  return new Response(JSON.stringify([segments, null, 'en']), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('google-web HTTP 路径', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  test('成功：URL 参数正确 + 分句拼接为整段译文', async () => {
+    const byQ: Record<string, string> = { Hello: '你好', World: '世界' };
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      const q = new URL(String(url)).searchParams.get('q');
+      return Promise.resolve(okResponse([[byQ[q!] ?? q!, '', null, null, 1]]));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { googleWeb } = await import('~/src/engines/google-web');
+    const resp = await googleWeb.translate({
+      texts: ['Hello', 'World'],
+      from: 'auto',
+      to: 'zh-CN',
+    });
+
+    expect(resp.translations).toEqual(['你好', '世界']);
+    expect(resp.failedIndices).toBeUndefined();
+
+    const url = new URL(String(fetchMock.mock.calls[0]![0]));
+    expect(`${url.origin}${url.pathname}`).toBe(G_API);
+    expect(url.searchParams.get('client')).toBe('gtx');
+    expect(url.searchParams.get('sl')).toBe('auto');
+    expect(url.searchParams.get('tl')).toBe('zh-CN');
+    expect(url.searchParams.get('dt')).toBe('t');
+    expect(url.searchParams.get('strip')).toBe('1');
+    expect(url.searchParams.get('nonced')).toBe('1');
+    expect(url.searchParams.get('q')).toBe('Hello');
+  });
+
+  test('批量：每个文本一个请求，q 参数一一对应', async () => {
+    const bodies = ['甲', '乙', '丙'];
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      const q = new URL(String(url)).searchParams.get('q');
+      return Promise.resolve(okResponse([[`${q}→${bodies.shift()}`]]));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { googleWeb } = await import('~/src/engines/google-web');
+    const resp = await googleWeb.translate({
+      texts: ['a', 'b', 'c'],
+      from: 'en',
+      to: 'zh-CN',
+    });
+
+    expect(resp.translations).toEqual(['a→甲', 'b→乙', 'c→丙']);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const qs = fetchMock.mock.calls.map((c) => new URL(String(c[0])).searchParams.get('q'));
+    expect(qs).toEqual(['a', 'b', 'c']);
+  });
+
+  test('空分句项被忽略，不产生空译文', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      okResponse([['有效', '', null, null, 1], [], [null, '', null, null, 1]]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { googleWeb } = await import('~/src/engines/google-web');
+    const resp = await googleWeb.translate({ texts: ['x'], from: 'auto', to: 'zh' });
+    expect(resp.translations).toEqual(['有效']);
+  });
+
+  test('非 200 → 全部失败抛 EngineError（retryable）', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('err', { status: 503 })));
+    const { googleWeb } = await import('~/src/engines/google-web');
+    await expect(
+      googleWeb.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({ name: 'EngineError', engineId: 'google-web', retryable: true });
+  });
+
+  test('坏 JSON → 全部失败抛 EngineError', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('<html>', { status: 200 })));
+    const { googleWeb } = await import('~/src/engines/google-web');
+    await expect(
+      googleWeb.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({ name: 'EngineError', retryable: true });
+  });
+
+  test('部分失败：失败槽位进 failedIndices，成功槽位保留', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okResponse([['你好']]))
+      .mockRejectedValueOnce(new TypeError('fetch failed'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { googleWeb } = await import('~/src/engines/google-web');
+    const resp = await googleWeb.translate({ texts: ['Hello', 'Boom'], from: 'auto', to: 'zh-CN' });
+    expect(resp.translations).toEqual(['你好', '']);
+    expect(resp.failedIndices).toEqual([1]);
+  });
+
+  test('全部失败（含混合原因）→ 抛 EngineError 让 router 切换', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('err', { status: 500 }))
+      .mockRejectedValueOnce(new TypeError('fetch failed'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { googleWeb } = await import('~/src/engines/google-web');
+    await expect(
+      googleWeb.translate({ texts: ['a', 'b'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({ retryable: true, message: '全部 2 条翻译失败' });
+  });
+
+  test('并发闸门：maxConcurrency 生效（设置读取于首次翻译）', async () => {
+    const { getSettings } = await import('~/src/storage/settings');
+    vi.mocked(getSettings).mockReturnValue({ maxConcurrency: 2 } as never);
+
+    let inFlight = 0;
+    let peak = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 10));
+      inFlight--;
+      return okResponse([['t']]);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { googleWeb } = await import('~/src/engines/google-web');
+    const resp = await googleWeb.translate({
+      texts: ['1', '2', '3', '4', '5'],
+      from: 'auto',
+      to: 'zh',
+    });
+
+    expect(resp.translations).toEqual(['t', 't', 't', 't', 't']);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(peak).toBeLessThanOrEqual(2);
+  });
+});

--- a/docs/testing/unit/engines/openai-http.test.ts
+++ b/docs/testing/unit/engines/openai-http.test.ts
@@ -1,0 +1,123 @@
+/**
+ * engines/openai.ts — 真实 HTTP 路径单元测试（#135）
+ *
+ * fetch stub 断言：端点 / 授权头 / 请求体、编号 prompt 与换行归一化、
+ * 401/403 key 无效、非 200 降级、响应解析。
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('~/src/storage/settings', () => ({
+  getSettings: vi.fn(() => ({ models: { openai: 'gpt-4o' } })),
+}));
+
+vi.mock('~/src/storage/keys', () => ({
+  getKey: vi.fn(),
+}));
+
+const okResp = (text: string) =>
+  new Response(JSON.stringify({ choices: [{ message: { content: text } }] }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+
+describe('openai HTTP 路径', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  test('未配置 key → EngineError（retryable=false）', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue(undefined);
+    const { openai } = await import('~/src/engines/openai');
+    await expect(
+      openai.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({ engineId: 'openai', retryable: false, message: '未配置 API key' });
+    expect(getKey).toHaveBeenCalledWith('openai');
+  });
+
+  test('成功：端点 / 头 / 体断言 + 编号解析', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('sk-test');
+    const fetchMock = vi.fn().mockResolvedValue(okResp('1. 你好\n2. 世界'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { openai } = await import('~/src/engines/openai');
+    const resp = await openai.translate({ texts: ['Hello', 'World'], from: 'en', to: 'zh-CN' });
+
+    expect(resp.translations).toEqual(['你好', '世界']);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe('https://api.openai.com/v1/chat/completions');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer sk-test',
+    });
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.model).toBe('gpt-4o');
+    expect(body.temperature).toBe(0);
+    expect(body.messages[0].role).toBe('user');
+    expect(body.messages[0].content).toContain('1. Hello');
+    expect(body.messages[0].content).toContain('2. World');
+    expect(body.messages[0].content).toContain('源语言：en');
+  });
+
+  test('文本自带换行被归一化，不撑破编号结构', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('sk-test');
+    const fetchMock = vi.fn().mockResolvedValue(okResp('1. 你好'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { openai } = await import('~/src/engines/openai');
+    await openai.translate({ texts: ['line1\nline2'], from: 'auto', to: 'zh' });
+    const body = JSON.parse((fetchMock.mock.calls[0]![1] as RequestInit).body as string);
+    expect(body.messages[0].content).toContain('1. line1 line2');
+    expect(body.messages[0].content).not.toContain('\nline');
+  });
+
+  test('401 / 403 → EngineError（retryable=false，key 无效）', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('bad');
+    for (const status of [401, 403]) {
+      vi.resetModules();
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('err', { status })));
+      const { openai } = await import('~/src/engines/openai');
+      await expect(
+        openai.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+      ).rejects.toMatchObject({ retryable: false, message: 'API key 无效' });
+    }
+  });
+
+  test('其他非 200 → EngineError（retryable）', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('err', { status: 429 })));
+    const { openai } = await import('~/src/engines/openai');
+    await expect(
+      openai.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({ retryable: true, message: 'HTTP 429' });
+  });
+
+  test('空 choices → 长度一致的空白译文数组', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
+    );
+    const { openai } = await import('~/src/engines/openai');
+    const resp = await openai.translate({ texts: ['a', 'b'], from: 'auto', to: 'zh' });
+    expect(resp.translations).toEqual(['', '']);
+  });
+
+  test('坏 JSON → 抛错', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('oops', { status: 200 })));
+    const { openai } = await import('~/src/engines/openai');
+    await expect(
+      openai.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toThrow();
+  });
+});

--- a/docs/testing/vitest.config.ts
+++ b/docs/testing/vitest.config.ts
@@ -31,8 +31,9 @@ export default defineConfig({
       ],
       // #134：门槛键必须是 glob（裸目录键不匹配任何文件，门槛从未生效）。
       // 值取当前实际覆盖率的现实下限（再低会无声失效，再高会立即红灯）。
+      // #135：真实引擎 HTTP 路径补测试后 engines 已达 95%+，门槛提到 85%。
       thresholds: {
-        'src/engines/**': { lines: 45 },
+        'src/engines/**': { lines: 85 },
         'src/dom/**': { lines: 77 },
         'src/storage/**': { lines: 97 },
         'src/hotkeys/**': { lines: 15 },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.55",
+  "version": "0.6.56",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## 问题
src/engines/ 真实引擎的请求构造/响应解析/错误处理路径几乎无测试覆盖（google-web 19.7% / bing-edge 20.7% / gemini 26.2% / openai 38.5% / deepl 52.9% / e2e-mock 0%）。现有测试全部走 mock 路径，mock 与真实 HTTP 是两套代码。

## 根因
引擎测试仅覆盖 router 分发与 mock 注入；真实 fetch 路径没有 mock-fetch 单测。

## 修复
新增 6 个 fetch-stub 单测文件（docs/testing/unit/engines/）：
- google-web-http.test.ts：URL/query 参数断言、分句拼接、非 200、坏 JSON、部分失败槽位、并发闸门
- bing-edge-http.test.ts：JWT 获取/缓存/过期重取/401 清缓存、POST 头体断言、降级
- gemini-http.test.ts / openai-http.test.ts：key 缺失、端点/头/体、400/401/403 key 无效、编号解析、坏 JSON
- deepl-http.test.ts：:fx 免费端点选择、form 体、语言码大写化、401/403、解析
- e2e-mock.test.ts：安装/幂等包裹、failOnce/fail/failTexts、echoTargetLang、delayMs、storage 自愈路径

真实引擎行覆盖提升至 95-100%，engines 门槛 45%→85%（#134 门槛真正生效）。版本号 0.6.55→0.6.56。

## 验证
- pnpm typecheck 通过
- pnpm test:coverage 372/372 通过，engines 覆盖门槛 85% 达标