### PR TITLE
fix(engines): fetch 无超时 + 消息无响应级超时 → 网络挂起时整页翻译死锁（#154）

### DIFF
--- a/docs/testing/unit/engines/fetch-timeout.test.ts
+++ b/docs/testing/unit/engines/fetch-timeout.test.ts
@@ -1,0 +1,71 @@
+/**
+ * engines/fetch-timeout.ts — 引擎 fetch 超时层 单元测试（#154）
+ *
+ * Chrome fetch 无默认超时，网络黑洞时连接可挂数分钟。断言：
+ * 永不 settle 的 fetch 在有界时间内抛 retryable EngineError；
+ * 正常路径透传 init 并挂 AbortSignal。
+ */
+import { describe, test, expect, vi, afterEach } from 'vitest';
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('fetchWithTimeout', () => {
+  test('fetch 永不 settle → 30s 超时抛 EngineError（retryable）', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
+
+    const { fetchWithTimeout, FETCH_TIMEOUT_MS } = await import(
+      '~/src/engines/fetch-timeout'
+    );
+    const pending = fetchWithTimeout('google-web', 'https://example.com');
+    // 先挂兜底 handler：fake timer tick 内 reject 会被 Node 记为未处理
+    pending.catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(FETCH_TIMEOUT_MS);
+    await expect(pending).rejects.toMatchObject({
+      name: 'EngineError',
+      engineId: 'google-web',
+      retryable: true,
+      message: expect.stringContaining('请求超时'),
+    });
+  });
+
+  test('超时后 abort 在飞 fetch（信号已挂）', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockReturnValue(new Promise(() => {}));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchWithTimeout, FETCH_TIMEOUT_MS } = await import(
+      '~/src/engines/fetch-timeout'
+    );
+    const pending = fetchWithTimeout('bing-edge', 'https://example.com');
+    pending.catch(() => {});
+    await vi.advanceTimersByTimeAsync(FETCH_TIMEOUT_MS);
+    await expect(pending).rejects.toMatchObject({ retryable: true });
+
+    const init = fetchMock.mock.calls[0]![1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    expect(init.signal?.aborted).toBe(true);
+  });
+
+  test('正常响应：透传 init 并返回 Response', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchWithTimeout } = await import('~/src/engines/fetch-timeout');
+    const resp = await fetchWithTimeout('deepl', 'https://example.com', {
+      method: 'POST',
+    });
+
+    expect(await resp.text()).toBe('ok');
+    const [input, init] = fetchMock.mock.calls[0]!;
+    expect(String(input)).toBe('https://example.com');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/docs/testing/unit/engines/google-web-http.test.ts
+++ b/docs/testing/unit/engines/google-web-http.test.ts
@@ -25,7 +25,10 @@ describe('google-web HTTP 路径', () => {
     vi.resetModules();
     vi.clearAllMocks();
   });
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
 
   test('成功：URL 参数正确 + 分句拼接为整段译文', async () => {
     const byQ: Record<string, string> = { Hello: '你好', World: '世界' };
@@ -155,5 +158,28 @@ describe('google-web HTTP 路径', () => {
     expect(resp.translations).toEqual(['t', 't', 't', 't', 't']);
     expect(fetchMock).toHaveBeenCalledTimes(5);
     expect(peak).toBeLessThanOrEqual(2);
+  });
+
+  test('fetch 永不 settle → 30s 超时，全部失败抛 EngineError 让 router 降级（#154）', async () => {
+    vi.useFakeTimers();
+    // 网络黑洞：mock 的 fetch 永不 settle —— 修复前整批 route() 永不返回
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
+
+    const { googleWeb } = await import('~/src/engines/google-web');
+    const pending = googleWeb.translate({
+      texts: ['a', 'b'],
+      from: 'auto',
+      to: 'zh',
+    });
+    // 先挂兜底 handler：fake timer tick 内 reject 会被 Node 记为未处理
+    pending.catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await expect(pending).rejects.toMatchObject({
+      name: 'EngineError',
+      engineId: 'google-web',
+      retryable: true,
+      message: '全部 2 条翻译失败',
+    });
   });
 });

