### PR TITLE
fix(observer): flush 去重重叠新增/切块节点 —— 同一文本只发一次翻译请求（#158）

### DIFF
--- a/docs/testing/e2e/core.spec.ts
+++ b/docs/testing/e2e/core.spec.ts
@@ -565,6 +565,60 @@ test.describe('Fixture: pre-blocks', () => {
       }
     });
   });
+
+  test('@core TC-E2E-50: 分步 append + 慢引擎 —— 每单元只发一次请求（#158 回归）', async ({
+    page, serviceWorker, mockGoogle, seedSettings, gotoFixture,
+  }) => {
+    await seedSettings({});
+    // 慢引擎（800ms > 300ms 防抖窗口）：二次 flush 发生时首轮翻译仍在飞，
+    // 修复前同一单元被再次请求（分步 append 祖先+后代 / pre 切块两条路径）
+    await mockGoogle({ prefix: '[MOCK] ', delayMs: 800 });
+    await gotoFixture('basic');
+
+    await translateAndWait(page);
+    const initialDone = await page.locator('[data-pt="done"]').count();
+    const served = () =>
+      serviceWorker.evaluate(() => (self as any).getE2EMockStats().totalServed);
+
+    // 阶段 1：分步 append 容器 + 20 段（同一防抖窗口）。修复前 collect(容器)
+    // 与 collect(每段) 各收集一遍 → 40 单元 → 40 请求；修复后只收容器
+    // 覆盖的子树 → 20 单元 → 20 请求（google-web 每文本一个请求）
+    const before1 = await served();
+    await page.evaluate(() => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      for (let i = 1; i <= 20; i++) {
+        const p = document.createElement('p');
+        p.textContent = `Stepwise paragraph ${i} added after initial translation.`;
+        container.appendChild(p);
+      }
+    });
+    await expect(page.locator('[data-pt="done"]')).toHaveCount(initialDone + 20, { timeout: 30_000 });
+    expect(await served()).toBe(before1 + 20);
+
+    // 阶段 2：分步 append 容器 + 超大纯文本 pre（24 个空行分隔的段落块）。
+    // flush#1 的 collect 同步 splitPre 切出 24 块并收集；切块插入产生的
+    // mutation 若再进 pending，flush#2 会把这些在飞块重复请求 —— 修复后
+    // 忽略 .pt-chunk 自身插入 → 24 单元 → 24 请求
+    const before2 = await served();
+    await page.evaluate(() => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const pre = document.createElement('pre');
+      const para = (i: number) =>
+        Array.from(
+          { length: 5 },
+          (_, j) =>
+            `Pre line ${i * 5 + j} of stepwise appended long plain text document paragraph.`,
+        ).join('\n');
+      pre.textContent = Array.from({ length: 24 }, (_, i) => para(i)).join('\n\n');
+      container.appendChild(pre);
+    });
+    const chunks = page.locator('[data-pt-chunk="1"]');
+    await expect(chunks).toHaveCount(24, { timeout: 30_000 });
+    await expect(chunks.first()).toHaveAttribute('data-pt', 'done');
+    expect(await served()).toBe(before2 + 24);
+  });
 });
 
 test.describe('Fixture: rtl', () => {

--- a/docs/testing/unit/dom/observer.test.ts
+++ b/docs/testing/unit/dom/observer.test.ts
@@ -1,0 +1,93 @@
+/**
+ * dom/observer.ts — 增量补翻采集去重单元测试（#158）
+ *
+ * 覆盖两条系统性重复请求路径：
+ * - 祖先+后代同批 pending：分步 append 容器与子元素落在同一防抖窗口，
+ *   collect(容器) 已覆盖子树，collect(后代) 再收集一遍 → 同一单元重复请求
+ * - pre 切块二次收集：flush#1 的 collect 同步执行 splitPre 插入 .pt-chunk，
+ *   插入产生的 mutation 记录若再进 pending，flush#2 会把未完成翻译的
+ *   每个块再次发请求（真实引擎耗时 > 300ms 必然触发）
+ *
+ * jsdom 无 IntersectionObserver，startObserver 的 startWatching 需要占位 mock。
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mockAllBoundingRects } from '../../setup';
+import { startObserver } from '~/src/dom/observer';
+
+class IOStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+describe('startObserver 采集去重（#158）', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    vi.useFakeTimers();
+    vi.stubGlobal('IntersectionObserver', IOStub);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+  });
+
+  test('祖先+后代同批 pending：只收集祖先覆盖的子树，每单元只回调一次', async () => {
+    const restore = mockAllBoundingRects();
+    try {
+      const seen: Element[] = [];
+      const stop = startObserver((els) => seen.push(...els));
+
+      // 分步 append：容器与子元素落在同一 300ms 防抖窗口
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const p = document.createElement('p');
+      p.textContent = 'stepwise appended paragraph';
+      container.appendChild(p);
+
+      await vi.advanceTimersByTimeAsync(300);
+
+      // 修复前：collect(container) 与 collect(p) 各收集一次 p → 同一文本两条请求
+      expect(seen).toHaveLength(1);
+      expect(seen[0]).toBe(p);
+
+      stop();
+    } finally {
+      restore();
+    }
+  });
+
+  test('pre 切块产生的 mutation 不进 pending：不二次收集未完成翻译的块', async () => {
+    const restore = mockAllBoundingRects();
+    try {
+      const seen: Element[] = [];
+      const stop = startObserver((els) => seen.push(...els));
+
+      // 超长纯文本 pre（> MAX_TEXT），段落间空行分隔 → splitPre 切出多个 .pt-chunk
+      const para = (i: number) =>
+        Array.from({ length: 5 }, (_, j) => `Line ${i * 5 + j} of paragraph ${i} in a long plain text document.`).join('\n');
+      const pre = document.createElement('pre');
+      pre.textContent = Array.from({ length: 24 }, (_, i) => para(i)).join('\n\n');
+      document.body.appendChild(pre);
+
+      // flush#1：collect 同步切块并收集全部块 → 一次回调
+      await vi.advanceTimersByTimeAsync(300);
+      expect(seen.length).toBeGreaterThan(1);
+      const first = new Set(seen);
+
+      // 再等一个防抖窗口：切块插入的 mutation 若进 pending 会触发 flush#2
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(seen.length).toBe(first.size);
+
+      // 每块恰好一次
+      for (const el of first) {
+        expect(seen.filter((x) => x === el)).toHaveLength(1);
+      }
+
+      stop();
+    } finally {
+      restore();
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.64",
+  "version": "0.6.65",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/observer.ts
+++ b/src/dom/observer.ts
@@ -122,9 +122,30 @@ export function startObserver(
     timer = undefined;
     const batch = pending;
     pending = [];
-    const found = batch.flatMap((n) =>
-      n.nodeType === Node.ELEMENT_NODE ? collect(n, registerHidden) : [],
-    );
+
+    // #158：同批 pending 里祖先+后代并存时只收集「没有祖先也在 pending 里」
+    // 的节点 —— collect 覆盖整棵子树，后代单独再 collect 会重复收集。
+    // parentNode 链跨 shadow 边界时经 host 继续上行，避免漏掉 host 在批内的情况。
+    const pendingSet = new Set(batch);
+    const roots = batch.filter((n) => {
+      if (n.nodeType !== Node.ELEMENT_NODE) return false;
+      let p: Node | null = n.parentNode;
+      while (p) {
+        if (pendingSet.has(p)) return false;
+        p =
+          p.nodeType === Node.DOCUMENT_FRAGMENT_NODE
+            ? (p as ShadowRoot).host ?? null
+            : p.parentNode;
+      }
+      return true;
+    });
+
+    // 兜底去重：compat take、shadow 边界等极端路径下保证每单元只回调一次
+    const found = [
+      ...new Set(
+        roots.flatMap((n) => collect(n as Element, registerHidden)),
+      ),
+    ];
 
     // 新增节点中可能出现新的 shadow host，为其 shadow root 补挂 observer
     for (const n of batch) {
@@ -146,6 +167,10 @@ export function startObserver(
         const el = n as HTMLElement;
         // 忽略自己插入的译文与自己的 UI，否则形成无限循环
         if (el.classList?.contains('pt-trans')) continue;
+        // #158：splitPre 切出的 .pt-chunk 是采集器自己插入的单元 —— 触发切分
+        // 的那次 collect 在同一遍遍历里就会收集到它们，mutation 记录再进
+        // pending 只会让每个块在翻译未完成时被二次请求（系统性翻倍）
+        if (el.classList?.contains('pt-chunk')) continue;
         if (el.dataset?.ptUi === '1') continue;
         pending.push(n);
       }

--- a/src/engines/e2e-mock.ts
+++ b/src/engines/e2e-mock.ts
@@ -46,13 +46,17 @@ let failServed = 0;
 /** 已触发的 failTexts 命中次数（测试断言用，防止 failTexts 失效导致假绿）。 */
 let failTextsServed = 0;
 
+/** 已服务的翻译请求总数（#158：断言增量补翻每单元只发一次请求）。 */
+let totalServed = 0;
+
 /** 测试探针：返回 mock 统计。 */
 export function getE2EMockStats(): {
   failOnceServed: number;
   failServed: number;
   failTextsServed: number;
+  totalServed: number;
 } {
-  return { failOnceServed, failServed, failTextsServed };
+  return { failOnceServed, failServed, failTextsServed, totalServed };
 }
 
 /** mock 包裹层函数：带标记字段以便幂等安装 */
@@ -79,6 +83,7 @@ function installStub(): void {
     }
     const q = new URL(url).searchParams.get('q') ?? '';
     const tl = new URL(url).searchParams.get('tl') ?? '';
+    totalServed++;
     if (cfg.failOnce) {
       // 一次性故障：只活在实例内存里（不持久化）。消费即清除 ——
       // 并发批次消息各自在路由前重读 storage 描述符，若 failOnce


### PR DESCRIPTION
## 问题
observer flush 对每个 pending 节点单独 collect，而 collect 每次新建 seen 集合，跨 collect 不去重：祖先+后代同批 pending 时同一单元进 found 两次；pre 切块插入的 .pt-chunk 产生新 mutation，翻译耗时超过 300ms 防抖窗口时每个块被再次发请求。大 pre 页面系统性重复消耗 API 额度、触碰引擎限流。

## 根因
- `observer.ts` flush 对每个 pending 节点独立 `collect(n)`，collect 内 `seen` 每次新建（`walker.ts:18-26`），祖先的 collect 已覆盖子树，后代的 collect 再次收集
- `splitPre` 切块插入的 span 产生 mutation 记录进入 pending，flush#2 对未完成翻译的块重复请求

## 修复
- flush 只对「没有祖先也在 pending 里」的节点做 collect（parentNode 链跨 shadow 边界经 host 上行），并加 Set 兜底去重
- onMutationRecord 忽略 `.pt-chunk`（采集器自己插入的单元，触发切分的那次 collect 同遍已收集）

## 验证
- 单测 `docs/testing/unit/dom/observer.test.ts`：分步 append 容器+子元素、慢引擎（假定时器）→ 每单元只回调一次；pre 切块后二次防抖窗口不再收集
- 新增 `@core TC-E2E-50`：慢引擎 mock（800ms > 300ms）+ 分步 append 容器/20 段、容器/超大 pre（24 块），断言 mock totalServed 增量恰为 20、24；无修复时失败（30 → 46）
- 全量单测 376 通过；core e2e 24 通过
- package.json 0.6.64 → 0.6.65

Closes #158
