### PR TITLE
fix(hotkeys): 录制单一会话 + Esc 取消 + 空格/加号键映射（#176）

### DIFF
--- a/docs/testing/unit/hotkeys/normalize.test.ts
+++ b/docs/testing/unit/hotkeys/normalize.test.ts
@@ -103,6 +103,18 @@ describe('fromEvent', () => {
     const e = makeKeyEvent('Shift');
     expect(fromEvent(e, os)).toBeNull();
   });
+
+  // ── #176：空格 / 加号显式映射 ──
+
+  test('Mac Meta+空格 → "Mod+Space"（#176）', () => {
+    const e = makeKeyEvent(' ', { metaKey: true });
+    expect(fromEvent(e, 'mac')).toBe('Mod+Space');
+  });
+
+  test('Win Ctrl+加号 → "Mod+Plus"（#176）', () => {
+    const e = makeKeyEvent('+', { ctrlKey: true });
+    expect(fromEvent(e, 'other')).toBe('Mod+Plus');
+  });
 });
 
 describe('isTypingContext', () => {

--- a/docs/testing/unit/hotkeys/recorder.test.ts
+++ b/docs/testing/unit/hotkeys/recorder.test.ts
@@ -1,0 +1,66 @@
+/**
+ * hotkeys/recorder.ts — 录制组件（#176）
+ *
+ * 覆盖：Esc 走取消回调、带修饰键捕获、无修饰键拒绝。
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('~/src/i18n', () => ({
+  tf: (key: string, fallback: string) => fallback,
+}));
+
+import { startRecording } from '~/src/hotkeys/recorder';
+
+function keydown(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+}
+
+describe('startRecording', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('带修饰键 → onCapture 收到规范组合', () => {
+    const onCapture = vi.fn();
+    const onReject = vi.fn();
+    const stop = startRecording('mac', onCapture, onReject);
+    document.dispatchEvent(keydown({ key: 'y', metaKey: true, shiftKey: true }));
+    expect(onCapture).toHaveBeenCalledWith('Mod+Shift+Y');
+    expect(onReject).not.toHaveBeenCalled();
+    stop();
+  });
+
+  test('Esc → 走 onCancel 而非 onReject（#176）', () => {
+    const onCapture = vi.fn();
+    const onReject = vi.fn();
+    const onCancel = vi.fn();
+    const stop = startRecording('mac', onCapture, onReject, onCancel);
+    document.dispatchEvent(keydown({ key: 'Escape' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onReject).not.toHaveBeenCalled();
+    expect(onCapture).not.toHaveBeenCalled();
+    stop();
+  });
+
+  test('无修饰键 → onReject', () => {
+    const onCapture = vi.fn();
+    const onReject = vi.fn();
+    const stop = startRecording('mac', onCapture, onReject);
+    document.dispatchEvent(keydown({ key: 'y' }));
+    expect(onReject).toHaveBeenCalledTimes(1);
+    expect(onCapture).not.toHaveBeenCalled();
+    stop();
+  });
+
+  test('stop() 后不再监听', () => {
+    const onCapture = vi.fn();
+    const stop = startRecording('mac', onCapture, vi.fn());
+    stop();
+    document.dispatchEvent(keydown({ key: 'y', metaKey: true }));
+    expect(onCapture).not.toHaveBeenCalled();
+  });
+});

--- a/entrypoints/options/sections/hotkeys.ts
+++ b/entrypoints/options/sections/hotkeys.ts
@@ -25,6 +25,25 @@ const ACTIONS: HotkeyAction[] = [
 export function initHotkeys(os: OS): void {
   const listEl = document.getElementById('pt-hotkey-list')!;
 
+  // #176: 单一活动录制会话 —— 录制 A 未结束点 B 时先取消 A，
+  // 否则两个 keydown 监听并存，一次按键把同一 combo 同时写进两个动作
+  let activeRecording: { action: HotkeyAction; cancel: () => void } | null =
+    null;
+
+  function cancelActiveRecording(): void {
+    if (!activeRecording) return;
+    activeRecording.cancel();
+    const btn = document.getElementById(`pt-hotkey-${activeRecording.action}`);
+    if (btn) {
+      btn.classList.remove('pt-recording');
+      btn.textContent = formatHotkey(
+        getSettings().hotkeys[activeRecording.action]!,
+        os,
+      );
+    }
+    activeRecording = null;
+  }
+
   function render(): void {
     const s = getSettings();
     listEl.innerHTML = ACTIONS.map((action) => {
@@ -53,12 +72,14 @@ export function initHotkeys(os: OS): void {
       if (!btn) continue;
 
       btn.addEventListener('click', () => {
-        // Already recording? Cancel
+        // 点击正在录制的按钮 → 取消本次录制
         if (btn.classList.contains('pt-recording')) {
-          btn.classList.remove('pt-recording');
-          btn.textContent = formatHotkey(getSettings().hotkeys[action], recOS);
+          cancelActiveRecording();
           return;
         }
+
+        // 开始新录制前取消上一个会话（#176）
+        cancelActiveRecording();
 
         // Show recording state
         btn.classList.add('pt-recording');
@@ -68,6 +89,7 @@ export function initHotkeys(os: OS): void {
           recOS,
           (combo) => {
             cancelRecord();
+            activeRecording = null;
             btn.classList.remove('pt-recording');
             btn.textContent = formatHotkey(combo, recOS);
 
@@ -87,8 +109,9 @@ export function initHotkeys(os: OS): void {
           },
           (reason) => {
             cancelRecord();
+            activeRecording = null;
             btn.classList.remove('pt-recording');
-            btn.textContent = formatHotkey(getSettings().hotkeys[action], recOS);
+            btn.textContent = formatHotkey(getSettings().hotkeys[action]!, recOS);
             const existing = document.getElementById(`pt-conflict-${action}`);
             if (existing) existing.remove();
             const warn = document.createElement('div');
@@ -98,7 +121,23 @@ export function initHotkeys(os: OS): void {
             btn.parentElement!.after(warn);
             setTimeout(() => warn.remove(), 2500);
           },
+          () => {
+            // #176: Esc 取消 —— 还原按钮态并给出「已取消」提示
+            cancelRecord();
+            activeRecording = null;
+            btn.classList.remove('pt-recording');
+            btn.textContent = formatHotkey(getSettings().hotkeys[action]!, recOS);
+            const existing = document.getElementById(`pt-conflict-${action}`);
+            if (existing) existing.remove();
+            const warn = document.createElement('div');
+            warn.id = `pt-conflict-${action}`;
+            warn.className = 'pt-hotkey-conflict';
+            warn.textContent = tf('recordCancelled', '已取消');
+            btn.parentElement!.after(warn);
+            setTimeout(() => warn.remove(), 2500);
+          },
         );
+        activeRecording = { action, cancel: cancelRecord };
       });
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.85",
+  "version": "0.6.86",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/hotkeys/normalize.ts
+++ b/src/hotkeys/normalize.ts
@@ -10,8 +10,11 @@ import type { OS } from './platform';
  * 拒绝无修饰键的单键 → 避免与页面输入冲突。
  */
 export function fromEvent(e: KeyboardEvent, os: OS): string | null {
-  const key = e.key;
-  if (['Control', 'Meta', 'Alt', 'Shift'].includes(key)) return null;
+  // #176: 空格/加号等会破坏 '+' 分隔符语义的键显式映射 ——
+  // 原样保留会生成 'Mod+ ' / 'Mod++'，解析与显示双双损坏
+  const KEY_ALIAS: Record<string, string> = { ' ': 'Space', '+': 'Plus' };
+  const key = KEY_ALIAS[e.key] ?? e.key;
+  if (['Control', 'Meta', 'Alt', 'Shift'].includes(e.key)) return null;
 
   const mods: string[] = [];
   if (os === 'mac') {

--- a/src/hotkeys/platform.ts
+++ b/src/hotkeys/platform.ts
@@ -57,11 +57,12 @@ const PC_ORDER = ['Ctrl', 'Mod', 'Alt', 'Shift'];
 export function formatHotkey(combo: string, os: OS): string {
   const parts = combo.split('+');
   const key = parts.pop()!;
+  // #176: 别名键的显示形式（与 fromEvent 的 KEY_ALIAS 对应）
+  const DISPLAY_KEY: Record<string, string> = { Space: 'Space', Plus: '+' };
+  const shown = DISPLAY_KEY[key] ?? key.toUpperCase();
   const order = os === 'mac' ? MAC_ORDER : PC_ORDER;
   const mods = order
     .filter((m) => parts.includes(m))
     .map((m) => SYMBOLS[os][m]!);
-  return os === 'mac'
-    ? mods.join('') + key.toUpperCase()
-    : [...mods, key.toUpperCase()].join('+');
+  return os === 'mac' ? mods.join('') + shown : [...mods, shown].join('+');
 }

--- a/src/hotkeys/recorder.ts
+++ b/src/hotkeys/recorder.ts
@@ -69,10 +69,18 @@ export function startRecording(
   os: OS,
   onCapture: (combo: string) => void,
   onReject: (reason: string) => void,
+  onCancel?: () => void,
 ): () => void {
   const onKeyDown = (e: KeyboardEvent) => {
     e.preventDefault();
     e.stopPropagation();
+
+    // #176: Esc 单独走取消回调 —— 修复前 fromEvent 返回 null 走 onReject，
+    // 误报「请使用带修饰键的组合」，用户以为录制出错
+    if (e.key === 'Escape') {
+      onCancel?.();
+      return;
+    }
 
     // 仅修饰键 -> 忽略
     if (['Control', 'Meta', 'Alt', 'Shift'].includes(e.key)) return;


### PR DESCRIPTION
## 问题
1. 录制状态机缺陷：录制 A 未结束点 B 不取消 A，两个 keydown 监听并存，一次按键写进两个动作；Esc 误报「请使用带修饰键的组合」
2. 空格/加号键生成 'Mod+ ' / 'Mod++'，显示损坏

## 修复
- 模块级单一活动录制：开始新录制前取消上一个并还原按钮态
- recorder 对 Esc 单独走取消回调，提示「已取消」
- fromEvent 显式映射 ' ' → Space、'+' → Plus，formatHotkey 对应显示

## 验证
- 新增单测：Esc → onCancel；Mod+Space / Mod+Plus 规范化
- 单元测试 437 项、core E2E 29 项全部通过