### PR TITLE
fix(styles): 自定义 CSS 校验统一 + 特异性提升 —— 表单/导入/运行时一致（#168）

### DIFF
--- a/docs/testing/unit/styles/custom.test.ts
+++ b/docs/testing/unit/styles/custom.test.ts
@@ -34,8 +34,20 @@ describe('validateCustomCss', () => {
     if (!result.ok) expect(result.msg).toContain('花括号');
   });
 
+  test('含 url() → 拒绝（#168）', () => {
+    const result = validateCustomCss('background: url("https://track.example/x.gif")');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.msg).toContain('url()');
+  });
+
+  test('含反斜杠 → 拒绝（#168）', () => {
+    const result = validateCustomCss('color: red\\; } .evil {');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.msg).toContain('花括号');
+  });
+
   test('含 javascript: → 拒绝', () => {
-    const result = validateCustomCss('background: url("javascript:alert(1)")');
+    const result = validateCustomCss('color: javascript:alert(1)');
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.msg).toContain('javascript:');
   });
@@ -54,14 +66,28 @@ describe('applyCustomCss', () => {
     if (existing) existing.remove();
   });
 
-  test('合法输入 → 注入 <style> 到 <head>，内容被 .pt-trans {} 包裹', () => {
+  test('合法输入 → 注入 <style> 到 <head>，选择器为 .pt-trans.pt-trans（#168 特异性）', () => {
     applyCustomCss('color: #555');
 
     const styleEl = document.getElementById('pt-custom-style');
     expect(styleEl).not.toBeNull();
     expect(styleEl!.tagName).toBe('STYLE');
-    expect(styleEl!.textContent).toContain('.pt-trans');
+    // #168: 双类选择器（0,2,0）与预设 .pt-style-fade .pt-trans 同级，
+    // 自定义 opacity 等属性才能覆盖预设
+    expect(styleEl!.textContent).toContain('.pt-trans.pt-trans');
     expect(styleEl!.textContent).toContain('color: #555');
+  });
+
+  test('非法输入 → 不注入，且保留已有旧样式（#168）', () => {
+    applyCustomCss('color: red');
+    const old = document.getElementById('pt-custom-style');
+    expect(old).not.toBeNull();
+
+    applyCustomCss('@import url("evil.css");');
+    // 旧样式未被清掉（修复前先删后校验，用户样式被无声清除）
+    const still = document.getElementById('pt-custom-style');
+    expect(still).not.toBeNull();
+    expect(still!.textContent).toContain('color: red');
   });
 
   test('非法输入 → 不注入', () => {

--- a/entrypoints/options/sections/advanced.ts
+++ b/entrypoints/options/sections/advanced.ts
@@ -1,6 +1,7 @@
 // Phase 7 — 高级分区：并发数、缓存管理、设置导入/导出。
 
 import { DEFAULT_SETTINGS, clampConcurrency } from '~/src/storage/schema';
+import { validateCustomCss } from '~/src/styles/custom';
 import {
   getSettings,
   patchSettings,
@@ -44,6 +45,15 @@ async function importSettings(json: string): Promise<void> {
     // 否则 0/负数会让 Google 闸门永久饿死、全部翻译挂起
     if (typeof sanitized.maxConcurrency === 'number') {
       sanitized.maxConcurrency = clampConcurrency(sanitized.maxConcurrency);
+    }
+    // #168: 导入同样走统一校验器 —— 否则 @import/url() 等可通过导入
+    // 绕过表单校验，运行时注入被拒后旧样式还被清掉
+    if (typeof sanitized.customCss === 'string') {
+      const cssResult = validateCustomCss(sanitized.customCss);
+      if (!cssResult.ok) {
+        showToast(tf('toastImportFail', `导入失败：${cssResult.msg}`));
+        return;
+      }
     }
     // 显式移除任何密钥相关字段
     delete sanitized.apiKeys;

--- a/entrypoints/options/sections/appearance.ts
+++ b/entrypoints/options/sections/appearance.ts
@@ -7,21 +7,10 @@ import {
   onSettingsChanged,
 } from '~/src/storage/settings';
 import { tf } from '~/src/i18n';
+import { validateCustomCss } from '~/src/styles/custom';
 
 function savePatch(patch: Parameters<typeof patchSettings>[0]): void {
   patchSettings(patch).catch((e) => console.error('[PT] 设置写入失败:', e));
-}
-
-/**
- * 校验 CSS 声明块的语法安全性。
- * 不允许选择器、不允许 url()（防隐私泄漏）。
- */
-function validateCss(css: string): string | null {
-  if (!css.trim()) return null;
-  if (/[{}\\]/.test(css))
-    return tf('cssNoSelector', '只需填写 CSS 属性，无需选择器与花括号');
-  if (/url\s*\(/i.test(css)) return tf('cssNoUrl', '不允许使用 url()');
-  return null;
 }
 
 export function initAppearance(): void {
@@ -50,11 +39,12 @@ export function initAppearance(): void {
     clearTimeout(cssTimer);
     cssTimer = setTimeout(() => {
       const css = cssTextarea.value;
-      const err = validateCss(css);
-      if (err) {
+      // #168: 与运行时/导入共用同一校验器，行为不再分叉
+      const result = validateCustomCss(css);
+      if (!result.ok) {
         cssTextarea.classList.add('pt-error');
         cssErrorEl.classList.add('pt-visible');
-        cssErrorEl.textContent = err;
+        cssErrorEl.textContent = result.msg;
       } else {
         cssTextarea.classList.remove('pt-error');
         cssErrorEl.classList.remove('pt-visible');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.80",
+  "version": "0.6.81",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/styles/custom.ts
+++ b/src/styles/custom.ts
@@ -8,13 +8,18 @@ const STYLE_ID = 'pt-custom-style';
 
 /** 禁止出现的构造 —— 一旦允许，用户就能改宿主页面和扩展自身 UI */
 const FORBIDDEN = [
-  { pattern: /[{}]/, msg: '只需填写 CSS 属性，无需选择器与花括号' },
+  { pattern: /[{}\\]/, msg: '只需填写 CSS 属性，无需选择器与花括号' },
   { pattern: /@import/i, msg: '不支持 @import' },
   { pattern: /<\/?style/i, msg: '不允许 style 标签' },
+  { pattern: /url\s*\(/i, msg: '不允许使用 url()' },
   { pattern: /javascript:/i, msg: '不允许 javascript: 协议' },
   { pattern: /expression\s*\(/i, msg: '不允许 expression()' },
 ];
 
+/**
+ * 自定义 CSS 的唯一校验器 —— #168。
+ * 表单校验、设置导入、运行时注入三处共用，行为不再分叉。
+ */
 export function validateCustomCss(
   input: string,
 ): { ok: true } | { ok: false; msg: string } {
@@ -27,15 +32,25 @@ export function validateCustomCss(
 /**
  * 把用户输入的声明块包进 .pt-trans 作用域后注入。
  * 用户写 `color: #555`，实际注入 `.pt-trans { color: #555 }`。
+ *
+ * #168: 选择器用 `.pt-trans.pt-trans`（特异性 0,2,0，与预设
+ * `.pt-style-fade .pt-trans` 同级）—— 单类选择器（0,1,0）会被预设
+ * 压住，opacity 等预设属性永远无法被自定义覆盖。同级特异性下
+ * 后注入者胜：扩展的预设样式随文档注入，本 style 在设置加载/变更时
+ * 追加到 head 末尾，时序上晚于预设，自定义总能覆盖预设。
  */
 export function applyCustomCss(input: string): void {
-  document.getElementById(STYLE_ID)?.remove();
   const css = input.trim();
-  if (!css || !validateCustomCss(css).ok) return;
+  // #168: 先校验后删除 —— 校验失败时保留旧样式，避免「用户以为生效，
+  // 实际旧样式也被清掉」的无声失败
+  if (css && !validateCustomCss(css).ok) return;
+
+  document.getElementById(STYLE_ID)?.remove();
+  if (!css) return;
 
   const el = document.createElement('style');
   el.id = STYLE_ID;
   el.setAttribute('data-pt-ui', '1'); // 防止被 walker 采集
-  el.textContent = `.pt-trans { ${css} }`;
+  el.textContent = '.pt-trans.pt-trans { ' + css + ' }';
   document.head.appendChild(el);
 }


### PR DESCRIPTION
## 问题
1. 校验三处不一致：表单只拒花括号/url()，运行时另拒 @import 等，导入完全不校验；applyCustomCss 先删旧样式再校验失败 → 用户样式被无声清除
2. 自定义 CSS 用 .pt-trans（0,1,0）被预设 .pt-style-fade .pt-trans（0,2,0）压住，opacity 等预设属性无法覆盖

## 修复
- 统一为 validateCustomCss（补 url()、反斜杠），表单/导入/运行时三处共用；导入失败给出提示
- applyCustomCss 先校验后删除；注入选择器改为 .pt-trans.pt-trans（0,2,0 与预设同级，后注入胜）

## 验证
- 新增单测：url()/反斜杠被拒；非法输入保留旧样式；注入选择器为 .pt-trans.pt-trans
- 单元测试 422 项、core E2E 29 项全部通过