### PR TITLE
fix(gemini): 解析错误体区分认证/超长/模型错误 —— 400 不再一律判 key 无效（#161）

### DIFF
--- a/docs/testing/unit/engines/gemini-http.test.ts
+++ b/docs/testing/unit/engines/gemini-http.test.ts
@@ -89,20 +89,89 @@ describe('gemini HTTP 路径', () => {
     expect(body.contents[0].parts[0].text).not.toContain('\nline');
   });
 
-  test('400 / 403 → EngineError（retryable=false，key 无效）', async () => {
+  test('403 → EngineError（retryable=false，key 无效）', async () => {
     const { getKey } = await import('~/src/storage/keys');
     vi.mocked(getKey).mockResolvedValue('bad');
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('err', { status: 400 })));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('err', { status: 403 })));
     const { gemini } = await import('~/src/engines/gemini');
     await expect(
       gemini.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
     ).rejects.toMatchObject({ retryable: false, message: 'API key 无效' });
+  });
 
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('err', { status: 403 })));
-    const { gemini: gemini2 } = await import('~/src/engines/gemini');
+  test('400 带「API key not valid」错误体 → retryable=false，key 无效（#161）', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('bad');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 400,
+              message: 'API key not valid. Please pass a valid API key.',
+              status: 'INVALID_ARGUMENT',
+            },
+          }),
+          { status: 400, headers: { 'content-type': 'application/json' } },
+        ),
+      ),
+    );
+    const { gemini } = await import('~/src/engines/gemini');
     await expect(
-      gemini2.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+      gemini.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
     ).rejects.toMatchObject({ retryable: false, message: 'API key 无效' });
+  });
+
+  test('400 带「input too large」错误体 → retryable，交给下一引擎降级（#161）', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 400,
+              message: 'The input token count (12345) exceeds the maximum token limit (1048576).',
+              status: 'INVALID_ARGUMENT',
+            },
+          }),
+          { status: 400, headers: { 'content-type': 'application/json' } },
+        ),
+      ),
+    );
+    const { gemini } = await import('~/src/engines/gemini');
+    await expect(
+      gemini.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({
+      retryable: true,
+      message: /exceeds the maximum token limit/,
+    });
+  });
+
+  test('404（模型名错误）→ retryable（#161）', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 404,
+              message: 'models/gemini-typo is not found.',
+              status: 'NOT_FOUND',
+            },
+          }),
+          { status: 404, headers: { 'content-type': 'application/json' } },
+        ),
+      ),
+    );
+    const { gemini } = await import('~/src/engines/gemini');
+    await expect(
+      gemini.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({ retryable: true, message: /is not found/ });
   });
 
   test('其他非 200 → EngineError（retryable）', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.71",
+  "version": "0.6.72",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/gemini.ts
+++ b/src/engines/gemini.ts
@@ -13,6 +13,46 @@ import type { TranslateEngine } from './types';
 // #159: 引擎级并发闸门 —— 整页翻译批次并发 → translate() 并发调用
 const getGate = engineGate();
 
+/**
+ * 按 Gemini 错误体区分错误类别 —— #161。
+ *
+ * Gemini 的 400 覆盖多种情况：key 无效、上下文过长（input too large）、
+ * 内容被安全拦截；403 也不只来自 key。此前一律判「key 无效」且
+ * retryable=false，router 直接抛错不尝试后续引擎，超长文本/模型名错误
+ * 会让整页翻译失败。这里只对确凿的认证错误置 non-retryable，
+ * 其余 400/404（超长、模型名、安全拦截）交给下一引擎降级。
+ */
+async function classifyError(resp: Response): Promise<EngineError> {
+  let status = '';
+  let message = '';
+  try {
+    // Gemini 错误体形如 { error: { code, message, status } }
+    const body = (await resp.json()) as {
+      error?: { status?: string; message?: string };
+    };
+    status = body.error?.status ?? '';
+    message = body.error?.message ?? '';
+  } catch {
+    // 非 JSON 错误体，按状态码兜底
+  }
+
+  // 确凿的认证错误 → 立即提示用户，不浪费后续引擎
+  const isAuth =
+    resp.status === 403 ||
+    status === 'UNAUTHENTICATED' ||
+    status === 'PERMISSION_DENIED' ||
+    /API key/i.test(message) ||
+    /API_KEY_INVALID/i.test(message);
+  if (isAuth) {
+    return new EngineError('gemini', false, 'API key 无效');
+  }
+
+  // 其余错误（上下文过长 / 模型名错误 / 安全拦截等）→ retryable，
+  // router 降级到下一引擎，页面翻译不中断
+  const detail = message ? `：${message}` : '';
+  return new EngineError('gemini', true, `HTTP ${resp.status}${detail}`);
+}
+
 export const gemini: TranslateEngine = {
   id: 'gemini',
   displayName: 'Gemini',
@@ -53,12 +93,8 @@ export const gemini: TranslateEngine = {
         }),
       });
 
-      if (resp.status === 400 || resp.status === 403) {
-        // 400 可能是无效 key（Gemini 把 auth 错误也打成 400）
-        throw new EngineError('gemini', false, 'API key 无效');
-      }
       if (!resp.ok) {
-        throw new EngineError('gemini', true, `HTTP ${resp.status}`);
+        throw await classifyError(resp);
       }
 
       const data = await resp.json();


### PR DESCRIPTION
## 问题
Gemini 的 400 一律判「API key 无效」且 retryable=false，router 立即抛错不尝试后续引擎：超长文本（input too large）、模型名错误等场景整页翻译失败，文案还误导用户。

## 修复
解析响应错误体（error.status / error.message）分类：403 / UNAUTHENTICATED / PERMISSION_DENIED / 含「API key」信息 → key 无效（non-retryable）；其余 400/404（超长、模型名、安全拦截）→ retryable，交给下一引擎降级，并在报错中附带 API 原始信息。

## 验证
- 新增单测：400+input too large → retryable；400+API key not valid → key 无效；404 模型不存在 → retryable
- 单元测试 408 项、core E2E 27 项全部通过