### PR TITLE
fix(gemini): 拼 prompt 前压掉文本自带换行 —— pre 多行文本译文错位/丢行（#160）

### DIFF
--- a/docs/testing/unit/engines/gemini-http.test.ts
+++ b/docs/testing/unit/engines/gemini-http.test.ts
@@ -75,6 +75,19 @@ describe('gemini HTTP 路径', () => {
     expect(body.contents[0].parts[0].text).not.toContain('源语言');
   });
 
+  test('pre 多行文本换行被归一化，不撑破编号结构（#160）', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+    const fetchMock = vi.fn().mockResolvedValue(okResp('1. 你好'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { gemini } = await import('~/src/engines/gemini');
+    await gemini.translate({ texts: ['line1\nline2'], from: 'auto', to: 'zh' });
+    const body = JSON.parse((fetchMock.mock.calls[0]![1] as RequestInit).body as string);
+    expect(body.contents[0].parts[0].text).toContain('1. line1 line2');
+    expect(body.contents[0].parts[0].text).not.toContain('\nline');
+  });
+
   test('400 / 403 → EngineError（retryable=false，key 无效）', async () => {
     const { getKey } = await import('~/src/storage/keys');
     vi.mocked(getKey).mockResolvedValue('bad');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.63",
+  "version": "0.6.64",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/gemini.ts
+++ b/src/engines/gemini.ts
@@ -3,6 +3,7 @@
 
 import { getKey } from '~/src/storage/keys';
 import { getSettings } from '~/src/storage/settings';
+import { normalizeText } from '~/src/dom/normalize';
 import { EngineError } from './types';
 import { parseNumbered } from './openai';
 import type { TranslateEngine } from './types';
@@ -24,7 +25,11 @@ export const gemini: TranslateEngine = {
     const endpoint =
       `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
 
-    const numbered = texts.map((t, i) => `${i + 1}. ${t}`).join('\n');
+    // 与 openai 相同（#30）：编号结构靠 \n 分隔，文本自带换行会把编号撑破
+    // 导致 LLM 重编号、parseNumbered 回填错位，拼 prompt 前压一次（#160）。
+    const numbered = texts
+      .map((t, i) => `${i + 1}. ${normalizeText(t)}`)
+      .join('\n');
     const prompt =
       `将以下编号文本翻译成${to}${from === 'auto' ? '' : `（源语言：${from}）`}。` +
       `严格保持编号与行数一致，只输出译文，不要解释。\n\n${numbered}`;


### PR DESCRIPTION
## 问题
Gemini 与 OpenAI 使用完全相同的编号批量策略，但只有 openai 在拼 prompt 前调 `normalizeText(t)` 压掉文本自带的 `\n`；gemini 直接拼 `texts.map((t, i) => \`${i + 1}. ${t}\`).join('\n')`，pre 多行文本（如 GitHub README）编号条目被撑破，LLM 重编号后 `parseNumbered` 回填错位/漏行。

## 根因
commit `4ab9410`（fix #30）当时只改了 openai.ts 与采集入口，未覆盖 gemini.ts，属同源遗漏。

## 修复
`gemini.ts` 编号拼接改用 `normalizeText(t)`，与 openai 保持一致；补 pre 多行文本单测。

## 验证
- 单测新增「pre 多行文本换行被归一化，不撑破编号结构」用例：含 `\n` 文本经 gemini 编号后行数与输入一致
- 全套 374 单测通过，typecheck 通过，`pnpm build` 通过
- 版本号 0.6.63 → 0.6.64
