### PR TITLE
fix(dom): hasNonTextContent 检查元素自身 —— div[role=button]/summary 不再被翻译（#162）

### DIFF
--- a/docs/testing/unit/dom/classify.test.ts
+++ b/docs/testing/unit/dom/classify.test.ts
@@ -159,6 +159,21 @@ describe('hasNonTextContent', () => {
     expect(hasNonTextContent(div)).toBe(true);
   });
 
+  test('自身是 role=button 的元素 → true（#162）', () => {
+    const div = el('<div role="button">点我</div>');
+    expect(hasNonTextContent(div)).toBe(true);
+  });
+
+  test('自身是 summary 的元素 → true（#162）', () => {
+    const s = el('<summary>更多</summary>');
+    expect(hasNonTextContent(s)).toBe(true);
+  });
+
+  test('自身是普通 div 含 role=button 后代 → true（回归）', () => {
+    const div = el('<div><div role="button">点我</div></div>');
+    expect(hasNonTextContent(div)).toBe(true);
+  });
+
   test('空元素 → false', () => {
     const p = el('<p></p>');
     expect(hasNonTextContent(p)).toBe(false);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.69",
+  "version": "0.6.70",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/classify.ts
+++ b/src/dom/classify.ts
@@ -124,7 +124,7 @@ export function shouldSkip(el: Element): boolean {
  */
 export const NON_TEXT_SELECTOR =
   'img, picture, video, audio, iframe, canvas, object, embed,' +
-  ' button, input, select, textarea,' +
+  ' button, input, select, textarea, summary,' +
   ' [role="button"], [role="tab"], [role="menuitem"], [role="switch"], [role="checkbox"]';
 
 /**
@@ -136,6 +136,10 @@ export const NON_TEXT_SELECTOR =
  * badge 等），不应阻止翻译；否则视为独立媒体块，仍然拒绝。
  */
 export function hasNonTextContent(el: Element): boolean {
+  // #162: 元素自身就是交互控件（div[role=button]、summary 等）时同样
+  // 视为含非文本内容 —— 只查后代会漏掉自身，导致 role 型控件与
+  // summary 被当普通文本段采集、渲染。
+  if (el.matches(NON_TEXT_SELECTOR)) return true;
   const matches = el.querySelectorAll(NON_TEXT_SELECTOR);
   for (const match of matches) {
     let cur: Element | null = match;


### PR DESCRIPTION
## 问题
`hasNonTextContent` 只查后代不查自身，`<div role="button">`、`<summary>` 这类自身就是交互控件的元素被当普通文本段采集、渲染；summary 还不在 `NON_TEXT_SELECTOR` 里。

## 修复
判定开头补 `el.matches(NON_TEXT_SELECTOR)` 检查自身，并把 `summary` 加入选择器。

## 验证
- 新增单测：`<div role="button">`、`<summary>` 判定为含非文本内容
- 单元测试 401 项全部通过