### PR TITLE
fix(background): 右键菜单创建前 removeAll（#178）

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -45,7 +45,7 @@ export default defineBackground(() => {
 
   // 右键菜单 + 首次安装引导
   chrome.runtime.onInstalled.addListener((details) => {
-    initContextMenu();
+    initContextMenu().catch(() => {});
 
     if (details.reason === 'install') {
       // 根据浏览器 UI 语言推导默认目标语言

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.87",
+  "version": "0.6.88",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/ui/context-menu.ts
+++ b/src/ui/context-menu.ts
@@ -4,14 +4,24 @@
 import { tf } from '../i18n';
 
 /**
- * 初始化右键菜单。必须在 onInstalled 中调用以避免重复注册报错。
+ * 初始化右键菜单。必须在 onInstalled 中调用。
+ *
+ * #178: onInstalled 在扩展 update 时同样触发 —— 右键菜单跨更新持久
+ * 存在（尤其 Firefox），同 id 重复 create 会报错（Chrome 控制台噪音、
+ * Firefox 报错）。创建前先 removeAll 清掉旧菜单，保证幂等。
  */
-export function initContextMenu(): void {
-  chrome.contextMenus.create({
-    id: 'pt-translate-selection',
-    title: tf('ctxTranslateSelection', '翻译所选文本'),
-    contexts: ['selection'],
-  });
+export async function initContextMenu(): Promise<void> {
+  try {
+    // removeAll 只清本扩展的菜单；await 保证 create 时旧菜单已清空
+    await chrome.contextMenus.removeAll();
+    chrome.contextMenus.create({
+      id: 'pt-translate-selection',
+      title: tf('ctxTranslateSelection', '翻译所选文本'),
+      contexts: ['selection'],
+    });
+  } catch (e) {
+    console.warn('[PT] 右键菜单初始化失败:', e);
+  }
 }
 
 /**


### PR DESCRIPTION
## 问题
onInstalled 每次（含 update）无条件 contextMenus.create({ id: 'pt-translate-selection' })，右键菜单跨更新持久存在，同 id 重复 create 报错。

## 修复
initContextMenu 改为 async：创建前先 removeAll 清掉旧菜单（幂等），失败 console.warn。

## 验证
- 单元测试 437 项全部通过，构建成功