--- a/docs/testing/unit/runtime/messaging.test.ts
+++ b/docs/testing/unit/runtime/messaging.test.ts
@@ -222,12 +222,35 @@ describe('translateViaBackground — 失败语义', () => {
     });
 
     const pending = translateViaBackground(PAYLOAD);
-    await vi.advanceTimersByTimeAsync(20_000);
+    await vi.advanceTimersByTimeAsync(46_000);
     const result = await pending;
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toContain('无响应');
+    }
+  });
+
+  test('translate 永不 settle（SW 挂起）→ 响应级超时中断，预算内有界失败（#154）', async () => {
+    vi.useFakeTimers();
+    sendMessage.mockImplementation(async (msg: unknown) => {
+      const m = msg as { type?: string };
+      if (m.type === 'pt:ping') return { ok: true };
+      // 永不 settle —— 修复前这里会让 deadline 检查永远走不到
+      return new Promise(() => {});
+    });
+
+    const pending = translateViaBackground(PAYLOAD);
+    await vi.advanceTimersByTimeAsync(0);
+    // 首次 translate 在 30s 响应级超时中断（而非无限挂起）
+    await vi.advanceTimersByTimeAsync(30_000);
+    // 预算（45s）耗尽 → 有界返回失败
+    await vi.advanceTimersByTimeAsync(16_000);
+    const result = await pending;
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('响应超时');
     }
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.66",
+  "version": "0.6.67",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/bing-edge.ts
+++ b/src/engines/bing-edge.ts
@@ -3,6 +3,7 @@
 // 再调 cognitive.microsofttranslator.com 批量翻译。
 // JWT 缓存约 10 分钟，解析 exp 复用，401 清空重取。
 
+import { fetchWithTimeout } from './fetch-timeout';
 import { EngineError } from './types';
 import type { TranslateEngine } from './types';
 
@@ -25,7 +26,7 @@ function isExpired(jwt: string): boolean {
 async function getJwt(): Promise<string> {
   if (cachedJwt && !isExpired(cachedJwt)) return cachedJwt;
 
-  const resp = await fetch(AUTH_ENDPOINT);
+  const resp = await fetchWithTimeout('bing-edge', AUTH_ENDPOINT);
   if (!resp.ok) {
     throw new EngineError('bing-edge', true, `auth HTTP ${resp.status}`);
   }
@@ -52,7 +53,7 @@ export const bingEdge: TranslateEngine = {
       textType: 'html',
     });
 
-    const resp = await fetch(`${TRANS_ENDPOINT}?${qs}`, {
+    const resp = await fetchWithTimeout('bing-edge', `${TRANS_ENDPOINT}?${qs}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/engines/deepl.ts
+++ b/src/engines/deepl.ts
@@ -3,6 +3,7 @@
 // DeepL 语言覆盖有限，supportedLangs 必须显式列举。
 
 import { getKey } from '~/src/storage/keys';
+import { fetchWithTimeout } from './fetch-timeout';
 import { EngineError } from './types';
 import type { TranslateEngine } from './types';
 
@@ -79,7 +80,7 @@ export const deepl: TranslateEngine = {
       body.append('text', text);
     }
 
-    const resp = await fetch(endpoint, {
+    const resp = await fetchWithTimeout('deepl', endpoint, {
       method: 'POST',
       headers: {
         Authorization: `DeepL-Auth-Key ${key}`,

--- a/src/engines/fetch-timeout.ts
+++ b/src/engines/fetch-timeout.ts
@@ -1,0 +1,40 @@
+// 引擎 fetch 超时层 —— #154。
+//
+// Chrome fetch 无默认超时，网络黑洞 / 代理中断 / 服务端接受连接但不响应时
+// 可挂数分钟（依赖 OS TCP 超时）。各引擎 fetch 统一走 fetchWithTimeout：
+// 超时抛 retryable EngineError，router 降级到下一引擎；
+// 同时 abort 掉在飞请求，不再空占连接与并发闸门槽位。
+//
+// 用 setTimeout + AbortController 手动实现而非 AbortSignal.timeout：
+// 需 Promise.race 兜住「fetch 永不 settle」的 mock / 极端实现，
+// 且 fake timers 可确定性推进，便于单测。
+
+import { EngineError } from './types';
+
+/** 引擎 fetch 超时（毫秒）。 */
+export const FETCH_TIMEOUT_MS = 30_000;
+
+export async function fetchWithTimeout(
+  engineId: string,
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const ctrl = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        ctrl.abort();
+        reject(new EngineError(engineId, true, `请求超时（${timeoutMs}ms）`));
+      }, timeoutMs);
+    });
+    // race 放弃方（fetch 或 timeout）的后续 settle 由 race 内部消化，无未处理拒绝。
+    return await Promise.race([
+      fetch(input, { ...init, signal: ctrl.signal }),
+      timeout,
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/engines/gemini.ts
+++ b/src/engines/gemini.ts
@@ -4,6 +4,7 @@
 import { getKey } from '~/src/storage/keys';
 import { getSettings } from '~/src/storage/settings';
 import { normalizeText } from '~/src/dom/normalize';
+import { fetchWithTimeout } from './fetch-timeout';
 import { EngineError } from './types';
 import { parseNumbered } from './openai';
 import type { TranslateEngine } from './types';
@@ -34,7 +35,7 @@ export const gemini: TranslateEngine = {
       `将以下编号文本翻译成${to}${from === 'auto' ? '' : `（源语言：${from}）`}。` +
       `严格保持编号与行数一致，只输出译文，不要解释。\n\n${numbered}`;
 
-    const resp = await fetch(endpoint, {
+    const resp = await fetchWithTimeout('gemini', endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/engines/google-web.ts
+++ b/src/engines/google-web.ts
@@ -4,6 +4,7 @@
 
 import { getSettings, onSettingsChanged } from '~/src/storage/settings';
 import { createGate } from '~/src/queue/concurrency';
+import { fetchWithTimeout } from './fetch-timeout';
 import { EngineError } from './types';
 import type { TranslateEngine } from './types';
 
@@ -24,7 +25,7 @@ async function fetchOne(
     q: text,
   });
 
-  const resp = await fetch(`${ENDPOINT}?${qs}`);
+  const resp = await fetchWithTimeout('google-web', `${ENDPOINT}?${qs}`);
   if (!resp.ok) {
     throw new EngineError('google-web', true, `HTTP ${resp.status}`);
   }

--- a/src/engines/openai.ts
+++ b/src/engines/openai.ts
@@ -5,6 +5,7 @@
 import { getKey } from '~/src/storage/keys';
 import { getSettings } from '~/src/storage/settings';
 import { normalizeText } from '~/src/dom/normalize';
+import { fetchWithTimeout } from './fetch-timeout';
 import { EngineError } from './types';
 import type { TranslateEngine } from './types';
 
@@ -45,7 +46,7 @@ export const openai: TranslateEngine = {
       `将以下编号文本翻译成${to}${from === 'auto' ? '' : `（源语言：${from}）`}。` +
       `严格保持编号与行数一致，只输出译文，不要解释。\n\n${numbered}`;
 
-    const resp = await fetch(DEFAULT_ENDPOINT, {
+    const resp = await fetchWithTimeout('openai', DEFAULT_ENDPOINT, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/runtime/messaging.ts
+++ b/src/runtime/messaging.ts
@@ -6,9 +6,14 @@
 // 要么 reject "Could not establish connection. Receiving end does not exist."。
 // 直接当作最终失败会让整页翻译静默失败（[data-pt="done"] 永不出现）。
 //
+// #154：sendMessage 在 SW 挂起时永不 settle（响应级超时前的原实现
+// 只 await 不设限），deadline 检查走不到，预算形同虚设。现在每次发送
+// 都套 withTimeout —— 单次最长等 MESSAGE_TIMEOUT_MS（与引擎 fetch
+// 超时对齐），超时视为一次传输层失败进入重试，预算真正封顶总耗时。
+//
 // translateViaBackground 是 content script 三个翻译入口共用的通道：
 // 1. 先 ping（pt:ping）确认 SW 消息通道就绪，有界重试
-// 2. 再发 pt:translate；传输层失败（无响应/连接被拒）有界重试
+// 2. 再发 pt:translate；传输层失败（无响应/连接被拒/超时）有界重试
 // 3. SW 已响应的 {ok:false} 是引擎级失败（router 已做过引擎降级），不重试
 // 4. 预算耗尽返回 {ok:false} + 错误说明，永不抛出 —— 调用方按原约定处理
 
@@ -21,8 +26,13 @@ export type TranslateResult =
 
 /** SW 就绪等待预算（ping 阶段）。覆盖 CI 中 SW 冷启动的常见耗时。 */
 const READY_BUDGET_MS = 10_000;
-/** 翻译消息传输层重试预算。 */
-const SEND_BUDGET_MS = 15_000;
+/**
+ * 翻译消息总预算（含重试）。须 ≥ MESSAGE_TIMEOUT_MS 让单次完整
+ * 引擎往返（30s fetch 超时 + SW 开销）能在预算内完成。
+ */
+const SEND_BUDGET_MS = 45_000;
+/** 单次 sendMessage 响应级超时 —— 与引擎 fetch 超时对齐（#154）。 */
+const MESSAGE_TIMEOUT_MS = 30_000;
 /** 退避起点（毫秒），每次翻倍，上限 2s。 */
 const BACKOFF_INITIAL_MS = 250;
 const BACKOFF_MAX_MS = 2000;
@@ -58,7 +68,30 @@ function isContextInvalidated(): boolean {
 }
 
 /**
- * 有界重试发送：只要收不到任何响应（undefined / 连接被拒），
+ * 响应级超时包装（#154）：ms 内未 settle 即拒绝。
+ * 放弃方（sendMessage）的后续 settle 由内部 then/catch 消化，无未处理拒绝。
+ */
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`响应超时（${ms}ms）`)),
+      ms,
+    );
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      },
+    );
+  });
+}
+
+/**
+ * 有界重试发送：只要收不到任何响应（undefined / 连接被拒 / 超时），
  * 就以指数退避重发，直到预算耗尽。收到响应（无论内容）即返回。
  * 预算耗尽时抛出最后一次失败原因。
  */
@@ -76,13 +109,21 @@ async function sendWithTransportRetry(
       throw new ContextInvalidatedError();
     }
 
+    // 单次最长等待 = 剩余预算与响应级超时的较小者（#154）
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    const attemptTimeout = Math.min(remaining, MESSAGE_TIMEOUT_MS);
+
     let resp: unknown;
     try {
-      resp = await chrome.runtime.sendMessage(msg);
+      resp = await withTimeout(
+        chrome.runtime.sendMessage(msg),
+        attemptTimeout,
+      );
     } catch (e) {
       // 类型化判定（#139）：sendMessage 抛错时再查一次上下文是否已失效 ——
       // 失效是结构化状态（chrome.runtime.id 为 null），不依赖错误文案。
-      // 上下文仍有效则视为可重试的传输层错误（如 SW 监听器未注册）。
+      // 上下文仍有效则视为可重试的传输层错误（如 SW 监听器未注册、响应超时）。
       if (isContextInvalidated()) {
         throw new ContextInvalidatedError();
       }


### PR DESCRIPTION
## 问题
1. 全部引擎 fetch 无超时，网络黑洞 / 代理中断 / 服务端不响应时连接可挂数分钟（依赖 OS TCP 超时）
2. messaging 的 `await chrome.runtime.sendMessage` 永不 settle 时 deadline 检查走不到，`SEND_BUDGET_MS` 形同虚设
3. google-web 挂起请求占住并发闸门槽位，整批与后续批次排队饿死，整页翻译永久 pending

## 根因
- 各引擎直接裸 `fetch`，无 AbortController / 超时
- sendWithTransportRetry 只 await 不设响应级时限，预算检查在 settle 之后

## 修复
- 新增 `src/engines/fetch-timeout.ts`：所有引擎 fetch 统一走 `fetchWithTimeout`（30s），超时抛 retryable `EngineError` 并 abort 在飞请求 → router 降级到下一引擎，闸门槽位及时释放
- messaging 每次发送套响应级超时（与引擎 fetch 超时对齐），单次最长 30s，超时按传输层失败重试；总预算提到 45s 容纳单次完整引擎往返，预算真正封顶总耗时
- 悬浮球超时后回到 idle 可再次点击（{ok:false} 原约定返回）

## 验证
- 新增单测：永不 settle 的 fetch → 30s 内抛 EngineError 让 router 降级；永不 settle 的 sendMessage → 响应级超时中断、预算内有界失败
- 单测 397 全通过，typecheck 通过

Closes #154
