### PR TITLE
fix(router): 回填译文校验长度 —— 短数组不再填 undefined（#171）

### DIFF
--- a/docs/testing/unit/engines/router.test.ts
+++ b/docs/testing/unit/engines/router.test.ts
@@ -304,6 +304,33 @@ describe('route', () => {
     expect(bingReq.texts).toEqual(['World']);
   });
 
+  test('引擎返回短数组 → 不足槽位置 null 交给下一引擎补齐（#171）', async () => {
+    // 请求 3 条，引擎只返回 1 条 —— 短出的槽位不能是 undefined
+    mockGoogleTranslate.mockResolvedValue({
+      translations: ['你好'],
+    });
+    mockBingTranslate.mockResolvedValue({
+      translations: ['世界', '再见'],
+    });
+
+    const resp = await route({
+      texts: ['Hello', 'World', 'Bye'],
+      from: 'auto',
+      to: 'zh-CN',
+    });
+
+    // 全部补齐，无 undefined
+    expect(resp.translations).toEqual(['你好', '世界', '再见']);
+    expect(mockGoogleTranslate).toHaveBeenCalledTimes(1);
+    expect(mockBingTranslate).toHaveBeenCalledTimes(1);
+    // Bing 只收到短出的 2 条
+    const bingReq = mockBingTranslate.mock.calls[0]![0];
+    expect(bingReq.texts).toEqual(['World', 'Bye']);
+    // 短数组槽位不得写入缓存
+    const cacheWrites = vi.mocked(cacheSet).mock.calls.map((c) => c[1]);
+    expect(cacheWrites).not.toContain(undefined);
+  });
+
   test('useCache=false 部分失败 → 下一引擎只补失败槽位，不覆盖已成功译文（#120）', async () => {
     vi.mocked(getSettings).mockReturnValue({
       enginePriority: ['google-web', 'bing-edge'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.77",
+  "version": "0.6.78",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/router.ts
+++ b/src/engines/router.ts
@@ -85,28 +85,39 @@ export async function route(req: TranslateRequest): Promise<TranslateResponse> {
       };
       const resp = await engine.translate(subReq);
 
-      // 将译文放回正确槽位
+      // #171: 引擎可能返回短于请求长度的译文数组（第三方 API 异常形状）。
+      // 短出的槽位若填 undefined，content 侧 restorePreserves 会抛
+      // TypeError —— 一律置 null 并记入失败，交给下一个引擎补齐。
+      const failed = [...(resp.failedIndices ?? [])];
       for (let j = 0; j < uncached.length; j++) {
-        translations[uncached[j]!.idx] = resp.translations[j]!;
+        const text = resp.translations[j];
+        if (text === undefined || text === null) {
+          translations[uncached[j]!.idx] = null;
+          failed.push(j);
+        } else {
+          translations[uncached[j]!.idx] = text;
+        }
       }
 
       // 处理部分失败：将失败槽位重置为 null，交给下一个引擎重试
-      if (resp.failedIndices && resp.failedIndices.length > 0) {
-        for (const j of resp.failedIndices) {
+      if (failed.length > 0) {
+        for (const j of resp.failedIndices ?? []) {
           translations[uncached[j]!.idx] = null;
         }
 
         // 并行写缓存（仅成功的条目）
         if (useCache) {
-          const succeeded = uncached.filter(
-            (_, j) => !resp.failedIndices!.includes(j),
-          );
+          const succeeded = uncached.filter((_, j) => !failed.includes(j));
           if (succeeded.length > 0) {
             await Promise.all(
               succeeded.map(async (u) => {
                 const k = await cacheKey(id, req.from, req.to, u.text);
                 const idx = uncached.indexOf(u);
-                await cacheSet(k, resp.translations[idx]!);
+                const val = resp.translations[idx];
+                // #171: 短数组下成功槽位必然有值，这里再做一次防御
+                if (val !== undefined && val !== null) {
+                  await cacheSet(k, val);
+                }
               }),
             );
           }
@@ -116,7 +127,7 @@ export async function route(req: TranslateRequest): Promise<TranslateResponse> {
           new EngineError(
             id,
             true,
-            `${resp.failedIndices.length}/${uncached.length} 条失败，尝试下一个引擎`,
+            `${failed.length}/${uncached.length} 条失败，尝试下一个引擎`,
           ),
         );
         continue; // 下一个引擎自动拾取 translations[i] === null 的槽位


### PR DESCRIPTION
## 问题
router 回填译文槽位不校验长度：引擎返回短数组时尾部槽位被赋 undefined（failedIndices 未定义 → 走「全部成功」分支 → cacheSet(undefined) + content 侧 restorePreserves 抛 TypeError）。

## 修复
回填时校验：undefined/null 槽位置 null 并记入失败，交给下一引擎补齐；缓存写入前防御性校验。

## 验证
- 新增单测：引擎返回短数组 → 下一引擎补齐、无 undefined、不写坏缓存
- 单元测试 418 项、core E2E 29 项全部通过