### PR TITLE
fix(storage): patchSettings 写前重读存储再合并 —— 跨上下文并发写不再静默回滚（#167）

### DIFF
--- a/docs/testing/integration/settings-sync.test.ts
+++ b/docs/testing/integration/settings-sync.test.ts
@@ -18,6 +18,28 @@ describe('设置跨上下文同步', () => {
     expect(p1).toBe(p2);
   });
 
+  test('陈旧内存副本 patch → 写前重读存储，不覆盖其他上下文写入（#167）', async () => {
+    const { settingsReady, patchSettings } = await import('~/src/storage/settings');
+    await settingsReady();
+
+    // 模拟上下文 A 写入 displayMode（直接写存储；本实例不触发
+    // onChanged，内存副本保持陈旧 —— 等价于另一个标签页的修改）
+    await chrome.storage.sync.set({
+      'pt-settings': { ...DEFAULT_SETTINGS, displayMode: 'translation-only' },
+    });
+
+    // 本上下文用陈旧内存副本 patch style —— 修复前整对象覆盖，
+    // displayMode 被静默回滚（lost update）；修复后写前重读存储，
+    // 基于最新值合并，两个修改都保留
+    await patchSettings({ style: 'bold' });
+
+    const stored = ((await chrome.storage.sync.get('pt-settings'))[
+      'pt-settings'
+    ] ?? {}) as Record<string, unknown>;
+    expect(stored.displayMode).toBe('translation-only');
+    expect(stored.style).toBe('bold');
+  });
+
   test('onSettingsChanged 接收 patchSettings 触发的变更', async () => {
     const { settingsReady, patchSettings, onSettingsChanged } =
       await import('~/src/storage/settings');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.79",
+  "version": "0.6.80",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/storage/settings.ts
+++ b/src/storage/settings.ts
@@ -70,7 +70,14 @@ export function getSettings(): Settings {
 
 /** 部分更新设置并写回 sync。嵌套对象递归合并，不会丢兄弟键。 */
 export async function patchSettings(patch: DeepPartial<Settings>): Promise<void> {
-  current = mergeInto(current, patch);
+  // #167: 跨上下文并发写保护 —— 写前重读存储，基于最新值合并再写回
+  // （compare-and-swap 风格）。每个上下文（popup/options/content）都有
+  // 自己的内存副本，直接拿内存值整对象覆盖会静默回滚另一个上下文刚
+  // 写入的修改（lost update）。
+  const stored = ((await chrome.storage.sync.get(KEY))[KEY] as
+    | Partial<Settings>
+    | undefined);
+  current = mergeInto(merge(stored), patch);
   await chrome.storage.sync.set({ [KEY]: current });
 }
 


### PR DESCRIPTION
## 问题
patchSettings 每次把整个 settings 对象写入 storage 且读-改-写非原子：两个上下文（popup + options 等）并发 patch 时，后写者用自己内存里的旧副本覆盖先写者的修改——设置静默回滚（lost update）。

## 修复
patchSettings 写前重读存储，基于最新值合并再写回（compare-and-swap 风格），并同步更新内存副本。

## 验证
- 新增集成测试：陈旧内存副本 patch → 写前重读，其他上下文写入的键保留
- 单元测试 419 项、core E2E 29 项全部通过