### PR TITLE
feat(engines): 并发闸门提升为引擎公共层 —— 全部引擎限流（#159）

### DIFF
--- a/docs/testing/unit/engines/bing-edge-http.test.ts
+++ b/docs/testing/unit/engines/bing-edge-http.test.ts
@@ -6,6 +6,11 @@
  */
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
+vi.mock('~/src/storage/settings', () => ({
+  getSettings: vi.fn(() => ({ maxConcurrency: 6 })),
+  onSettingsChanged: vi.fn(() => () => {}),
+}));
+
 const AUTH_URL = 'https://edge.microsoft.com/translate/auth';
 const TRANS_URL = 'https://api-edge.cognitive.microsofttranslator.com/translate';
 
@@ -48,6 +53,37 @@ describe('bing-edge HTTP 路径', () => {
     vi.clearAllMocks();
   });
   afterEach(() => vi.unstubAllGlobals());
+
+  test('并发闸门：并发 translate() 调用在飞请求不超过 maxConcurrency（#159）', async () => {
+    const { getSettings } = await import('~/src/storage/settings');
+    vi.mocked(getSettings).mockReturnValue({ maxConcurrency: 2 } as never);
+
+    let inFlight = 0;
+    let peak = 0;
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 10));
+      inFlight--;
+      // auth 请求返回 JWT，翻译请求返回译文（URL 分流）
+      return String(url) === AUTH_URL
+        ? new Response(futureJwt, { status: 200 })
+        : okTrans(['你好']);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { bingEdge } = await import('~/src/engines/bing-edge');
+    const resps = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        bingEdge.translate({ texts: ['Hello'], from: 'en', to: 'zh-CN' }),
+      ),
+    );
+
+    // 全部成功（JWT 首取后缓存 → 1 次 auth + 8 次翻译 POST）
+    expect(resps.every((r) => r.translations[0] === '你好')).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(9);
+    expect(peak).toBeLessThanOrEqual(2);
+  });
 
   test('成功：先取 JWT，再 POST 翻译（URL / 头 / 体断言）', async () => {
     const fetchMock = scriptedFetch([

--- a/docs/testing/unit/engines/deepl-http.test.ts
+++ b/docs/testing/unit/engines/deepl-http.test.ts
@@ -6,6 +6,11 @@
  */
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
+vi.mock('~/src/storage/settings', () => ({
+  getSettings: vi.fn(() => ({ maxConcurrency: 6 })),
+  onSettingsChanged: vi.fn(() => () => {}),
+}));
+
 vi.mock('~/src/storage/keys', () => ({
   getKey: vi.fn(),
 }));
@@ -137,5 +142,34 @@ describe('deepl HTTP 路径', () => {
     await expect(
       deepl.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
     ).rejects.toThrow();
+  });
+
+  test('并发闸门：并发 translate() 调用在飞请求不超过 maxConcurrency（#159）', async () => {
+    const { getSettings } = await import('~/src/storage/settings');
+    vi.mocked(getSettings).mockReturnValue({ maxConcurrency: 2 } as never);
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+
+    let inFlight = 0;
+    let peak = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 10));
+      inFlight--;
+      return okResp(['你好']);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { deepl } = await import('~/src/engines/deepl');
+    const resps = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        deepl.translate({ texts: ['Hello'], from: 'en', to: 'zh-CN' }),
+      ),
+    );
+
+    expect(resps.every((r) => r.translations[0] === '你好')).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(8);
+    expect(peak).toBeLessThanOrEqual(2);
   });
 });

