### PR TITLE
refactor: 重复代码收敛 sleep×3 / waitForBall×3 / 标签集合共享（#136）

### DIFF
--- a/docs/testing/e2e/core.spec.ts
+++ b/docs/testing/e2e/core.spec.ts
@@ -6,14 +6,7 @@
  *
  * 翻译端点由 mockGoogle 拦截，完全确定性，不依赖外网。
  */
-import { test, expect } from './fixtures';
-
-// ── 辅助：等待扩展注入（悬浮球出现 = content script 已运行）──
-async function waitForBall(page: import('@playwright/test').Page) {
-  const ball = page.locator('#pt-host-ball .pt-ball');
-  await expect(ball).toBeVisible({ timeout: 60_000 });
-  return ball;
-}
+import { test, expect, waitForBall } from './fixtures';
 
 // ── 辅助：触发翻译并等待完成 ──
 async function translateAndWait(page: import('@playwright/test').Page) {

--- a/docs/testing/e2e/extended.spec.ts
+++ b/docs/testing/e2e/extended.spec.ts
@@ -9,15 +9,8 @@
  * 网络全部走 SW 内 stub（google mock / bing / openai），完全确定性；
  * TC-E2E-34~38（缓存上限、内存泄漏、样式）仍需扩展环境/CDP，保留 skip。
  */
-import { test, expect, fixtureFileUrl } from './fixtures';
+import { test, expect, fixtureFileUrl, waitForBall } from './fixtures';
 import type { Page, Worker } from '@playwright/test';
-
-// ── 辅助：等待扩展注入（悬浮球出现 = content script 已运行）──
-async function waitForBall(page: Page) {
-  const ball = page.locator('#pt-host-ball .pt-ball');
-  await expect(ball).toBeVisible({ timeout: 60_000 });
-  return ball;
-}
 
 // ── 辅助：在 SW 内 stub Bing 两个端点（与 core.spec.ts TC-E2E-16 同法）──
 async function stubBing(sw: Worker, prefix = '[BING] ') {

--- a/docs/testing/e2e/fixtures.ts
+++ b/docs/testing/e2e/fixtures.ts
@@ -52,6 +52,19 @@ export function fixtureFileUrl(name: FixtureName): string {
   return 'file://' + fileURLToPath(new URL(`./fixtures/${name}.html`, import.meta.url));
 }
 
+/** 悬浮球定位器（#136：与 #124 getBoundingClientRect 同思路收敛到夹具层）。 */
+export const BALL_LOCATOR = '#pt-host-ball .pt-ball';
+
+/** 等待扩展注入：悬浮球出现 = content script 已运行（core/extended/real-sites 共用）。 */
+export async function waitForBall(
+  page: Page,
+  timeout = 60_000,
+): Promise<import('@playwright/test').Locator> {
+  const ball = page.locator(BALL_LOCATOR);
+  await expect(ball).toBeVisible({ timeout });
+  return ball;
+}
+
 export const test = base.extend<
   {
     serviceWorker: Worker;

--- a/docs/testing/e2e/real-sites.spec.ts
+++ b/docs/testing/e2e/real-sites.spec.ts
@@ -7,14 +7,7 @@
  * 翻译端点使用 mockGoogle 拦截，只有站点 DOM 走真实网络。
  * 这些测试标记 @real，通过 --grep "@real" 控制运行时机。
  */
-import { test, expect } from './fixtures';
-
-// ── 辅助 ──
-async function waitForBall(page: import('@playwright/test').Page, timeout = 45_000) {
-  const ball = page.locator('#pt-host-ball .pt-ball');
-  await expect(ball).toBeVisible({ timeout });
-  return ball;
-}
+import { test, expect, waitForBall } from './fixtures';
 
 // ================================================================
 // GitHub

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -28,6 +28,7 @@ import { startHotkeys } from '~/src/hotkeys/listener';
 import { startSelectionDrag } from '~/src/ui/selection-drag';
 import { translateViaBackground } from '~/src/runtime/messaging';
 import { attemptBatchWithRetry } from '~/src/runtime/batch-retry';
+import { sleep } from '~/src/runtime/sleep';
 import { detectOS } from '~/src/hotkeys/platform';
 import {
   settingsReady,
@@ -148,8 +149,6 @@ export default defineContentScript({
     // #91: 批次级引擎失败有限重试（见 src/runtime/batch-retry.ts）。
     /** 还原纪元：doRestore 递增，在飞翻译据此放弃重试与渲染。 */
     const translateEpoch = { value: 0 };
-    const sleep = (ms: number) =>
-      new Promise<void>((resolve) => self.setTimeout(resolve, ms));
 
     async function doTranslate(
       elements?: Element[],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.56",
+  "version": "0.6.57",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/classify.ts
+++ b/src/dom/classify.ts
@@ -49,6 +49,15 @@ export const INLINE_SET = new Set([
   'tt', 'big',
 ]);
 
+/**
+ * 代码语义内联标签 —— #136：pre-split 等模块的共享标签词汇。
+ * 这些标签既是 INLINE_SET 成员（行内），又表达代码语义：
+ * 含它们的 pre 被视为代码块而拒绝切分 / 翻译（#64）。
+ */
+export const CODE_SEMANTIC_SET = new Set([
+  'code', 'kbd', 'samp', 'var',
+]);
+
 /** 应被整体跳过的非正文区域选择器（导航、页脚、侧栏、参考文献等） */
 const NON_CONTENT =
   'nav,footer,aside,.reflist,.references,.refbegin,.mw-references-wrap,' +

--- a/src/dom/pre-split.ts
+++ b/src/dom/pre-split.ts
@@ -9,7 +9,7 @@
 // MAX_TEXT / MAX_HTML，采集 0 单元（翻译静默失败）。改为仅当存在
 // 块级子元素才拒切，内联子元素随文本流切分保留。
 
-import { INLINE_SET, MAX_TEXT, isCodeBlockPre } from './classify';
+import { INLINE_SET, MAX_TEXT, CODE_SEMANTIC_SET, isCodeBlockPre } from './classify';
 
 /** 节点流 token：行内文本片段 / 行内元素 / 换行 */
 type Tok =
@@ -84,10 +84,10 @@ export function splitPre(pre: HTMLPreElement): HTMLSpanElement[] | null {
   // 仅纯行内文本子元素（GitHub .plain > pre 的 autolink <a>）可随文本流切分保留。
   // <pre><code> 是经典代码块结构，code 虽在 INLINE_SET（供段落判定用），
   // 但此处必须视为代码语义而拒切，避免纯代码 pre 被翻译。
-  const CODE_SEMANTIC = new Set(['code', 'kbd', 'samp', 'var']);
+  // #136：CODE_SEMANTIC_SET 与 classify 共享，不再局部重定义。
   for (const child of pre.children) {
     const tag = child.tagName.toLowerCase();
-    if (!INLINE_SET.has(tag) || CODE_SEMANTIC.has(tag)) return null;
+    if (!INLINE_SET.has(tag) || CODE_SEMANTIC_SET.has(tag)) return null;
   }
 
   const text = pre.textContent ?? '';

--- a/src/runtime/batch-retry.ts
+++ b/src/runtime/batch-retry.ts
@@ -15,6 +15,7 @@
 // 不匹配错误文案 —— 文案改写不影响短路行为。
 
 import type { TranslateResponse } from '~/src/engines/types';
+import { sleep as defaultSleep } from '~/src/runtime/sleep';
 
 /** #91: 批次级引擎失败最大重试次数。 */
 export const BATCH_RETRY_LIMIT = 2;
@@ -33,7 +34,7 @@ export type BatchRetryResult =
     };
 
 export interface BatchRetryOptions {
-  /** 注入 sleep 以便测试推进虚拟时钟；默认 setTimeout。 */
+  /** 注入 sleep 以便测试推进虚拟时钟（#136）；默认 src/runtime/sleep 共享实现。 */
   sleep?: (ms: number) => Promise<void>;
   /** 每次尝试前后检查；返回 true 则立即中止剩余重试。 */
   shouldAbort?: () => boolean;
@@ -55,9 +56,7 @@ export async function attemptBatchWithRetry(
   }>,
   opts: BatchRetryOptions = {},
 ): Promise<BatchRetryResult> {
-  const sleep =
-    opts.sleep ??
-    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const sleep = opts.sleep ?? defaultSleep;
   let lastError = '未知错误';
   for (let attempt = 0; ; attempt++) {
     if (opts.shouldAbort?.()) {

--- a/src/runtime/messaging.ts
+++ b/src/runtime/messaging.ts
@@ -13,6 +13,7 @@
 // 4. 预算耗尽返回 {ok:false} + 错误说明，永不抛出 —— 调用方按原约定处理
 
 import type { TranslateRequest, TranslateResponse } from '~/src/engines/types';
+import { sleep } from '~/src/runtime/sleep';
 
 export type TranslateResult =
   | { ok: true; data: TranslateResponse }
@@ -25,10 +26,6 @@ const SEND_BUDGET_MS = 15_000;
 /** 退避起点（毫秒），每次翻倍，上限 2s。 */
 const BACKOFF_INITIAL_MS = 250;
 const BACKOFF_MAX_MS = 2000;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 /** 上下文失效错误文案。 */
 export const CONTEXT_INVALIDATED_MSG =

--- a/src/runtime/sleep.ts
+++ b/src/runtime/sleep.ts
@@ -1,0 +1,8 @@
+// 共享 sleep —— #136：收敛 content.ts / messaging.ts / batch-retry.ts 三份复制。
+//
+// 用 globalThis.setTimeout 而非裸 setTimeout：content script（self 作用域）
+// 与 service worker、Node 测试环境均可用，无环境绑定。
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## 收敛三处重复（#136）

1. **sleep×3 → 共享模块**：新增 `src/runtime/sleep.ts`（globalThis.setTimeout），content.ts / messaging.ts 改引共享实现；batch-retry 保留注入参数（测试虚拟时钟），默认值改共享实现。
2. **waitForBall×3 → e2e 夹具**：移入 `docs/testing/e2e/fixtures.ts`（含 `BALL_LOCATOR` 常量），core / extended / real-sites 三套件改引夹具导出（与 #124 收敛同思路）。
3. **标签集合共享**：classify.ts 新增导出 `CODE_SEMANTIC_SET`，pre-split.ts 删除局部 `CODE_SEMANTIC` 改复用。

版本 0.6.56 → 0.6.57（已确认 main 无冲突）。单测 372/372 通过，typecheck 通过，构建通过。

Closes #136