### PR TITLE
fix(background): 右键菜单转发 sendMessage 加 catch —— 无 content script 页面不再静默失败（#166）

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -66,10 +66,19 @@ export default defineBackground(() => {
 
   chrome.contextMenus.onClicked.addListener((info, tab) => {
     if (info.menuItemId === 'pt-translate-selection' && tab?.id) {
-      chrome.tabs.sendMessage(tab.id, {
-        type: 'pt:translate-selection',
-        text: info.selectionText ?? '',
-      });
+      // #166: 无 content script 的页面（chrome://、PDF 查看器、扩展更新前
+      // 已打开的旧标签页）sendMessage 会以 "Receiving end does not exist"
+      // 拒绝 —— 不加 catch 会在 SW 内留下未处理 rejection，用户侧零反馈。
+      chrome.tabs
+        .sendMessage(tab.id, {
+          type: 'pt:translate-selection',
+          text: info.selectionText ?? '',
+        })
+        .catch(() => {
+          console.debug(
+            '[PT] 右键翻译：目标标签页无 content script，忽略（请刷新页面后使用）',
+          );
+        });
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.75",
+  "version": "0.6.76",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## 问题
右键菜单转发 tabs.sendMessage 无 catch：chrome:// 页、PDF 查看器、扩展更新前已打开的旧标签页没有 content script，sendMessage 拒绝 → SW 内未处理 rejection。

## 修复
加 .catch() 吞掉拒绝并输出 debug 日志。

## 验证
- 单元测试 414 项全部通过，构建成功