--- a/docs/testing/unit/engines/gemini-http.test.ts
+++ b/docs/testing/unit/engines/gemini-http.test.ts
@@ -7,7 +7,8 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('~/src/storage/settings', () => ({
-  getSettings: vi.fn(() => ({ models: { gemini: 'gemini-2.5-flash' } })),
+  getSettings: vi.fn(() => ({ maxConcurrency: 6, models: { gemini: 'gemini-2.5-flash' } })),
+  onSettingsChanged: vi.fn(() => () => {}),
 }));
 
 vi.mock('~/src/storage/keys', () => ({
@@ -134,5 +135,34 @@ describe('gemini HTTP 路径', () => {
     await expect(
       gemini.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
     ).rejects.toThrow();
+  });
+
+  test('并发闸门：并发 translate() 调用在飞请求不超过 maxConcurrency（#159）', async () => {
+    const { getSettings } = await import('~/src/storage/settings');
+    vi.mocked(getSettings).mockReturnValue({ maxConcurrency: 2, models: { gemini: 'gemini-2.5-flash' } } as never);
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+
+    let inFlight = 0;
+    let peak = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 10));
+      inFlight--;
+      return okResp('1. 你好');
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { gemini } = await import('~/src/engines/gemini');
+    const resps = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        gemini.translate({ texts: ['Hello'], from: 'en', to: 'zh-CN' }),
+      ),
+    );
+
+    expect(resps.every((r) => r.translations[0] === '你好')).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(8);
+    expect(peak).toBeLessThanOrEqual(2);
   });
 });

