### PR TITLE
fix(welcome): 关闭按钮改 background 移除标签页（#177）

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -82,6 +82,16 @@ export default defineBackground(() => {
     }
   });
 
+  // #177: welcome 页「关闭」按钮 —— 页面脚本的 window.close() 会被
+  // 浏览器静默忽略（标签页由 background 打开），由这里移除标签页
+  chrome.runtime.onMessage.addListener((msg, sender) => {
+    if (msg?.type === 'pt:close-welcome' && sender.tab?.id) {
+      chrome.tabs.remove(sender.tab.id).catch(() => {
+        console.debug('[PT] 关闭 welcome 标签页失败或已关闭');
+      });
+    }
+  });
+
   // 健康检查（E2E 测试用于验证消息通道就绪）
   chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     if (msg?.type === 'pt:ping') {

--- a/entrypoints/welcome/main.ts
+++ b/entrypoints/welcome/main.ts
@@ -59,7 +59,13 @@ function bindButtons(): void {
   });
 
   document.getElementById('pt-welcome-close')?.addEventListener('click', () => {
-    window.close();
+    // #177: window.close() 只对脚本自己打开的窗口生效 —— welcome 标签页
+    // 由 background 的 chrome.tabs.create 打开，浏览器会静默忽略 close()。
+    // 改为通知 background 用 chrome.tabs.remove 关闭当前标签页。
+    chrome.runtime.sendMessage({ type: 'pt:close-welcome' }).catch(() => {
+      // background 不可达（理论上不会发生）时兜底尝试直接关闭
+      window.close();
+    });
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.86",
+  "version": "0.6.87",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## 问题
welcome 页「关闭」按钮调 window.close()，但标签页由 background 的 chrome.tabs.create 打开，页面脚本不满足「只能关闭自己打开的窗口」条件，浏览器静默忽略 → 按钮无效。

## 修复
改为发消息给 background，由 background 调 chrome.tabs.remove 关闭当前标签页；background 不可达时兜底 window.close()。

## 验证
- 单元测试 437 项全部通过，构建成功