### PR TITLE
fix(cache): key 加模型维度 + 30 天 TTL + 配额失败告警（#175）

### DIFF
--- a/docs/testing/unit/storage/cache.test.ts
+++ b/docs/testing/unit/storage/cache.test.ts
@@ -31,6 +31,25 @@ describe('cacheKey', () => {
     const k2 = await cacheKey('google-web', 'auto', 'zh-CN', 'World');
     expect(k1).not.toBe(k2);
   });
+
+  test('不同模型 → 不同 key（#175）', async () => {
+    const k1 = await cacheKey('openai', 'auto', 'zh-CN', 'Hello', 'gpt-4o-mini');
+    const k2 = await cacheKey('openai', 'auto', 'zh-CN', 'Hello', 'gpt-5');
+    expect(k1).not.toBe(k2);
+    expect(k1).toContain('gpt-4o-mini');
+  });
+
+  test('同模型 → 相同 key（#175）', async () => {
+    const k1 = await cacheKey('openai', 'auto', 'zh-CN', 'Hello', 'gpt-4o-mini');
+    const k2 = await cacheKey('openai', 'auto', 'zh-CN', 'Hello', 'gpt-4o-mini');
+    expect(k1).toBe(k2);
+  });
+
+  test('无模型引擎 → key 不含模型段', async () => {
+    const k = await cacheKey('google-web', 'auto', 'zh-CN', 'Hello');
+    expect(k).not.toContain(':model');
+    expect(k).toMatch(/^pt-c:google-web:auto:zh-CN:[0-9a-f]{40}$/);
+  });
 });
 
 describe('cacheGet / cacheSet', () => {
@@ -60,6 +79,39 @@ describe('cacheGet / cacheSet', () => {
     const val = await cacheGet(key);
     expect(val).toBe('第一');
     // 不抛异常即通过
+  });
+
+  test('过期条目 → 未命中且被移除（#175）', async () => {
+    const key = await cacheKey('google-web', 'auto', 'zh-CN', 'Stale');
+    await cacheSet(key, '旧译文');
+
+    // 把条目的时间戳改为超期（31 天前）
+    await chrome.storage.local.set({
+      [key]: JSON.stringify({ v: '旧译文', t: Date.now() - 31 * 24 * 60 * 60 * 1000 }),
+    });
+
+    const value = await cacheGet(key);
+    expect(value).toBeNull();
+    // 条目被移除
+    const stored = await chrome.storage.local.get(key);
+    expect(stored[key]).toBeUndefined();
+  });
+
+  test('未过期条目 → 命中', async () => {
+    const key = await cacheKey('google-web', 'auto', 'zh-CN', 'Fresh');
+    await cacheSet(key, '新译文');
+
+    const value = await cacheGet(key);
+    expect(value).toBe('新译文');
+  });
+
+  test('旧版纯字符串条目（无时间戳）→ 兼容读取', async () => {
+    const key = await cacheKey('google-web', 'auto', 'zh-CN', 'Legacy');
+    // 直接写入旧格式（升级前 cacheSet 的存储格式）
+    await chrome.storage.local.set({ [key]: '旧格式译文' });
+
+    const value = await cacheGet(key);
+    expect(value).toBe('旧格式译文');
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.84",
+  "version": "0.6.85",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/gemini.ts
+++ b/src/engines/gemini.ts
@@ -3,6 +3,7 @@
 
 import { getKey } from '~/src/storage/keys';
 import { getSettings } from '~/src/storage/settings';
+import { DEFAULT_MODELS } from '~/src/storage/schema';
 import { normalizeText } from '~/src/dom/normalize';
 import { fetchWithTimeout } from './fetch-timeout';
 import { engineGate } from './engine-gate';
@@ -65,7 +66,7 @@ export const gemini: TranslateEngine = {
       const key = await getKey('gemini');
       if (!key) throw new EngineError('gemini', false, '未配置 API key');
 
-      const model = getSettings().models?.gemini ?? 'gemini-2.0-flash';
+      const model = getSettings().models?.gemini ?? DEFAULT_MODELS.gemini!;
       // key 走 x-goog-api-key 请求头而非 ?key= query。
       // URL 会进浏览器网络日志、DevTools 记录与任何中间层的访问日志，请求头不会；
       // 另两个引擎也都是走头，保持一致。

--- a/src/engines/openai.ts
+++ b/src/engines/openai.ts
@@ -4,6 +4,7 @@
 
 import { getKey } from '~/src/storage/keys';
 import { getSettings } from '~/src/storage/settings';
+import { DEFAULT_MODELS } from '~/src/storage/schema';
 import { normalizeText } from '~/src/dom/normalize';
 import { fetchWithTimeout } from './fetch-timeout';
 import { engineGate } from './engine-gate';
@@ -41,7 +42,7 @@ export const openai: TranslateEngine = {
       const key = await getKey('openai');
       if (!key) throw new EngineError('openai', false, '未配置 API key');
 
-      const model = getSettings().models?.openai ?? 'gpt-4o-mini';
+      const model = getSettings().models?.openai ?? DEFAULT_MODELS.openai!;
 
       // 纵深防御：编号结构靠 \n 分隔，文本自带的换行会把编号撑破导致错位。
       // 即便入口采集漏了归一化，这里也必须兜住，拼 prompt 前再压一次。

--- a/src/engines/router.ts
+++ b/src/engines/router.ts
@@ -3,6 +3,7 @@
 // 集成翻译缓存：先查后写，二次请求不碰网络。
 
 import { getSettings } from '~/src/storage/settings';
+import { DEFAULT_MODELS } from '~/src/storage/schema';
 import { cacheGet, cacheSet, cacheKey } from '~/src/storage/cache';
 import { googleWeb } from './google-web';
 import { bingEdge } from './bing-edge';
@@ -33,6 +34,9 @@ export async function route(req: TranslateRequest): Promise<TranslateResponse> {
     const engine = REGISTRY[id];
     if (!engine) continue;
 
+    // #175: BYOK 引擎的模型名参与缓存 key —— 切换模型后不命中旧译文
+    const model = getSettings().models?.[id] ?? DEFAULT_MODELS[id] ?? '';
+
     if (
       engine.supportedLangs !== 'all' &&
       !engine.supportedLangs.includes(req.to)
@@ -49,7 +53,7 @@ export async function route(req: TranslateRequest): Promise<TranslateResponse> {
       const cacheChecks = await Promise.all(
         req.texts.map(async (text, i) => {
           if (translations[i] !== null) return { i, cached: null, text };
-          const k = await cacheKey(id, req.from, req.to, text);
+          const k = await cacheKey(id, req.from, req.to, text, model);
           const cached = await cacheGet(k);
           return { i, cached, text };
         }),
@@ -111,7 +115,7 @@ export async function route(req: TranslateRequest): Promise<TranslateResponse> {
           if (succeeded.length > 0) {
             await Promise.all(
               succeeded.map(async (u) => {
-                const k = await cacheKey(id, req.from, req.to, u.text);
+                const k = await cacheKey(id, req.from, req.to, u.text, model);
                 const idx = uncached.indexOf(u);
                 const val = resp.translations[idx];
                 // #171: 短数组下成功槽位必然有值，这里再做一次防御
@@ -137,7 +141,7 @@ export async function route(req: TranslateRequest): Promise<TranslateResponse> {
       if (useCache) {
         await Promise.all(
           uncached.map(async (u) => {
-            const k = await cacheKey(id, req.from, req.to, u.text);
+            const k = await cacheKey(id, req.from, req.to, u.text, model);
             const idx = uncached.indexOf(u);
             await cacheSet(k, resp.translations[idx]!);
           }),

--- a/src/storage/cache.ts
+++ b/src/storage/cache.ts
@@ -2,15 +2,22 @@ const PREFIX = 'pt-c:';
 const MAX_ENTRIES = 5000;
 const INDEX_KEY = 'pt-cache-index';
 
+/** 缓存条目有效期 —— 30 天。超期条目在读取时惰性淘汰（#175）。 */
+export const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
 /**
- * 生成缓存 key: pt-c:{engine}:{from}:{to}:{sha1hex(text)}
+ * 生成缓存 key: pt-c:{engine}:{from}:{to}[:{model}]:{sha1hex(text)}
  * 跨站点共享 —— 同一段英文在不同网站只翻一次。
+ *
+ * #175: BYOK 引擎（openai/gemini）的模型名进 key —— 切换模型后
+ * 不再命中旧模型的译文。无模型的引擎（google/bing）key 不含模型段。
  */
 export async function cacheKey(
   engine: string,
   from: string,
   to: string,
   text: string,
+  model = '',
 ): Promise<string> {
   const buf = await crypto.subtle.digest(
     'SHA-1',
@@ -19,7 +26,7 @@ export async function cacheKey(
   const hex = [...new Uint8Array(buf)]
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('');
-  return `${PREFIX}${engine}:${from}:${to}:${hex}`;
+  return `${PREFIX}${engine}:${from}:${to}${model ? `:${model}` : ''}:${hex}`;
 }
 
 // ---- Index 序列化链 ----
@@ -31,7 +38,7 @@ let chain: Promise<void> = Promise.resolve();
 
 // ---- Index 内部操作 ----
 
-/** 将 key 移到 index 末尾（“最近使用”），必要时淘汰最旧的条目。 */
+/** 将 key 移到 index 末尾（"最近使用"），必要时淘汰最旧的条目。 */
 async function refreshIndex(key: string): Promise<void> {
   const idxResult = await chrome.storage.local.get(INDEX_KEY);
   let index: string[] = (idxResult[INDEX_KEY] as string[] | undefined) ?? [];
@@ -60,14 +67,29 @@ export function cacheGet(key: string): Promise<string | null> {
     .then(() => chrome.storage.local.get(key))
     .then((result) => {
       const v = result[key];
-      if (typeof v === 'string') {
+      if (typeof v !== 'string') return undefined;
+      // #175: 条目为带时间戳的 JSON 包装；超期 → 移除并视为未命中。
+      // 旧版纯字符串条目（升级前写入）没有时间戳，按永不过期处理，
+      // 由 LRU 自然淘汰。
+      try {
+        const parsed = JSON.parse(v) as { v?: string; t?: number };
+        if (typeof parsed.v === 'string' && typeof parsed.t === 'number') {
+          if (Date.now() - parsed.t > CACHE_TTL_MS) {
+            return chrome.storage.local.remove(key).then(() => undefined);
+          }
+          value = parsed.v;
+        } else {
+          value = v;
+        }
+      } catch {
         value = v;
-        // 命中 → 刷新 index 位置
-        return refreshIndex(key);
       }
-      return undefined;
+      // 命中 → 刷新 index 位置
+      return refreshIndex(key);
     })
-    .catch(() => {});
+    .catch((e) => {
+      console.warn('[PT] 缓存读取失败:', e);
+    });
 
   return chain.then(() => value);
 }
@@ -78,9 +100,17 @@ export function cacheGet(key: string): Promise<string | null> {
  */
 export function cacheSet(key: string, value: string): Promise<void> {
   chain = chain
-    .then(() => chrome.storage.local.set({ [key]: value }))
+    .then(() =>
+      chrome.storage.local.set({
+        [key]: JSON.stringify({ v: value, t: Date.now() }),
+      }),
+    )
     .then(() => refreshIndex(key))
-    .catch(() => {});
+    .catch((e) => {
+      // #175: 配额满（storage.local 总量 10MB）等写失败不再静默吞掉 ——
+      // 控制台可见原因，避免「缓存开了但从不生效」的无声失效
+      console.warn('[PT] 缓存写入失败（可能已达存储配额上限）:', e);
+    });
 
   return chain;
 }

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -113,6 +113,12 @@ export const LANG_LIST: { code: string; label: string }[] = [
 export const CONCURRENCY_MIN = 1;
 export const CONCURRENCY_MAX = 10;
 
+/** BYOK 引擎的默认模型名（缓存 key 的模型维度用，单一来源，#175）。 */
+export const DEFAULT_MODELS: Partial<Record<EngineId, string>> = {
+  openai: 'gpt-4o-mini',
+  gemini: 'gemini-2.0-flash',
+};
+
 /** 钳制并发数到合法范围 —— 导入/存储/写入口共用，防 0 或负数饿死闸门。 */
 export function clampConcurrency(n: unknown): number {
   const v = typeof n === 'number' && Number.isFinite(n) ? Math.floor(n) : CONCURRENCY_MIN;


### PR DESCRIPTION
## 问题
1. 缓存 key 无模型维度：BYOK 引擎切换模型名后仍命中旧模型译文
2. 无 TTL：缓存只按 LRU 淘汰，长期运行后同一文本永远返回旧译文
3. 配额满静默失败：cacheSet 的 catch 静默吞错，写入失败无提示

## 修复
- cacheKey 增加 model 参数（openai/gemini 模型名进 key，DEFAULT_MODELS 单一来源）
- 条目带时间戳 JSON 包装 + 30 天 TTL，读取时惰性淘汰；旧版纯字符串条目兼容
- cacheSet/cacheGet 失败 console.warn

## 验证
- 新增单测：不同模型不同 key、过期条目被移除、旧格式兼容
- 单元测试 431 项、core E2E 29 项全部通过