### PR TITLE
fix(ui): 段落按钮早退分支清除隐藏定时器 —— 按钮不再自行消失（#165）

### DIFF
--- a/docs/testing/e2e/core.spec.ts
+++ b/docs/testing/e2e/core.spec.ts
@@ -207,6 +207,35 @@ test.describe('入口：段落按钮', () => {
     // 该段标记 done
     await expect(firstP).toHaveAttribute('data-pt', 'done', { timeout: 10_000 });
   });
+
+  test('@core TC-E2E-55: 离开段落再回到同一段落 —— 按钮保持显示（#165 回归）', async ({
+    page, mockGoogle, seedSettings, gotoFixture,
+  }) => {
+    await seedSettings({ showParagraphBtn: true });
+    await mockGoogle();
+    await gotoFixture('basic');
+
+    await waitForBall(page);
+
+    const firstP = page.locator('p').first();
+    const paraBtn = page.locator('.pt-para-btn');
+
+    // 悬停段落 → 按钮浮出
+    await firstP.hover();
+    await expect(paraBtn).toBeVisible({ timeout: 5_000 });
+
+    // 移到远离段落的空白处 → 触发 scheduleHide（1.5s 隐藏窗口）
+    await page.mouse.move(5, 710);
+
+    // 在隐藏窗口内移回同一段落
+    await page.waitForTimeout(200);
+    await firstP.hover();
+    await expect(paraBtn).toBeVisible({ timeout: 2_000 });
+
+    // 修复前：隐藏定时器继续倒数 → 按钮在鼠标停留期间自行消失
+    await page.waitForTimeout(1_800); // 超过 HIDE_DELAY(1.5s)
+    await expect(paraBtn).toBeVisible({ timeout: 1_000 });
+  });
 });
 
 // ================================================================

--- a/docs/testing/unit/hotkeys/listener.test.ts
+++ b/docs/testing/unit/hotkeys/listener.test.ts
@@ -25,6 +25,16 @@ function keydown(init: KeyboardEventInit): KeyboardEvent {
   });
 }
 
+/** handlers 需覆盖全部 HotkeyAction（类型约束） */
+function handlers(translate: () => void): Record<string, () => void> {
+  return {
+    'toggle-translate': translate,
+    'toggle-mode': () => {},
+    'translate-paragraph': () => {},
+    'toggle-extension': () => {},
+  };
+}
+
 describe('startHotkeys', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -32,7 +42,7 @@ describe('startHotkeys', () => {
 
   test('命中组合键 → 触发 handler', () => {
     const handler = vi.fn();
-    const stop = startHotkeys({ 'toggle-translate': handler });
+    const stop = startHotkeys(handlers(handler));
     document.dispatchEvent(
       keydown({ key: 'y', metaKey: true, shiftKey: true }),
     );
@@ -42,7 +52,7 @@ describe('startHotkeys', () => {
 
   test('repeat=true（按住连发）→ 不触发 handler（#164）', () => {
     const handler = vi.fn();
-    const stop = startHotkeys({ 'toggle-translate': handler });
+    const stop = startHotkeys(handlers(handler));
     document.dispatchEvent(
       keydown({ key: 'y', metaKey: true, shiftKey: true, repeat: true }),
     );
@@ -52,7 +62,7 @@ describe('startHotkeys', () => {
 
   test('未命中组合键 → 不触发 handler', () => {
     const handler = vi.fn();
-    const stop = startHotkeys({ 'toggle-translate': handler });
+    const stop = startHotkeys(handlers(handler));
     document.dispatchEvent(keydown({ key: 'y', metaKey: true }));
     expect(handler).not.toHaveBeenCalled();
     stop();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.74",
+  "version": "0.6.75",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/ui/paragraph-btn.ts
+++ b/src/ui/paragraph-btn.ts
@@ -140,8 +140,14 @@ export function createParaBtn(handlers: ParaBtnHandlers): () => void {
       }
       if (!el) return;
 
-      // 已经停在这一段上了 —— 段落内部换子元素不重定位，省掉无谓的强制布局
-      if (el === target && isVisible()) return;
+      // 已经停在这一段上了 —— 段落内部换子元素不重定位，省掉无谓的强制布局。
+      // #165: 必须先清隐藏定时器 —— 离开段落再回来（<1.5s）的路径上
+      // scheduleHide 挂起的计时器还在倒数，不清的话按钮在鼠标停留期间
+      // 自行消失，用户必须再挪一下鼠标才重新浮出。
+      if (el === target && isVisible()) {
+        clearTimeout(hideTimer);
+        return;
+      }
 
       clearTimeout(hideTimer);
       show(el);


### PR DESCRIPTION
## 问题
段落按钮悬停确认回调的早退分支只重定位不清除隐藏定时器：离开段落再回来（<1.5s）时 scheduleHide 挂起的计时器继续倒数，按钮在鼠标停留期间自行消失。

## 修复
早退分支先 clearTimeout(hideTimer) 再返回，保证按钮显示时无隐藏计时器悬空。

## 验证
- 新增 E2E TC-E2E-55：离开段落再回到同一段落 → 按钮保持显示（超过 HIDE_DELAY 后仍可见）
- 单元测试 414 项、core E2E 29 项全部通过