### PR TITLE
fix(storage): 恢复默认改为整体替换 —— 自定义模型名不再残留（#169）

### DIFF
--- a/docs/testing/unit/storage/settings.test.ts
+++ b/docs/testing/unit/storage/settings.test.ts
@@ -42,6 +42,21 @@ describe('merge / patchSettings', () => {
     expect(s.enabled).toBe(DEFAULT_SETTINGS.enabled);
   });
 
+  test('replaceSettings 整体替换 —— 自定义 models 被清空（#169）', async () => {
+    const { patchSettings, replaceSettings } = await import('~/src/storage/settings');
+    const { settingsReady, getSettings } = await import('~/src/storage/settings');
+
+    await settingsReady();
+    await patchSettings({ models: { openai: 'gpt-custom' } });
+    expect(getSettings().models.openai).toBe('gpt-custom');
+
+    // 恢复默认：patch 语义下 DEFAULT_SETTINGS.models={} 合并不掉
+    // 自定义模型名，replaceSettings 整体替换才能清空
+    await replaceSettings(DEFAULT_SETTINGS);
+    expect(getSettings().models).toEqual({});
+    expect(getSettings().style).toBe(DEFAULT_SETTINGS.style);
+  });
+
   test('maxConcurrency: 0 → 钳制为 1（#172）', async () => {
     const { patchSettings } = await import('~/src/storage/settings');
     const { settingsReady, getSettings } = await import('~/src/storage/settings');

--- a/entrypoints/options/sections/advanced.ts
+++ b/entrypoints/options/sections/advanced.ts
@@ -5,6 +5,7 @@ import { validateCustomCss } from '~/src/styles/custom';
 import {
   getSettings,
   patchSettings,
+  replaceSettings,
   onSettingsChanged,
 } from '~/src/storage/settings';
 import { cacheClear } from '~/src/storage/cache';
@@ -71,8 +72,10 @@ async function resetSettings(): Promise<void> {
   await removeKey('openai');
   await removeKey('deepl');
   await removeKey('gemini');
-  // 重置设置为默认值
-  await patchSettings(DEFAULT_SETTINGS);
+  // #169: 整体替换而非 patch —— patch 对 models 是合并语义，
+  // DEFAULT_SETTINGS.models = {} 合并不掉自定义模型名，恢复默认后
+  // openai/gemini 自定义模型会残留
+  await replaceSettings(DEFAULT_SETTINGS);
   showToast(tf('toastReset', '已恢复默认设置'));
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.81",
+  "version": "0.6.82",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/storage/settings.ts
+++ b/src/storage/settings.ts
@@ -82,6 +82,17 @@ export async function patchSettings(patch: DeepPartial<Settings>): Promise<void>
 }
 
 /**
+ * 整对象替换设置（恢复默认专用）—— #169。
+ * patchSettings 对嵌套对象（models/hotkeys/siteList）是合并语义，
+ * DEFAULT_SETTINGS.models = {} 合并不掉用户自定义的模型名 —— 恢复
+ * 默认必须整体替换而不是合并。替换本身就是有意的全量覆盖。
+ */
+export async function replaceSettings(next: Settings): Promise<void> {
+  current = next;
+  await chrome.storage.sync.set({ [KEY]: current });
+}
+
+/**
  * 跨上下文变更订阅。
  * popup 改设置 → 所有已打开标签页的 content script 立即收到回调。
  *


### PR DESCRIPTION
## 问题
「恢复默认」调 patchSettings(DEFAULT_SETTINGS)，但 patch 对 models 是合并语义（{...base.models, ...{}} = base.models），自定义模型名在恢复默认后残留。

## 修复
settings 新增 replaceSettings（整对象替换），恢复默认改用它。

## 验证
- 新增单测：设置自定义模型后 replaceSettings → models 清空
- 单元测试 423 项、core E2E 29 项全部通过