### PR TITLE
fix(dom): pre 切块放宽 MAX_HTML —— 含大量 autolink 的块不再被静默丢弃（#174）

### DIFF
--- a/docs/testing/unit/dom/classify.test.ts
+++ b/docs/testing/unit/dom/classify.test.ts
@@ -12,6 +12,8 @@ import {
   closestUnit,
   shouldSkipNonVisual,
   shouldSkip,
+  MAX_TEXT,
+  MAX_HTML,
 } from '~/src/dom/classify';
 
 // ---- 辅助 ----
@@ -350,5 +352,19 @@ describe('shouldSkip', () => {
     const p = el('<p>No</p>');
     mockBoundingRect(p, { width: 30, right: 30 });
     expect(shouldSkip(p)).toBe(true);
+  });
+
+  test('shouldSkipNonVisual > 含大量链接的 pre 切块 → false（#174）', () => {
+    // 80 个 GitHub 风格 autolink：文本 ≤ MAX_TEXT，但 outerHTML 远超 MAX_HTML
+    const links = Array.from(
+      { length: 80 },
+      (_, i) =>
+        `<a href="https://github.com/org/repo/blob/main/docs/guide-${i}.md">文档 ${i} 链接文本</a>`,
+    ).join(' ');
+    const span = el(`<span data-pt-chunk="1">${links}</span>`);
+    expect(span.textContent!.trim().length).toBeLessThanOrEqual(MAX_TEXT);
+    expect(span.outerHTML.length).toBeGreaterThan(MAX_HTML);
+    // 修复前：outerHTML > MAX_HTML → 跳过 → 整块静默漏翻
+    expect(shouldSkipNonVisual(span)).toBe(false);
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.83",
+  "version": "0.6.84",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/classify.ts
+++ b/src/dom/classify.ts
@@ -65,7 +65,7 @@ const NON_CONTENT =
   '.vector-menu-content-list,#catlinks,#mw-hidden-catlinks,#mw-normal-catlinks';
 
 export const MAX_TEXT = 3072;
-const MAX_HTML = 4096;
+export const MAX_HTML = 4096;
 const MIN_TEXT = 3;
 
 /** pre 是否处于代码块上下文（.highlight / .notranslate 祖先）—— #64/#65 站点相关判定 */
@@ -94,7 +94,15 @@ export function shouldSkipNonVisual(el: Element): boolean {
 
   const text = el.textContent?.trim() ?? '';
   if (text.length < MIN_TEXT || text.length > MAX_TEXT) return true;
-  if ((el as HTMLElement).outerHTML.length > MAX_HTML) return true;
+  // #174: pre 切块（.pt-chunk）的文本长度已由 splitPre 保证 ≤ MAX_TEXT，
+  // 但行内标记开销（GitHub autolink <a> 每个 48+ 字符）会让 outerHTML
+  // 远超 MAX_HTML —— 对切块放宽 HTML 上限，否则含大量链接的块被
+  // 静默漏翻。普通元素仍按 outerHTML 上限拒绝。
+  if (
+    (el as HTMLElement).dataset?.ptChunk !== '1' &&
+    (el as HTMLElement).outerHTML.length > MAX_HTML
+  )
+    return true;
   if (isMainlyNumeric(text)) return true;
 
   return false;


### PR DESCRIPTION
## 问题
pre 切块只按文本长度切分，不预留行内标记开销：块文本 ≤3072 但含大量 autolink 时 outerHTML 超 MAX_HTML → shouldSkipNonVisual 返回 true → 块静默漏翻。

## 修复
shouldSkipNonVisual 对 [data-pt-chunk="1"] 切块放宽 MAX_HTML —— 切块文本长度已由 splitPre 保证，标记膨胀不阻断翻译。

## 验证
- 新增单测：80 个链接的切块（文本≤3072、outerHTML>4096）不被跳过
- 单元测试 425 项、core E2E 29 项全部通过