### PR TITLE
fix(storage): maxConcurrency 全链路钳制 —— 0/负数不再饿死并发闸门（#172）

### DIFF
--- a/docs/testing/unit/queue/concurrency.test.ts
+++ b/docs/testing/unit/queue/concurrency.test.ts
@@ -127,6 +127,22 @@ describe('Gate', () => {
     expect(result).toBe('success');
   });
 
+  test('createGate(0) 不挂死 —— 防御钳制为 1（#172）', async () => {
+    const gate = createGate(0);
+    const result = await gate(async () => 'ok');
+    expect(result).toBe('ok');
+  });
+
+  test('setMax(0) 不挂死 —— 防御钳制为 1（#172）', async () => {
+    const gate = createGate(1);
+    const pending = gate(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      return 'ok';
+    });
+    gate.setMax(0);
+    await expect(pending).resolves.toBe('ok');
+  });
+
   test('active 计数全程正确', async () => {
     const gate = createGate(2);
     let running = 0;

--- a/docs/testing/unit/storage/settings.test.ts
+++ b/docs/testing/unit/storage/settings.test.ts
@@ -42,6 +42,21 @@ describe('merge / patchSettings', () => {
     expect(s.enabled).toBe(DEFAULT_SETTINGS.enabled);
   });
 
+  test('maxConcurrency: 0 → 钳制为 1（#172）', async () => {
+    const { patchSettings } = await import('~/src/storage/settings');
+    const { settingsReady, getSettings } = await import('~/src/storage/settings');
+
+    await settingsReady();
+    await patchSettings({ maxConcurrency: 0 });
+    expect(getSettings().maxConcurrency).toBe(1);
+
+    // 负数与超大值同样钳制
+    await patchSettings({ maxConcurrency: -5 });
+    expect(getSettings().maxConcurrency).toBe(1);
+    await patchSettings({ maxConcurrency: 999 });
+    expect(getSettings().maxConcurrency).toBe(10);
+  });
+
   test('hotkeys 部分覆盖 → 兄弟键不丢失', async () => {
     const { patchSettings } = await import('~/src/storage/settings');
     const { settingsReady, getSettings } = await import('~/src/storage/settings');

--- a/entrypoints/options/sections/advanced.ts
+++ b/entrypoints/options/sections/advanced.ts
@@ -1,6 +1,6 @@
 // Phase 7 — 高级分区：并发数、缓存管理、设置导入/导出。
 
-import { DEFAULT_SETTINGS } from '~/src/storage/schema';
+import { DEFAULT_SETTINGS, clampConcurrency } from '~/src/storage/schema';
 import {
   getSettings,
   patchSettings,
@@ -39,6 +39,11 @@ async function importSettings(json: string): Promise<void> {
     const sanitized: Record<string, unknown> = {};
     for (const key of allowed) {
       if (key in data) sanitized[key] = data[key];
+    }
+    // #172: 值校验 —— 导入文件可绕过 UI 下拉，maxConcurrency 必须钳制，
+    // 否则 0/负数会让 Google 闸门永久饿死、全部翻译挂起
+    if (typeof sanitized.maxConcurrency === 'number') {
+      sanitized.maxConcurrency = clampConcurrency(sanitized.maxConcurrency);
     }
     // 显式移除任何密钥相关字段
     delete sanitized.apiKeys;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.76",
+  "version": "0.6.77",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/queue/concurrency.ts
+++ b/src/queue/concurrency.ts
@@ -3,6 +3,9 @@
 // 浏览器对单域名并发连接数的常见上限为 6，与默认值对齐。
 
 export function createGate(max: number) {
+  // #172: 防御 max <= 0 —— 0 会让 pump 永不放行，在飞任务全部挂死。
+  // 正常路径已有设置侧钳制（clampConcurrency），这里兜住所有调用方。
+  max = Math.max(1, Math.floor(max) || 1);
   let active = 0;
   const waiting: (() => void)[] = [];
 
@@ -34,7 +37,7 @@ export function createGate(max: number) {
 
   /** 动态调整上限，保留当前 active 计数与等待队列。 */
   run.setMax = (n: number) => {
-    max = n;
+    max = Math.max(1, Math.floor(n) || 1);
     pump();
   };
 

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -109,6 +109,16 @@ export const LANG_LIST: { code: string; label: string }[] = [
   { code: 'it', label: 'Italiano' },
 ];
 
+/** maxConcurrency 合法范围（UI 下拉允许 2-10，#172）。 */
+export const CONCURRENCY_MIN = 1;
+export const CONCURRENCY_MAX = 10;
+
+/** 钳制并发数到合法范围 —— 导入/存储/写入口共用，防 0 或负数饿死闸门。 */
+export function clampConcurrency(n: unknown): number {
+  const v = typeof n === 'number' && Number.isFinite(n) ? Math.floor(n) : CONCURRENCY_MIN;
+  return Math.min(CONCURRENCY_MAX, Math.max(CONCURRENCY_MIN, v));
+}
+
 export const DEFAULT_SETTINGS: Settings = {
   enabled: true,
   enginePriority: ['google-web', 'bing-edge'],

--- a/src/storage/settings.ts
+++ b/src/storage/settings.ts
@@ -1,5 +1,5 @@
 import type { DeepPartial, Settings } from './schema';
-import { DEFAULT_SETTINGS } from './schema';
+import { DEFAULT_SETTINGS, clampConcurrency } from './schema';
 
 const KEY = 'pt-settings';
 
@@ -16,6 +16,12 @@ function mergeInto(base: Settings, patch: DeepPartial<Settings>): Settings {
   return {
     ...base,
     ...patch,
+    // #172: 任何写入口（导入/跨上下文 patch）都可能绕过 UI 下拉 ——
+    // maxConcurrency <= 0 会让并发闸门永久饿死，统一钳制到合法范围
+    maxConcurrency:
+      patch.maxConcurrency === undefined
+        ? base.maxConcurrency
+        : clampConcurrency(patch.maxConcurrency),
     hotkeys: patch.hotkeys
       ? { ...base.hotkeys, ...patch.hotkeys }
       : base.hotkeys,


### PR DESCRIPTION
## 问题
设置导入只做字段白名单不做值校验：导入 maxConcurrency:0 时 createGate(0) 的 pump 永不放行 → 全部翻译永久挂起。UI 下拉允许 2-10，导入可绕过。

## 修复
- schema 新增 clampConcurrency（1-10），patchSettings/merge 全写入口钳制
- createGate/setMax 对 max<=0 防御钳制为 1
- 导入路径显式钳制

## 验证
- 新增单测：导入 0/负数/999 被钳制；createGate(0)/setMax(0) 不挂死
- 单元测试 417 项全部通过