--- a/docs/testing/unit/engines/openai-http.test.ts
+++ b/docs/testing/unit/engines/openai-http.test.ts
@@ -7,7 +7,8 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('~/src/storage/settings', () => ({
-  getSettings: vi.fn(() => ({ models: { openai: 'gpt-4o' } })),
+  getSettings: vi.fn(() => ({ maxConcurrency: 6, models: { openai: 'gpt-4o' } })),
+  onSettingsChanged: vi.fn(() => () => {}),
 }));
 
 vi.mock('~/src/storage/keys', () => ({
@@ -119,5 +120,34 @@ describe('openai HTTP 路径', () => {
     await expect(
       openai.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
     ).rejects.toThrow();
+  });
+
+  test('并发闸门：并发 translate() 调用在飞请求不超过 maxConcurrency（#159）', async () => {
+    const { getSettings } = await import('~/src/storage/settings');
+    vi.mocked(getSettings).mockReturnValue({ maxConcurrency: 2, models: { openai: 'gpt-4o' } } as never);
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+
+    let inFlight = 0;
+    let peak = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 10));
+      inFlight--;
+      return okResp('1. 你好');
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { openai } = await import('~/src/engines/openai');
+    const resps = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        openai.translate({ texts: ['Hello'], from: 'en', to: 'zh-CN' }),
+      ),
+    );
+
+    expect(resps.every((r) => r.translations[0] === '你好')).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(8);
+    expect(peak).toBeLessThanOrEqual(2);
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.70",
+  "version": "0.6.71",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/bing-edge.ts
+++ b/src/engines/bing-edge.ts
@@ -4,14 +4,21 @@
 // JWT 缓存约 10 分钟，解析 exp 复用，401 清空重取。
 
 import { fetchWithTimeout } from './fetch-timeout';
+import { engineGate } from './engine-gate';
 import { EngineError } from './types';
 import type { TranslateEngine } from './types';
+
+// #159: 引擎级并发闸门 —— 整页翻译批次并发 → translate() 并发调用
+const getGate = engineGate();
 
 const AUTH_ENDPOINT = 'https://edge.microsoft.com/translate/auth';
 const TRANS_ENDPOINT =
   'https://api-edge.cognitive.microsofttranslator.com/translate';
 
 let cachedJwt: string | null = null;
+/** 在飞的 auth 请求（single-flight，#159）—— 并发 translate() 首取 JWT
+ * 时只发一次 auth 请求，其余调用共享同一个 promise。 */
+let jwtPromise: Promise<string> | null = null;
 
 function isExpired(jwt: string): boolean {
   try {
@@ -25,13 +32,20 @@ function isExpired(jwt: string): boolean {
 
 async function getJwt(): Promise<string> {
   if (cachedJwt && !isExpired(cachedJwt)) return cachedJwt;
-
-  const resp = await fetchWithTimeout('bing-edge', AUTH_ENDPOINT);
-  if (!resp.ok) {
-    throw new EngineError('bing-edge', true, `auth HTTP ${resp.status}`);
+  if (!jwtPromise) {
+    jwtPromise = (async () => {
+      const resp = await fetchWithTimeout('bing-edge', AUTH_ENDPOINT);
+      if (!resp.ok) {
+        throw new EngineError('bing-edge', true, `auth HTTP ${resp.status}`);
+      }
+      cachedJwt = await resp.text(); // 返回纯文本 JWT，非 JSON
+      return cachedJwt!;
+    })().finally(() => {
+      // 无论成败都清掉在飞引用，下次调用可重新发起
+      jwtPromise = null;
+    });
   }
-  cachedJwt = await resp.text(); // 返回纯文本 JWT，非 JSON
-  return cachedJwt!;
+  return jwtPromise;
 }
 
 export const bingEdge: TranslateEngine = {
@@ -41,39 +55,42 @@ export const bingEdge: TranslateEngine = {
   supportedLangs: 'all',
 
   async translate({ texts, from, to }) {
-    const jwt = await getJwt();
+    // #159: 整个请求体（含 JWT 获取）过闸门，限制并发在飞请求数
+    return getGate()(async () => {
+      const jwt = await getJwt();
 
-    // auto → 空字符串（Bing 不接受 'auto' 字面量）
-    const fromParam = from === 'auto' ? '' : from;
+      // auto → 空字符串（Bing 不接受 'auto' 字面量）
+      const fromParam = from === 'auto' ? '' : from;
 
-    const qs = new URLSearchParams({
-      from: fromParam,
-      to,
-      'api-version': '3.0',
-      textType: 'html',
+      const qs = new URLSearchParams({
+        from: fromParam,
+        to,
+        'api-version': '3.0',
+        textType: 'html',
+      });
+
+      const resp = await fetchWithTimeout('bing-edge', `${TRANS_ENDPOINT}?${qs}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${jwt}`,
+        },
+        body: JSON.stringify(texts.map((Text) => ({ Text }))),
+      });
+
+      if (!resp.ok) {
+        if (resp.status === 401) cachedJwt = null;
+        throw new EngineError('bing-edge', true, `HTTP ${resp.status}`);
+      }
+
+      const data = await resp.json();
+      const translations: string[] = data.map(
+        (d: any) => d.translations[0].text as string,
+      );
+      const detectedFrom =
+        data[0]?.detectedLanguage?.language as string | undefined;
+
+      return { translations, detectedFrom };
     });
-
-    const resp = await fetchWithTimeout('bing-edge', `${TRANS_ENDPOINT}?${qs}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${jwt}`,
-      },
-      body: JSON.stringify(texts.map((Text) => ({ Text }))),
-    });
-
-    if (!resp.ok) {
-      if (resp.status === 401) cachedJwt = null;
-      throw new EngineError('bing-edge', true, `HTTP ${resp.status}`);
-    }
-
-    const data = await resp.json();
-    const translations: string[] = data.map(
-      (d: any) => d.translations[0].text as string,
-    );
-    const detectedFrom =
-      data[0]?.detectedLanguage?.language as string | undefined;
-
-    return { translations, detectedFrom };
   },
 };

--- a/src/engines/deepl.ts
+++ b/src/engines/deepl.ts
@@ -4,8 +4,12 @@
 
 import { getKey } from '~/src/storage/keys';
 import { fetchWithTimeout } from './fetch-timeout';
+import { engineGate } from './engine-gate';
 import { EngineError } from './types';
 import type { TranslateEngine } from './types';
+
+// #159: 引擎级并发闸门 —— 整页翻译批次并发 → translate() 并发调用
+const getGate = engineGate();
 
 /** 免费版 key 以 :fx 结尾，必须走 free 端点 */
 function endpointFor(key: string): string {
@@ -58,53 +62,56 @@ export const deepl: TranslateEngine = {
   ],
 
   async translate({ texts, from, to }) {
-    const key = await getKey('deepl');
-    if (!key) throw new EngineError('deepl', false, '未配置 API key');
+    // #159: 整个请求体过闸门，限制并发在飞请求数
+    return getGate()(async () => {
+      const key = await getKey('deepl');
+      if (!key) throw new EngineError('deepl', false, '未配置 API key');
 
-    const endpoint = endpointFor(key);
+      const endpoint = endpointFor(key);
 
-    // DeepL 使用 'EN' / 'ZH' 大写格式，尝试标准化
-    const normalizeLang = (code: string): string => {
-      // 'auto' → null（让 DeepL 自动检测）
-      if (code === 'auto') return '';
-      // DeepL API v2 不接受带国家后缀的中文码，官方只认 ZH / ZH-HANS / ZH-HANT（#155）
-      if (code === 'zh-CN') return 'ZH-HANS';
-      if (code === 'zh-TW') return 'ZH-HANT';
-      return code.toUpperCase();
-    };
+      // DeepL 使用 'EN' / 'ZH' 大写格式，尝试标准化
+      const normalizeLang = (code: string): string => {
+        // 'auto' → null（让 DeepL 自动检测）
+        if (code === 'auto') return '';
+        // DeepL API v2 不接受带国家后缀的中文码，官方只认 ZH / ZH-HANS / ZH-HANT（#155）
+        if (code === 'zh-CN') return 'ZH-HANS';
+        if (code === 'zh-TW') return 'ZH-HANT';
+        return code.toUpperCase();
+      };
 
-    const body = new URLSearchParams();
-    body.append('target_lang', normalizeLang(to) || to.toUpperCase());
-    if (from !== 'auto') body.append('source_lang', normalizeLang(from));
-    for (const text of texts) {
-      body.append('text', text);
-    }
+      const body = new URLSearchParams();
+      body.append('target_lang', normalizeLang(to) || to.toUpperCase());
+      if (from !== 'auto') body.append('source_lang', normalizeLang(from));
+      for (const text of texts) {
+        body.append('text', text);
+      }
 
-    const resp = await fetchWithTimeout('deepl', endpoint, {
-      method: 'POST',
-      headers: {
-        Authorization: `DeepL-Auth-Key ${key}`,
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: body.toString(),
+      const resp = await fetchWithTimeout('deepl', endpoint, {
+        method: 'POST',
+        headers: {
+          Authorization: `DeepL-Auth-Key ${key}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: body.toString(),
+      });
+
+      if (resp.status === 403 || resp.status === 401) {
+        throw new EngineError('deepl', false, 'API key 无效');
+      }
+      if (!resp.ok) {
+        throw new EngineError('deepl', true, `HTTP ${resp.status}`);
+      }
+
+      const data = await resp.json();
+      const translations: string[] = (
+        data.translations as Array<{ text: string }>
+      ).map((t) => t.text);
+      const detectedFrom =
+        data.translations?.[0]?.detected_source_language as
+          | string
+          | undefined;
+
+      return { translations, detectedFrom };
     });
-
-    if (resp.status === 403 || resp.status === 401) {
-      throw new EngineError('deepl', false, 'API key 无效');
-    }
-    if (!resp.ok) {
-      throw new EngineError('deepl', true, `HTTP ${resp.status}`);
-    }
-
-    const data = await resp.json();
-    const translations: string[] = (
-      data.translations as Array<{ text: string }>
-    ).map((t) => t.text);
-    const detectedFrom =
-      data.translations?.[0]?.detected_source_language as
-        | string
-        | undefined;
-
-    return { translations, detectedFrom };
   },
 };

--- a/src/engines/engine-gate.ts
+++ b/src/engines/engine-gate.ts
@@ -1,0 +1,29 @@
+// 引擎级并发闸门 —— #159。
+//
+// 整页翻译的所有批次在 content 侧并发发出（Promise.all），每个引擎的
+// translate() 会被并发调用多次。此前只有 google-web 有模块级惰性单例
+// 闸门（逐文本限流），bing-edge / deepl / openai / gemini 都是裸 fetch：
+// Bing 易 429 整批降级、付费 LLM 并发付费调用费用放大、DeepL 免费版
+// 对并发敏感。
+//
+// 此模块把闸门提升为引擎公共层：每个引擎模块加载时调一次 engineGate()，
+// 得到模块级惰性单例的获取函数 —— 跨所有调用共享，上限随设置动态调整。
+
+import { createGate } from '~/src/queue/concurrency';
+import { getSettings, onSettingsChanged } from '~/src/storage/settings';
+
+/**
+ * 返回引擎的惰性闸门获取函数。
+ *
+ * 上限推迟到首次翻译时读取，避免模块 import 时设置尚未加载；设置变更
+ * 时调 setMax 改上限，保留当前 active 计数与等待队列，避免 gate=null
+ * 重建导致两个闸门并发翻倍。
+ */
+export function engineGate(): () => ReturnType<typeof createGate> {
+  let gate: ReturnType<typeof createGate> | null = null;
+  onSettingsChanged(() => {
+    if (gate) gate.setMax(getSettings().maxConcurrency);
+    else gate = createGate(getSettings().maxConcurrency);
+  });
+  return () => (gate ??= createGate(getSettings().maxConcurrency));
+}

--- a/src/engines/gemini.ts
+++ b/src/engines/gemini.ts
@@ -5,9 +5,13 @@ import { getKey } from '~/src/storage/keys';
 import { getSettings } from '~/src/storage/settings';
 import { normalizeText } from '~/src/dom/normalize';
 import { fetchWithTimeout } from './fetch-timeout';
+import { engineGate } from './engine-gate';
 import { EngineError } from './types';
 import { parseNumbered } from './openai';
 import type { TranslateEngine } from './types';
+
+// #159: 引擎级并发闸门 —— 整页翻译批次并发 → translate() 并发调用
+const getGate = engineGate();
 
 export const gemini: TranslateEngine = {
   id: 'gemini',
@@ -16,48 +20,51 @@ export const gemini: TranslateEngine = {
   supportedLangs: 'all',
 
   async translate({ texts, from, to }) {
-    const key = await getKey('gemini');
-    if (!key) throw new EngineError('gemini', false, '未配置 API key');
+    // #159: 整个请求体过闸门，限制并发在飞请求数
+    return getGate()(async () => {
+      const key = await getKey('gemini');
+      if (!key) throw new EngineError('gemini', false, '未配置 API key');
 
-    const model = getSettings().models?.gemini ?? 'gemini-2.0-flash';
-    // key 走 x-goog-api-key 请求头而非 ?key= query。
-    // URL 会进浏览器网络日志、DevTools 记录与任何中间层的访问日志，请求头不会；
-    // 另两个引擎也都是走头，保持一致。
-    const endpoint =
-      `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
+      const model = getSettings().models?.gemini ?? 'gemini-2.0-flash';
+      // key 走 x-goog-api-key 请求头而非 ?key= query。
+      // URL 会进浏览器网络日志、DevTools 记录与任何中间层的访问日志，请求头不会；
+      // 另两个引擎也都是走头，保持一致。
+      const endpoint =
+        `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
 
-    // 与 openai 相同（#30）：编号结构靠 \n 分隔，文本自带换行会把编号撑破
-    // 导致 LLM 重编号、parseNumbered 回填错位，拼 prompt 前压一次（#160）。
-    const numbered = texts
-      .map((t, i) => `${i + 1}. ${normalizeText(t)}`)
-      .join('\n');
-    const prompt =
-      `将以下编号文本翻译成${to}${from === 'auto' ? '' : `（源语言：${from}）`}。` +
-      `严格保持编号与行数一致，只输出译文，不要解释。\n\n${numbered}`;
+      // 与 openai 相同（#30）：编号结构靠 \n 分隔，文本自带换行会把编号撑破
+      // 导致 LLM 重编号、parseNumbered 回填错位，拼 prompt 前压一次（#160）。
+      const numbered = texts
+        .map((t, i) => `${i + 1}. ${normalizeText(t)}`)
+        .join('\n');
+      const prompt =
+        `将以下编号文本翻译成${to}${from === 'auto' ? '' : `（源语言：${from}）`}。` +
+        `严格保持编号与行数一致，只输出译文，不要解释。\n\n${numbered}`;
 
-    const resp = await fetchWithTimeout('gemini', endpoint, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-goog-api-key': key,
-      },
-      body: JSON.stringify({
-        contents: [{ parts: [{ text: prompt }] }],
-        generationConfig: { temperature: 0 },
-      }),
+      const resp = await fetchWithTimeout('gemini', endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-goog-api-key': key,
+        },
+        body: JSON.stringify({
+          contents: [{ parts: [{ text: prompt }] }],
+          generationConfig: { temperature: 0 },
+        }),
+      });
+
+      if (resp.status === 400 || resp.status === 403) {
+        // 400 可能是无效 key（Gemini 把 auth 错误也打成 400）
+        throw new EngineError('gemini', false, 'API key 无效');
+      }
+      if (!resp.ok) {
+        throw new EngineError('gemini', true, `HTTP ${resp.status}`);
+      }
+
+      const data = await resp.json();
+      const raw = data.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+      const out = parseNumbered(raw, texts.length);
+      return { translations: out };
     });
-
-    if (resp.status === 400 || resp.status === 403) {
-      // 400 可能是无效 key（Gemini 把 auth 错误也打成 400）
-      throw new EngineError('gemini', false, 'API key 无效');
-    }
-    if (!resp.ok) {
-      throw new EngineError('gemini', true, `HTTP ${resp.status}`);
-    }
-
-    const data = await resp.json();
-    const raw = data.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
-    const out = parseNumbered(raw, texts.length);
-    return { translations: out };
   },
 };

--- a/src/engines/google-web.ts
+++ b/src/engines/google-web.ts
@@ -2,9 +2,8 @@
 // 端点 translate.googleapis.com，单次只接受一段文本，批量靠并发多请求；
 // 外裹并发闸门防限流。
 
-import { getSettings, onSettingsChanged } from '~/src/storage/settings';
-import { createGate } from '~/src/queue/concurrency';
 import { fetchWithTimeout } from './fetch-timeout';
+import { engineGate } from './engine-gate';
 import { EngineError } from './types';
 import type { TranslateEngine } from './types';
 
@@ -39,19 +38,9 @@ async function fetchOne(
   return parts.join('');
 }
 
-// 惰性单例闸门 —— 阶段 3 起同一域名可能有多次并行 route() 调用，
-// 每次新建闸门会导致总并发 = 6 × 调用数，限流失效。
-// 上限推迟到首次翻译时读取，避免模块 import 时设置尚未加载。
-// 设置变更时调 setMax 改上限，保留当前 active 计数与等待队列，
-// 避免 gate=null 重建导致两个闸门并发翻倍。
-let gate: ReturnType<typeof createGate> | null = null;
-function getGate() {
-  return (gate ??= createGate(getSettings().maxConcurrency));
-}
-onSettingsChanged(() => {
-  if (gate) gate.setMax(getSettings().maxConcurrency);
-  else gate = createGate(getSettings().maxConcurrency);
-});
+// #159: 惰性单例闸门（引擎公共层）—— 阶段 3 起同一域名可能有多次
+// 并行 route() 调用，每次新建闸门会导致总并发 = 6 × 调用数，限流失效。
+const getGate = engineGate();
 
 export const googleWeb: TranslateEngine = {
   id: 'google-web',

--- a/src/engines/openai.ts
+++ b/src/engines/openai.ts
@@ -6,10 +6,14 @@ import { getKey } from '~/src/storage/keys';
 import { getSettings } from '~/src/storage/settings';
 import { normalizeText } from '~/src/dom/normalize';
 import { fetchWithTimeout } from './fetch-timeout';
+import { engineGate } from './engine-gate';
 import { EngineError } from './types';
 import type { TranslateEngine } from './types';
 
 const DEFAULT_ENDPOINT = 'https://api.openai.com/v1/chat/completions';
+
+// #159: 引擎级并发闸门 —— 整页翻译批次并发 → translate() 并发调用
+const getGate = engineGate();
 
 /**
  * 解析 LLM 编号输出为译文数组。
@@ -32,43 +36,46 @@ export const openai: TranslateEngine = {
   supportedLangs: 'all',
 
   async translate({ texts, from, to }) {
-    const key = await getKey('openai');
-    if (!key) throw new EngineError('openai', false, '未配置 API key');
+    // #159: 整个请求体过闸门，限制并发在飞请求数
+    return getGate()(async () => {
+      const key = await getKey('openai');
+      if (!key) throw new EngineError('openai', false, '未配置 API key');
 
-    const model = getSettings().models?.openai ?? 'gpt-4o-mini';
+      const model = getSettings().models?.openai ?? 'gpt-4o-mini';
 
-    // 纵深防御：编号结构靠 \n 分隔，文本自带的换行会把编号撑破导致错位。
-    // 即便入口采集漏了归一化，这里也必须兜住，拼 prompt 前再压一次。
-    const numbered = texts
-      .map((t, i) => `${i + 1}. ${normalizeText(t)}`)
-      .join('\n');
-    const prompt =
-      `将以下编号文本翻译成${to}${from === 'auto' ? '' : `（源语言：${from}）`}。` +
-      `严格保持编号与行数一致，只输出译文，不要解释。\n\n${numbered}`;
+      // 纵深防御：编号结构靠 \n 分隔，文本自带的换行会把编号撑破导致错位。
+      // 即便入口采集漏了归一化，这里也必须兜住，拼 prompt 前再压一次。
+      const numbered = texts
+        .map((t, i) => `${i + 1}. ${normalizeText(t)}`)
+        .join('\n');
+      const prompt =
+        `将以下编号文本翻译成${to}${from === 'auto' ? '' : `（源语言：${from}）`}。` +
+        `严格保持编号与行数一致，只输出译文，不要解释。\n\n${numbered}`;
 
-    const resp = await fetchWithTimeout('openai', DEFAULT_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${key}`,
-      },
-      body: JSON.stringify({
-        model,
-        messages: [{ role: 'user', content: prompt }],
-        temperature: 0,
-      }),
+      const resp = await fetchWithTimeout('openai', DEFAULT_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${key}`,
+        },
+        body: JSON.stringify({
+          model,
+          messages: [{ role: 'user', content: prompt }],
+          temperature: 0,
+        }),
+      });
+
+      if (resp.status === 401 || resp.status === 403) {
+        throw new EngineError('openai', false, 'API key 无效');
+      }
+      if (!resp.ok) {
+        throw new EngineError('openai', true, `HTTP ${resp.status}`);
+      }
+
+      const data = await resp.json();
+      const raw = data.choices?.[0]?.message?.content ?? '';
+      const out = parseNumbered(raw, texts.length);
+      return { translations: out };
     });
-
-    if (resp.status === 401 || resp.status === 403) {
-      throw new EngineError('openai', false, 'API key 无效');
-    }
-    if (!resp.ok) {
-      throw new EngineError('openai', true, `HTTP ${resp.status}`);
-    }
-
-    const data = await resp.json();
-    const raw = data.choices?.[0]?.message?.content ?? '';
-    const out = parseNumbered(raw, texts.length);
-    return { translations: out };
   },
 };


### PR DESCRIPTION
## 问题
只有 google-web 有并发闸门（模块级惰性单例），bing-edge / deepl / openai / gemini 都是裸 fetch：整页翻译所有批次并发发出时，Bing 易 429 整批降级、付费 LLM 并发付费调用费用放大、DeepL 免费版对并发敏感。

## 修复
把闸门提升为引擎公共层（engineGate()）：每个引擎模块级惰性单例，全部引擎限流；bing-edge 的 JWT 获取同时加 single-flight，首取只发一次 auth 请求。

## 验证
- 新增单测：各引擎并发 8 次 translate() → 在飞请求数 ≤ maxConcurrency
- 单元测试 405 项、core E2E 27 项全部通过