### PR TITLE
fix(deepl): zh-CN/zh-TW 映射 ZH-HANS/ZH-HANT —— 修复默认目标语言下 DeepL 永远 400 静默降级（#155）

### DIFF
--- a/docs/testing/unit/engines/deepl-http.test.ts
+++ b/docs/testing/unit/engines/deepl-http.test.ts
@@ -58,9 +58,28 @@ describe('deepl HTTP 路径', () => {
       'Content-Type': 'application/x-www-form-urlencoded',
     });
     const body = new URLSearchParams((init as RequestInit).body as string);
-    expect(body.get('target_lang')).toBe('ZH-CN');
+    expect(body.get('target_lang')).toBe('ZH-HANS');
     expect(body.get('source_lang')).toBe('EN');
     expect(body.getAll('text')).toEqual(['Hello', 'World']);
+  });
+
+  test('zh-CN → ZH-HANS、zh-TW → ZH-HANT（#155：DeepL 不接受带国家后缀中文码）', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+    for (const [to, expected] of [
+      ['zh-CN', 'ZH-HANS'],
+      ['zh-TW', 'ZH-HANT'],
+    ] as const) {
+      vi.resetModules();
+      const fetchMock = vi.fn().mockResolvedValue(okResp(['你好']));
+      vi.stubGlobal('fetch', fetchMock);
+      const { deepl } = await import('~/src/engines/deepl');
+      await deepl.translate({ texts: ['Hello'], from: 'auto', to });
+      const body = new URLSearchParams(
+        (fetchMock.mock.calls[0]![1] as RequestInit).body as string,
+      );
+      expect(body.get('target_lang')).toBe(expected);
+    }
   });
 
   test('普通 key → api.deepl.com 端点', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.62",
+  "version": "0.6.63",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/deepl.ts
+++ b/src/engines/deepl.ts
@@ -66,6 +66,9 @@ export const deepl: TranslateEngine = {
     const normalizeLang = (code: string): string => {
       // 'auto' → null（让 DeepL 自动检测）
       if (code === 'auto') return '';
+      // DeepL API v2 不接受带国家后缀的中文码，官方只认 ZH / ZH-HANS / ZH-HANT（#155）
+      if (code === 'zh-CN') return 'ZH-HANS';
+      if (code === 'zh-TW') return 'ZH-HANT';
       return code.toUpperCase();
     };
 


### PR DESCRIPTION
## 修复
- `normalizeLang` 增加中文区域码映射：`zh-CN → ZH-HANS`、`zh-TW → ZH-HANT`（DeepL API v2 官方只认 ZH/ZH-HANS/ZH-HANT，带国家后缀返回 400）
- `supportedLangs` 保持 `zh-CN`/`zh-TW`（UI 码，router 仍判为支持，映射后正常发送）
- 单测：断言 `target_lang=ZH-HANS` / `ZH-HANT`，原 `ZH-CN` 固化断言修正

Closes #155