### PR TITLE
refactor(runtime): messaging 失效判定改为纯类型化检查，删除 FATAL_CHANNEL_RE 正则（#139）

### DIFF
--- a/docs/testing/unit/runtime/messaging.test.ts
+++ b/docs/testing/unit/runtime/messaging.test.ts
@@ -145,22 +145,33 @@ describe('translateViaBackground — 扩展上下文失效', () => {
     }
   });
 
-  test('chrome.runtime.sendMessage 抛 TypeError（上下文失效形态）→ 同样立即失败', async () => {
+  test('sendMessage 抛 TypeError 且上下文随后失效（传输中失效）→ 同样立即失败', async () => {
+    // #139：失效判定只认结构化状态（chrome.runtime.id 为 null），
+    // 不再匹配错误文案 —— 这里模拟传输中途上下文失效：
+    // 首次检查时上下文仍有效，sendMessage 抛错前把 chrome.runtime 置空。
     vi.useFakeTimers();
+    const savedChrome = (globalThis as { chrome?: unknown }).chrome;
+    const savedRuntime = (savedChrome as { runtime?: unknown }).runtime;
+    (globalThis as { chrome?: unknown }).chrome = { runtime: savedRuntime };
     sendMessage.mockImplementation(async () => {
+      (globalThis as { chrome?: unknown }).chrome = { runtime: undefined };
       throw new TypeError(
         "Cannot read properties of undefined (reading 'sendMessage')",
       );
     });
 
-    const pending = translateViaBackground(PAYLOAD);
-    await vi.advanceTimersByTimeAsync(0);
-    const result = await pending;
+    try {
+      const pending = translateViaBackground(PAYLOAD);
+      await vi.advanceTimersByTimeAsync(0);
+      const result = await pending;
 
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.invalidated).toBe(true);
-      expect(result.error).toContain('已失效');
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.invalidated).toBe(true);
+        expect(result.error).toContain('已失效');
+      }
+    } finally {
+      (globalThis as { chrome?: unknown }).chrome = savedChrome;
     }
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.57",
+  "version": "0.6.58",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/runtime/messaging.ts
+++ b/src/runtime/messaging.ts
@@ -42,9 +42,6 @@ export class ContextInvalidatedError extends Error {
   }
 }
 
-/** 不可恢复的通道错误 —— 重试永远无意义，立即失败并提示用户 */
-const FATAL_CHANNEL_RE = /Extension context invalidated|Cannot read propert/i;
-
 /**
  * 扩展上下文是否已失效。重载 / 更新 / 禁用扩展后，已注入页面的
  * content script 里 chrome.runtime 变为 undefined 且永不恢复 ——
@@ -83,12 +80,13 @@ async function sendWithTransportRetry(
     try {
       resp = await chrome.runtime.sendMessage(msg);
     } catch (e) {
-      const msgText = e instanceof Error ? e.message : String(e);
-      // 不可恢复错误（上下文失效的 TypeError / Chrome 标准错误）
-      if (FATAL_CHANNEL_RE.test(msgText)) {
+      // 类型化判定（#139）：sendMessage 抛错时再查一次上下文是否已失效 ——
+      // 失效是结构化状态（chrome.runtime.id 为 null），不依赖错误文案。
+      // 上下文仍有效则视为可重试的传输层错误（如 SW 监听器未注册）。
+      if (isContextInvalidated()) {
         throw new ContextInvalidatedError();
       }
-      lastError = msgText;
+      lastError = e instanceof Error ? e.message : String(e);
       resp = undefined;
     }
     if (resp !== undefined) return resp;


### PR DESCRIPTION
## 修复
- 删除 `FATAL_CHANNEL_RE` 正则文案匹配
- sendMessage 抛错时改用结构化状态判定：重查 `isContextInvalidated()`（chrome.runtime.id 为 null）判为失效，否则视为可重试传输错误
- 更新单测模拟传输中途失效场景
- 版本号 0.6.57 → 0.6.58

Closes #139