### PR TITLE
fix(content): togglePage 加在飞互斥 —— 连点不再重复整页请求或翻完即还原（#156）

### DIFF
--- a/docs/testing/e2e/core.spec.ts
+++ b/docs/testing/e2e/core.spec.ts
@@ -54,6 +54,46 @@ test.describe('入口：悬浮球', () => {
     await expect(page.locator('[data-pt="done"]')).toHaveCount(0, { timeout: 10_000 });
     await expect(ball).toHaveAttribute('data-state', 'idle');
   });
+
+  test('@core TC-E2E-53: 在飞期间重复触发 —— 只发一次请求、不立即还原（#156 回归）', async ({
+    page, serviceWorker, mockGoogle, seedSettings, gotoFixture,
+  }) => {
+    await seedSettings({});
+    // 慢引擎制造在飞窗口。走快捷键路径而非点击悬浮球：悬浮球自身有
+    // loading 守卫，而 popup/快捷键路径没有 —— 修复前第二次触发并发
+    // 整页请求（请求翻倍），或首轮刚完成时触发还原（刚翻好的页面被
+    // 立即还原）。快捷键与 popup 都直接调 togglePage，互斥守卫相同。
+    await mockGoogle({ delayMs: 800 });
+    await gotoFixture('basic');
+    await waitForBall(page);
+
+    const served = () =>
+      serviceWorker.evaluate(() => (self as any).getE2EMockStats().totalServed);
+    const toggleKey = process.platform === 'darwin' ? 'Meta+Shift+Y' : 'Control+Shift+Y';
+
+    // 基线：单次触发的请求数
+    await page.keyboard.press(toggleKey);
+    await expect(page.locator('[data-pt="done"]').first()).toBeVisible({ timeout: 30_000 });
+    const baseline = await served();
+
+    // 还原，回到未翻译态
+    await page.keyboard.press(toggleKey);
+    await expect(page.locator('[data-pt="done"]')).toHaveCount(0, { timeout: 10_000 });
+
+    // 在飞窗口内连按两次（两次按键间隔远小于 800ms 延迟）
+    const before = await served();
+    await page.keyboard.press(toggleKey);
+    await page.keyboard.press(toggleKey);
+
+    // 最终页面处于已翻译态（第二次触发未被还原）
+    await expect(page.locator('[data-pt="done"]').first()).toBeVisible({ timeout: 30_000 });
+
+    // 第二次触发未产生整页翻译的请求量（未并发翻倍）。用上界而非精确
+    // 增量：SW 实例可能被 Chrome 替换（totalServed 清零、mock 自愈，
+    // #90）—— 修复前并发第二次翻译会让增量达到 2×baseline。
+    const after = await served();
+    expect(after - before).toBeLessThanOrEqual(baseline);
+  });
 });
 
 test.describe('入口：快捷键', () => {

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -151,6 +151,12 @@ export default defineContentScript({
     /** 还原纪元：doRestore 递增，在飞翻译据此放弃重试与渲染。 */
     const translateEpoch = { value: 0 };
 
+    // #156: 整页翻译在飞互斥。悬浮球自身的 loading 守卫挡不住 popup 与
+    // 快捷键路径 —— 它们直接调 togglePage。在飞期间忽略新的 toggle：
+    // 否则连点会并发整页请求（双倍引擎额度/缓存写入、双 toast），或
+    // 首轮刚完成时第二次触发把刚翻好的页面立即还原。
+    let pageToggleInFlight = false;
+
     async function doTranslate(
       elements?: Element[],
     ): Promise<string> {
@@ -404,7 +410,7 @@ export default defineContentScript({
      * 状态，任何入口各自记一份都会导致“按了没反应”或“重复翻一遍”。
      * 悬浮球的视觉由这里通过 setBallState 单向推送。
      */
-    async function togglePage(): Promise<string> {
+    async function togglePageImpl(): Promise<string> {
       if (hasTranslated()) {
         doRestore();
         if (isMainFrame) setBallState('idle');
@@ -452,6 +458,21 @@ export default defineContentScript({
         toast(tf('toastSiteBlocked', '该站点已在站点名单中被禁用翻译'), 'error');
       }
       return status;
+    }
+
+    // #156: 在飞互斥包裹层 —— 真正的实现见 togglePageImpl。
+    // 在飞期间：页面上尚无译文（首批未渲染）时忽略新 toggle，防止并发
+    // 整页请求（双倍额度/缓存写入）；已有译文则放行还原 —— #157 的
+    // 取消语义：doRestore 递增 epoch，在飞批次中止，页面被还原。
+    // popup 收到 'busy' 不把它当错误。
+    async function togglePage(): Promise<string> {
+      if (pageToggleInFlight && !hasTranslated()) return 'busy';
+      pageToggleInFlight = true;
+      try {
+        return await togglePageImpl();
+      } finally {
+        pageToggleInFlight = false;
+      }
     }
 
     // ── 翻译单段 ──

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.68",
+  "version": "0.6.69",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## 问题
`togglePage()` 无在飞互斥：悬浮球自身有 loading 守卫，但 popup 与快捷键路径直接调用不设防。连点会并发整页请求（双倍额度/缓存写入），或首轮刚完成时触发还原（刚翻好的页面被立即还原）。

## 修复
content script 内加 per-frame 在飞标志：在飞期间忽略新的 toggle（返回 busy）；已有译文时仍放行还原，保留 #157 的在飞取消语义。

## 验证
- 新增 E2E TC-E2E-53：慢引擎在飞窗口内连按两次快捷键 → 只发一次翻译请求、页面保持已翻译态
- 既有 TC-E2E-51/52（#157 在飞还原）通过，完整 core 套件 27 项通过