### PR TITLE
fix(styles): shadow root 注入扩展样式 —— shadow 内译文受模式/预设控制（#163）

### DIFF
--- a/docs/testing/e2e/core.spec.ts
+++ b/docs/testing/e2e/core.spec.ts
@@ -239,6 +239,39 @@ test.describe('Fixture: shadow', () => {
     // walker 穿透 shadow 后会翻译其中的内容
     expect(hasTranslated).toBe(true);
   });
+
+  test('@core TC-E2E-54: shadow 内译文受仅译文模式控制 —— 原文被隐藏（#163 回归）', async ({
+    page, mockGoogle, seedSettings, gotoFixture,
+  }) => {
+    await seedSettings({});
+    await mockGoogle();
+    await gotoFixture('shadow');
+
+    await translateAndWait(page);
+
+    // 切到仅译文模式（快捷键）
+    await page.keyboard.press(
+      process.platform === 'darwin' ? 'Meta+Shift+M' : 'Control+Shift+M',
+    );
+    await expect(page.locator('html')).toHaveClass(/pt-only-trans-page/, { timeout: 5_000 });
+
+    // 对照组：文档侧 .pt-origin 被隐藏
+    const docOriginDisplay = await page.evaluate(() => {
+      const origin = document.querySelector('[data-pt="done"] .pt-origin') as HTMLElement | null;
+      return origin ? getComputedStyle(origin).display : null;
+    });
+    expect(docOriginDisplay).toBe('none');
+
+    // #163 主体：shadow 内 .pt-origin 也被隐藏（样式注入生效）
+    const shadowOriginDisplay = await page.evaluate(() => {
+      const host = document.getElementById('host1');
+      const origin = host?.shadowRoot?.querySelector(
+        '[data-pt="done"] .pt-origin',
+      ) as HTMLElement | null;
+      return origin ? getComputedStyle(origin).display : null;
+    });
+    expect(shadowOriginDisplay).toBe('none');
+  });
 });
 
 test.describe('Fixture: nested', () => {

--- a/docs/testing/unit/styles/shadow.test.ts
+++ b/docs/testing/unit/styles/shadow.test.ts
@@ -1,0 +1,45 @@
+/**
+ * styles/shadow.ts — shadow root 样式注入（#163）
+ *
+ * 扩展 CSS 不跨 shadow 边界，shadow 内译文须经 <style> 注入
+ * tokens + presets + :host-context 变体才能被模式/样式预设控制。
+ */
+import { describe, test, expect } from 'vitest';
+import { injectShadowStyles } from '~/src/styles/shadow';
+
+describe('shadow 样式注入（#163）', () => {
+  test('注入 <style>，含 :host-context 变体与基础结构规则', () => {
+    const host = document.createElement('div');
+    const root = host.attachShadow({ mode: 'open' });
+    injectShadowStyles(root);
+
+    const style = root.querySelector('style');
+    expect(style).toBeTruthy();
+    const css = style!.textContent ?? '';
+    // 仅译文模式变体（文档侧类经宿主祖先链生效）
+    expect(css).toContain(":host-context(.pt-only-trans-page) [data-pt-src='page'] .pt-origin");
+    // 样式预设变体
+    expect(css).toContain(':host-context(.pt-style-default) .pt-trans');
+    // 元素级基础规则
+    expect(css).toContain('.pt-trans');
+  });
+
+  test('幂等：重复注入只产生一个 <style>', () => {
+    const host = document.createElement('div');
+    const root = host.attachShadow({ mode: 'open' });
+    injectShadowStyles(root);
+    injectShadowStyles(root);
+    expect(root.querySelectorAll('style')).toHaveLength(1);
+  });
+
+  test('不同 shadow root 各自注入', () => {
+    const h1 = document.createElement('div');
+    const h2 = document.createElement('div');
+    const r1 = h1.attachShadow({ mode: 'open' });
+    const r2 = h2.attachShadow({ mode: 'open' });
+    injectShadowStyles(r1);
+    injectShadowStyles(r2);
+    expect(r1.querySelectorAll('style')).toHaveLength(1);
+    expect(r2.querySelectorAll('style')).toHaveLength(1);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.72",
+  "version": "0.6.73",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/observer.ts
+++ b/src/dom/observer.ts
@@ -18,6 +18,7 @@
 // - rootMargin 提前 300px 触发，让即将滚入视口的内容提前翻译。
 
 import { collect } from './walker';
+import { injectShadowStyles } from '~/src/styles/shadow';
 
 /**
  * 递归收集 root 下所有 shadowRoot，对每个挂载 observer。
@@ -34,6 +35,9 @@ function observeShadowRoots(
   const attach = (el: Element): boolean => {
     if (!el.shadowRoot || seen.has(el.shadowRoot)) return false;
     seen.add(el.shadowRoot);
+    // #163: 扩展样式不跨 shadow 边界 —— 先注入样式再挂 observer，
+    // 避免注入动作触发自身 mutation 记录
+    injectShadowStyles(el.shadowRoot);
     const mo = new MutationObserver(onMutation);
     mo.observe(el.shadowRoot, { childList: true, subtree: true });
     observers.push(mo);

--- a/src/dom/renderer.ts
+++ b/src/dom/renderer.ts
@@ -9,6 +9,7 @@
 
 import type { DisplayMode, StyleId } from '../storage/schema';
 import { hasNonTextContent } from './classify';
+import { injectShadowStyles } from '~/src/styles/shadow';
 
 /** 渲染来源：区分整页翻译与单段翻译，落成 data-pt-src 属性供 CSS 分流。 */
 export type RenderSource = 'page' | 'para';
@@ -25,6 +26,13 @@ export function render(
   src: RenderSource = 'page',
 ): boolean {
   if (el.getAttribute('data-pt') === 'done') return true;
+
+  // #163: 翻译单元位于 shadow root 内时补注入扩展样式 ——
+  // 单段翻译路径可能早于 observer 启动，此时 shadow 内尚无样式
+  const rootNode = el.getRootNode();
+  if (rootNode instanceof ShadowRoot) {
+    injectShadowStyles(rootNode);
+  }
 
   // 纵深防御：拒绝含非文本内容的容器，防止缩略图、按钮等被藏进
   // display:none 的 .pt-origin（#22）。

--- a/src/styles/shadow.ts
+++ b/src/styles/shadow.ts
@@ -1,0 +1,73 @@
+// #163: 扩展样式不跨 shadow 边界 —— shadow 内译文不受模式/样式预设控制。
+//
+// content script 的 CSS（presets.css / tokens.css）由 Chrome 以文档级样式
+// 注入，不会穿透 shadow root（YouTube/Reddit 等站的核心内容都在 shadow
+// 里）。此模块把 tokens + presets + :host-context 变体以 <style> 注入每个
+// 被翻译/被观察的 shadow root：
+// - 元素级规则（.pt-trans { display:block } 等）直接生效；
+// - 模式/样式预设规则依赖文档 <html> 上的类（pt-only-trans-page、
+//   pt-style-* 等），在 shadow 树内匹配不到祖先 —— 用 :host-context
+//   变体让文档侧的类经宿主祖先链生效。
+// 不支持 :host-context 的浏览器（Safari <18 / Firefox <128）降级为
+// 修复前行为：shadow 内译文不受预设控制，功能不受损。
+
+import tokensCss from './tokens.css?inline';
+import presetsCss from './presets.css?inline';
+
+/** :host-context 变体 —— 与 presets.css 一一对应，仅作用于 shadow 内译文 */
+const HOST_CONTEXT_CSS = `
+/* 仅译文模式（按来源分流） */
+:host-context(.pt-only-trans-page) [data-pt-src='page'] .pt-origin { display: none; }
+:host-context(.pt-only-trans-para) [data-pt-src='para'] .pt-origin { display: none; }
+
+/* 6 种样式预设 */
+:host-context(.pt-style-default) .pt-trans {
+  border-left: 2px solid var(--pt-brass);
+  padding-left: 0.5em;
+  opacity: 0.6;
+}
+:host-context(.pt-style-dim) .pt-trans {
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+:host-context(.pt-style-dim) [data-pt='done']:hover .pt-trans {
+  opacity: 1;
+}
+:host-context(.pt-style-underline) .pt-trans {
+  text-decoration: underline solid;
+  text-underline-offset: 3px;
+}
+:host-context(.pt-style-bold) .pt-trans {
+  font-weight: 700;
+}
+:host-context(.pt-style-italic) .pt-trans {
+  font-style: italic;
+}
+:host-context(.pt-style-fade) .pt-trans {
+  opacity: 0.6;
+}
+`;
+
+let cssText: string | null = null;
+
+/** shadow 注入用完整样式文本（tokens + presets + :host-context 变体）。 */
+export function shadowStylesCss(): string {
+  return (cssText ??= `${tokensCss}
+${presetsCss}
+${HOST_CONTEXT_CSS}`);
+}
+
+/** 已注入样式的 shadow root，避免重复注入（防抖外的幂等保护）。 */
+const injectedRoots = new WeakSet<ShadowRoot>();
+
+/**
+ * 向 shadow root 注入扩展样式（幂等）。
+ * 必须在 observer 挂载前调用（避免注入动作触发自身的 mutation 记录）。
+ */
+export function injectShadowStyles(root: ShadowRoot): void {
+  if (injectedRoots.has(root)) return;
+  injectedRoots.add(root);
+  const style = document.createElement('style');
+  style.textContent = shadowStylesCss();
+  root.appendChild(style);
+}


### PR DESCRIPTION
## 问题
扩展穿透 shadow DOM 翻译内容，但样式只注入文档级，不跨 shadow 边界：shadow 内译文不受仅译文模式（原文不隐藏）、样式预设控制。

## 修复
新增 shadow 样式注入模块：observer 挂载 shadow root 时、render 遇到 shadow 内单元时，把 tokens + presets + :host-context 变体以 <style> 注入该 shadow root（幂等）。不支持 :host-context 的旧浏览器降级为原行为。

## 验证
- 新增 E2E TC-E2E-54：shadow 内 .pt-origin 在仅译文模式下 display:none
- 新增单测：注入内容/幂等性/多 root 各自注入
- 单元测试 411 项、core E2E 28 项全部通过