### PR TITLE
fix(hotkeys): 过滤 keydown 重复事件 + await detectOS —— 按住连发/ Mac 首次按键失效（#164）

### DIFF
--- a/docs/testing/unit/hotkeys/listener.test.ts
+++ b/docs/testing/unit/hotkeys/listener.test.ts
@@ -1,0 +1,60 @@
+/**
+ * hotkeys/listener.ts — 快捷键监听器（#164）
+ *
+ * 覆盖：e.repeat 重复事件过滤、组合键命中 handler。
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('~/src/storage/settings', () => ({
+  getSettings: vi.fn(() => ({
+    hotkeys: { 'toggle-translate': 'Mod+Shift+Y' },
+  })),
+}));
+
+vi.mock('~/src/hotkeys/platform', () => ({
+  getOSSync: vi.fn(() => 'mac'),
+}));
+
+import { startHotkeys } from '~/src/hotkeys/listener';
+
+function keydown(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+}
+
+describe('startHotkeys', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('命中组合键 → 触发 handler', () => {
+    const handler = vi.fn();
+    const stop = startHotkeys({ 'toggle-translate': handler });
+    document.dispatchEvent(
+      keydown({ key: 'y', metaKey: true, shiftKey: true }),
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  test('repeat=true（按住连发）→ 不触发 handler（#164）', () => {
+    const handler = vi.fn();
+    const stop = startHotkeys({ 'toggle-translate': handler });
+    document.dispatchEvent(
+      keydown({ key: 'y', metaKey: true, shiftKey: true, repeat: true }),
+    );
+    expect(handler).not.toHaveBeenCalled();
+    stop();
+  });
+
+  test('未命中组合键 → 不触发 handler', () => {
+    const handler = vi.fn();
+    const stop = startHotkeys({ 'toggle-translate': handler });
+    document.dispatchEvent(keydown({ key: 'y', metaKey: true }));
+    expect(handler).not.toHaveBeenCalled();
+    stop();
+  });
+});

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -53,7 +53,9 @@ export default defineContentScript({
   runAt: 'document_end',
   async main() {
     await settingsReady();
-    detectOS(); // 预热平台缓存
+    // #164: 必须等平台缓存就绪再注册快捷键 —— 否则首次按键按 'other'
+    // 匹配（忽略 metaKey），Mac 用户加载后的第一次 ⌘⇧Y 静默无响应
+    await detectOS();
     const s = getSettings();
 
     let stopObserving: (() => void) | null = null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.73",
+  "version": "0.6.74",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/hotkeys/listener.ts
+++ b/src/hotkeys/listener.ts
@@ -10,6 +10,10 @@ export function startHotkeys(
   handlers: Record<HotkeyAction, () => void>,
 ): () => void {
   const onKeyDown = (e: KeyboardEvent) => {
+    // #164: 按住按键时浏览器按 ~30Hz 重复派发 keydown —— 不过滤会
+    // 连续触发 toggle/翻页，翻译进行中重复发起、译文落地后又还原。
+    // 录制器 startRecording 首次捕获即移除监听，天然免疫此问题。
+    if (e.repeat) return;
     if (isTypingContext()) return;
     const os = getOSSync();
     const combo = fromEvent(e, os);


### PR DESCRIPTION
## 问题
1. keydown 重复事件未过滤：按住 Mod+Shift+Y 时浏览器 ~30Hz 重复派发，toggle/翻页被连续触发，页面反复抖动
2. detectOS 未 await：快捷键注册前平台缓存未就绪，Mac 用户首次按键按 'other' 匹配（忽略 metaKey）静默无响应

## 修复
onKeyDown 开头过滤 e.repeat；content 主流程注册快捷键前 await detectOS()。

## 验证
- 新增单测：repeat=true 不触发 handler
- 单元测试 414 项、core E2E 28 项全部通过