### PR TITLE
fix(dom): restorePreserves 改函数替换器（#173）

### DIFF
--- a/docs/testing/unit/dom/text.test.ts
+++ b/docs/testing/unit/dom/text.test.ts
@@ -210,6 +210,21 @@ describe('restorePreserves', () => {
     expect(result).toBe('@user says hi');
   });
 
+  test('保留文本含 $& 与 $1 → 回填结果与原文一致（#173）', () => {
+    // 修复前 String.replace 把 orig 当作替换模式展开：
+    // $& 会被替换为整个匹配串，$1 引用分组（无分组时为 ''）
+    const preserves = makePreserves(
+      ['⟦PT0⟧', 'price: $& and $1'],
+      ['⟦PT1⟧', '@user'],
+    );
+    const result = restorePreserves(
+      '⟦PT0⟧ paid ⟦PT1⟧',
+      preserves,
+      '⟦PT0⟧ paid ⟦PT1⟧',
+    );
+    expect(result).toBe('price: $& and $1 paid @user');
+  });
+
   test('降级结果不含任何 ⟦PT 残留', () => {
     const preserves = makePreserves(['⟦PT0⟧', '@test']);
     const originalText = '⟦PT0⟧ wrote';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.82",
+  "version": "0.6.83",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/text.ts
+++ b/src/dom/text.ts
@@ -206,7 +206,10 @@ export function restorePreserves(
   // 全部匹配 → 安全替换
   let result = translation;
   for (const [ph, orig] of preserves) {
-    result = result.replace(ph, orig);
+    // #173: 必须用函数替换器 —— orig 含 $& / $' / $` / $1 等序列时，
+    // 字符串替换参数会被 String.replace 当作替换模式展开，产生与原文
+    // 不同的字符。函数返回值不做任何模式解释。
+    result = result.replace(ph, () => orig);
   }
   return result;
 }
@@ -218,7 +221,8 @@ function restoreFallback(
 ): string {
   let result = placeholderText;
   for (const [ph, orig] of preserves) {
-    result = result.replace(ph, orig);
+    // #173: 函数替换器，避免 orig 中的 $ 序列被当作替换模式展开
+    result = result.replace(ph, () => orig);
   }
   return result;
 }


### PR DESCRIPTION
问题：replace 字符串替换参数会把保留原文中的 $&/ 当作替换模式展开。修复：改用函数替换器。验证：新增单测 + 424 项单元测试通过。