### PR TITLE
fix(content): 还原中止与真失败区分 —— epoch 中止批次不算失败、球回 idle 不误报（#157）

### DIFF
--- a/docs/testing/e2e/core.spec.ts
+++ b/docs/testing/e2e/core.spec.ts
@@ -621,6 +621,138 @@ test.describe('Fixture: pre-blocks', () => {
   });
 });
 
+// ================================================================
+// #157：还原 vs 在飞翻译竞态
+// ================================================================
+
+test.describe('还原 vs 在飞翻译（#157）', () => {
+  // 等在飞/排队请求全部结算（并发闸门 6 路 × 800ms，30 条最多约 5s 排空）。
+  // 还原只能中止未发出的请求 —— 已入队请求仍会走完，须等其结算再断言。
+  const waitDrained = (page: import('@playwright/test').Page, served: () => Promise<number>) =>
+    expect
+      .poll(async () => {
+        const s1 = await served();
+        await page.waitForTimeout(1200);
+        return (await served()) === s1;
+      }, { timeout: 20_000 })
+      .toBe(true);
+
+  test('@core TC-E2E-51: 部分批次已渲染时还原 —— 球回 idle、无错误 toast、无自动补翻', async ({
+    page, serviceWorker, mockGoogle, seedSettings, gotoFixture,
+  }) => {
+    await seedSettings({});
+    // 800ms 慢引擎制造在飞窗口：首批渲染后、次批仍在飞时还原
+    await mockGoogle({ delayMs: 800 });
+    await gotoFixture('basic');
+
+    const ball = await waitForBall(page);
+    const served = () =>
+      serviceWorker.evaluate(() => (self as any).getE2EMockStats().totalServed);
+    const errorToast = page.locator('#pt-host-toast .pt-toast[data-kind="error"]');
+
+    // 追加 20 段 → 30 单元 → 2 批（15/批），批间天然错峰
+    await page.evaluate(() => {
+      for (let i = 1; i <= 20; i++) {
+        const p = document.createElement('p');
+        p.textContent = `In-flight paragraph ${i} for restore race.`;
+        document.body.appendChild(p);
+      }
+    });
+
+    await ball.click();
+    await expect(ball).toHaveAttribute('data-state', 'loading');
+
+    // 等首批渲染（hasTranslated=true），次批仍在飞
+    await expect(page.locator('[data-pt="done"]').first()).toBeVisible({ timeout: 10_000 });
+
+    // 快捷键还原（悬浮球 loading 屏蔽点击，快捷键不设防 —— #157 场景）
+    await page.keyboard.press(
+      process.platform === 'darwin' ? 'Meta+Shift+Y' : 'Control+Shift+Y',
+    );
+
+    // 球回 idle 而非 done/error；页面全部还原
+    await expect(ball).toHaveAttribute('data-state', 'idle', { timeout: 10_000 });
+    await expect(page.locator('[data-pt="done"]')).toHaveCount(0, { timeout: 10_000 });
+
+    // 等所有在飞批次结算，确认无“所有引擎均失败”错误 toast
+    await waitDrained(page, served);
+    await expect(errorToast).toHaveCount(0);
+
+    // 还原后不启动 observer：新增段落不被自动补翻（无新请求、无译文）
+    const before = await served();
+    await page.evaluate(() => {
+      const p = document.createElement('p');
+      p.textContent = 'Appended after restore — must not auto-translate.';
+      document.body.appendChild(p);
+    });
+    await page.waitForTimeout(2500);
+    expect(await served()).toBe(before);
+    await expect(page.locator('[data-pt="done"]')).toHaveCount(0);
+  });
+
+  test('@core TC-E2E-52: 增量补翻在飞时还原（全批中止）—— 不误报引擎失败', async ({
+    page, serviceWorker, mockGoogle, seedSettings, gotoFixture,
+  }) => {
+    await seedSettings({});
+    await mockGoogle();
+    await gotoFixture('basic');
+
+    const ball = await waitForBall(page);
+    const errorToast = page.locator('#pt-host-toast .pt-toast[data-kind="error"]');
+    const served = () =>
+      serviceWorker.evaluate(() => (self as any).getE2EMockStats().totalServed);
+
+    // 完整翻译 → observer 已启动
+    await translateAndWait(page);
+    await expect(ball).toHaveAttribute('data-state', 'done');
+
+    // 换成慢引擎，追加 20 段 → 增量补翻在飞（约 300ms 防抖 + 800ms 响应）
+    await mockGoogle({ delayMs: 800 });
+    const baseline = await served();
+    await page.evaluate(() => {
+      for (let i = 1; i <= 20; i++) {
+        const p = document.createElement('p');
+        p.textContent = `Incremental paragraph ${i} for restore race.`;
+        document.body.appendChild(p);
+      }
+    });
+    // 等增量请求真正发出（在飞窗口），再触发还原
+    await expect
+      .poll(async () => await served(), { timeout: 10_000 })
+      .toBeGreaterThan(baseline);
+
+    // 增量批次在飞时还原（球 done 可点击）
+    await ball.click();
+    await expect(ball).toHaveAttribute('data-state', 'idle', { timeout: 10_000 });
+    await expect(page.locator('[data-pt="done"]')).toHaveCount(0, { timeout: 10_000 });
+
+    // 等在飞/排队批次结算（#157 前：全批中止 → 结算瞬间弹「所有引擎均失败」
+    // 并停留 3s —— toHaveCount(0) 会等 toast 自动过期而漏检，须持续采样）
+    await waitDrained(page, served);
+    let sawErrorToast = false;
+    const toastEnd = Date.now() + 3500;
+    while (Date.now() < toastEnd) {
+      if ((await errorToast.count()) > 0) {
+        sawErrorToast = true;
+        break;
+      }
+      await page.waitForTimeout(250);
+    }
+    expect(sawErrorToast).toBe(false);
+
+    // observer 已停：追加内容不再触发新请求
+    const settled = await served();
+    await page.evaluate(() => {
+      const p = document.createElement('p');
+      p.textContent = 'Appended after restore — must not auto-translate.';
+      document.body.appendChild(p);
+    });
+    await page.waitForTimeout(2500);
+    expect(await served()).toBe(settled);
+    await expect(page.locator('[data-pt="done"]')).toHaveCount(0);
+  });
+});
+
 test.describe('Fixture: rtl', () => {
   test('@core TC-E2E-28: RTL 页面正常加载', async ({
     page, mockGoogle, seedSettings, gotoFixture,

--- a/docs/testing/unit/runtime/batch-retry.test.ts
+++ b/docs/testing/unit/runtime/batch-retry.test.ts
@@ -135,4 +135,25 @@ describe('attemptBatchWithRetry — 中止（还原 / 全局短路）', () => {
     if (!result.ok) expect(result.aborted).toBe(true);
     expect(send).toHaveBeenCalledTimes(1);
   });
+
+  test('重试预算耗尽后的最后一次失败也查中止（#157 边界）', async () => {
+    // 还原恰在「最后一次尝试失败」与「返回」之间发生：shouldAbort
+    // 前 BATCH_RETRY_LIMIT+1 次（每次尝试的前/后检查）都返回 false，
+    // 最后一次失败后才变 true —— 必须报 aborted 而不是 failed
+    const send = vi.fn(async () => ({ ok: false, error: '引擎失败' }));
+    let calls = 0;
+    const result = await attemptBatchWithRetry(send, {
+      sleep: noopSleep,
+      // 每次尝试有前/后两次检查：(LIMIT+1) 次尝试共 6 次检查全放行，
+      // 第 7 次（预算耗尽后的最终返回检查）才命中 —— 证明该边界
+      shouldAbort: () => ++calls > (BATCH_RETRY_LIMIT + 1) * 2,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.aborted).toBe(true);
+      expect(result.invalidated).toBe(false);
+    }
+    expect(send).toHaveBeenCalledTimes(BATCH_RETRY_LIMIT + 1);
+  });
 });

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -225,7 +225,12 @@ export default defineContentScript({
 
       async function attemptBatch(
         batch: (typeof batches)[number],
-      ): Promise<{ rendered: number; rejected: number; failed: boolean }> {
+      ): Promise<{
+        rendered: number;
+        rejected: number;
+        failed: boolean;
+        aborted: boolean;
+      }> {
         // 重试策略（#91 有界重试 / #111 失效立即失败）集中在
         // batch-retry.ts，此处只负责渲染与全局短路标记。
         const result = await attemptBatchWithRetry(
@@ -252,7 +257,18 @@ export default defineContentScript({
           if (!result.aborted) {
             console.error('[PT] 批次翻译失败:', result.error);
           }
-          return { rendered: 0, rejected: 0, failed: true };
+          return {
+            rendered: 0,
+            rejected: 0,
+            // #157: 中止（还原）与失败分开记账 —— 中止不算失败
+            failed: !result.aborted,
+            aborted: result.aborted,
+          };
+        }
+        // #157: 本批在飞期间用户已还原（纪元递增）—— 放弃渲染，
+        // 否则还原后会把内容翻回来（#91 的渲染侧补漏）
+        if (translateEpoch.value !== epochAtStart) {
+          return { rendered: 0, rejected: 0, failed: false, aborted: true };
         }
         let rendered = 0;
         let rejected = 0;
@@ -276,7 +292,7 @@ export default defineContentScript({
             );
           }
         }
-        return { rendered, rejected, failed: false };
+        return { rendered, rejected, failed: false, aborted: false };
       }
 
       // 所有批次并发发送，每批返回即渲染。
@@ -284,11 +300,18 @@ export default defineContentScript({
       await Promise.all(
         batches.map(async (batch) => {
           const r = await attemptBatch(batch);
+          // #157: 中止批次不参与成败统计 —— 还原不是引擎失败
+          if (r.aborted) return;
           renderSucceeded += r.rendered;
           renderRejected += r.rejected;
           if (!r.failed) allFailed = false;
         }),
       );
+
+      // #157: 还原发生在翻译进行中 —— 批次被 epoch 中止不是失败：
+      // 不弹“所有引擎均失败”、状态置 aborted（悬浮球回 idle、
+      // 不启动 observer、不置 done）
+      if (translateEpoch.value !== epochAtStart) return 'aborted';
 
       // #49：整页翻译结束后用一条 toast 汇总被拒数量，而不是逐条刷屏
       if (renderRejected > 0 && isMainFrame) {
@@ -415,6 +438,8 @@ export default defineContentScript({
       }
 
       if (isMainFrame) {
+        // #157: 'aborted'（翻译中还原）不置 'done'/'error' —— 页面已还原，
+        // 球回 idle，不弹任何错误 toast
         setBallState(
           status === 'translated'
             ? 'done'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.67",
+  "version": "0.6.68",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/runtime/batch-retry.ts
+++ b/src/runtime/batch-retry.ts
@@ -77,5 +77,13 @@ export async function attemptBatchWithRetry(
     if (attempt >= BATCH_RETRY_LIMIT) break;
     await sleep(BATCH_RETRY_DELAYS_MS[attempt]!);
   }
-  return { ok: false, invalidated: false, aborted: false, error: lastError };
+  // #157: 最后一次尝试失败后、返回前再查一次中止 —— 还原（纪元递增）
+  // 恰在最后失败与返回之间发生时，也必须报 aborted 而不是 failed，
+  // 否则调用方把它记成真失败（allFailed/错误 toast 误报）
+  return {
+    ok: false,
+    invalidated: false,
+    aborted: opts.shouldAbort?.() ?? false,
+    error: lastError,
+  };
 }


### PR DESCRIPTION
## 问题
还原（`doRestore` 递增 `translateEpoch`）发生在翻译进行中时，被 epoch 中止的批次（`result.aborted === true`）与真失败批次一样返回 `failed: true`，而 `doTranslate` 没有「已中止」一档，导致：
1. **部分成功 → 状态错乱**：已渲染批次成功后剩余批次被中止 → 返回 `'translated'` → `togglePage` 启动 `startObserver` 增量补翻并把悬浮球置 `'done'`。但页面已被还原（所有 `data-pt="done"` 已 unrender）—— 页面是原文，球显示「已翻译 ✓」，此后任何 DOM 变动会被自动重新翻译
2. **全部中止 → 误报**：翻译刚开始就还原 → 所有批次 `failed:true` → 误弹「所有引擎均失败」错误 toast + 球置 `'error'`

## 修复
- `attemptBatch` 区分中止与失败：中止批次返回独立 `aborted` 标记，不参与 `allFailed` / `renderSucceeded` 统计
- 批次在飞期间纪元已递增 → 放弃渲染（补上 #91 渲染侧漏口，避免还原后把内容翻回来）
- `Promise.all` 结束后若 `translateEpoch.value !== epochAtStart` → `doTranslate` 返回独立状态 `'aborted'`，不弹任何错误 toast
- `togglePage` 对 `'aborted'`：跳过 `startObserver`、不置 `'done'`/`'error'`，球回 `'idle'`

## 验证
- 新增 E2E：TC-E2E-51（部分批次已渲染时还原 → 球回 idle、无错误 toast、无自动补翻）、TC-E2E-52（增量补翻在飞时还原（全批中止）→ 不误报引擎失败）
- 两测试在修复前均失败（球置 done / 弹出「所有引擎均失败」），修复后通过
- 单测 397 全通过，typecheck 通过，core E2E 26 通过

Closes #157
