### PR TITLE
fix(dom): 采集盲区修复 —— display:contents/SPA 文本更新/done 容器新内容/延迟 attachShadow（#179）

### DIFF
--- a/docs/testing/e2e/core.spec.ts
+++ b/docs/testing/e2e/core.spec.ts
@@ -402,6 +402,54 @@ test.describe('Fixture: spa', () => {
     await expect(page.locator('#view [data-pt="done"]')).toHaveCount(3, { timeout: 15_000 });
   });
 
+  test('@core TC-E2E-56: SPA 纯文本更新（textContent 原地改）→ 自动补翻（#179）', async ({
+    page, mockGoogle, seedSettings, gotoFixture,
+  }) => {
+    await seedSettings({});
+    await mockGoogle();
+    await gotoFixture('spa');
+
+    await translateAndWait(page);
+
+    // React 式原地更新：复用同一 DOM 元素，只改原文文本节点数据 ——
+    // 修复前 observer 只监 childList，新文本永不补翻
+    await page.evaluate(() => {
+      const view = document.getElementById('view')!;
+      const h1 = view.querySelector('h1')!;
+      // 已翻译单元的原文在 .pt-origin 内
+      h1.querySelector('.pt-origin')!.firstChild!.nodeValue = 'In-place updated heading text';
+    });
+
+    // 单元被还原并重新翻译 —— .pt-trans 携带新文本的译文（mock 前缀 + 原文）
+    await expect(page.locator('#view h1 .pt-trans')).toContainText(
+      'In-place updated heading text',
+      { timeout: 15_000 },
+    );
+  });
+
+  test('@core TC-E2E-57: 延迟 attachShadow 的组件内容 → 自动补翻（#179）', async ({
+    page, mockGoogle, seedSettings, gotoFixture,
+  }) => {
+    await seedSettings({});
+    await mockGoogle();
+    await gotoFixture('spa');
+
+    await translateAndWait(page);
+    const initialDone = await page.locator('[data-pt="done"]').count();
+
+    // host 已入 DOM 后才建 shadow root（childList 捕不到 attachShadow）
+    await page.evaluate(() => {
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const root = host.attachShadow({ mode: 'open' });
+      const p = document.createElement('p');
+      p.textContent = 'Late shadow root paragraph content.';
+      root.appendChild(p);
+    });
+
+    await expect(page.locator('[data-pt="done"]')).toHaveCount(initialDone + 1, { timeout: 15_000 });
+  });
+
   test('@core TC-E2E-47: 增量翻译瞬时失败后自动重试（#91 回归）', async ({
     page, serviceWorker, mockGoogle, seedSettings, gotoFixture,
   }) => {

--- a/docs/testing/unit/dom/classify.test.ts
+++ b/docs/testing/unit/dom/classify.test.ts
@@ -12,6 +12,7 @@ import {
   closestUnit,
   shouldSkipNonVisual,
   shouldSkip,
+  isVisible,
   MAX_TEXT,
   MAX_HTML,
 } from '~/src/dom/classify';
@@ -267,11 +268,16 @@ describe('shouldSkipNonVisual', () => {
     document.body.removeChild(div);
   });
 
-  test('已在 data-pt="done" 内 → true', () => {
-    const outer = el('<div data-pt="done"><p id="inner">Already translated</p></div>');
+  test('已翻译原文内容（.pt-origin 内）→ true（#179）', () => {
+    // render 后的真实结构：原文子节点被包进 .pt-origin
+    const outer = el(
+      '<div data-pt="done"><span class="pt-origin"><p id="inner">Already translated</p></span></div>',
+    );
     document.body.appendChild(outer);
     const inner = outer.querySelector('#inner')!;
     expect(shouldSkipNonVisual(inner)).toBe(true);
+    // 已翻译单元自身同样跳过
+    expect(shouldSkipNonVisual(outer)).toBe(true);
   });
 
   test('PT UI 内 → true', () => {
@@ -352,6 +358,40 @@ describe('shouldSkip', () => {
     const p = el('<p>No</p>');
     mockBoundingRect(p, { width: 30, right: 30 });
     expect(shouldSkip(p)).toBe(true);
+  });
+
+  test('display:contents 元素 → 视为可见（#179）', () => {
+    const p = el('<p>display contents text</p>');
+    p.setAttribute('style', 'display: contents');
+    // rect 恒 0×0（无盒），但 display:contents 的文本真实渲染
+    expect(isVisible(p)).toBe(true);
+    mockBoundingRect(p, { width: 0, height: 0 });
+    expect(shouldSkip(p)).toBe(false);
+  });
+
+  test('已翻译容器内新增段落（.pt-origin 外）→ 可采集（#179）', () => {
+    const container = el('<div><p>origin text</p></div>');
+    document.body.appendChild(container);
+    // 模拟已翻译的容器：原文被包进 .pt-origin
+    const origin = document.createElement('span');
+    origin.className = 'pt-origin';
+    while (container.firstChild) origin.appendChild(container.firstChild);
+    container.appendChild(origin);
+    container.setAttribute('data-pt', 'done');
+    mockBoundingRect(container);
+
+    // 容器内新增的段落（.pt-origin 之外）
+    const fresh = document.createElement('p');
+    fresh.textContent = 'Appended after translation, should be collected.';
+    container.appendChild(fresh);
+    mockBoundingRect(fresh);
+
+    // 修复前：closest([data-pt=done]) → 跳过 → 永久漏翻
+    expect(shouldSkipNonVisual(fresh)).toBe(false);
+    // 原文内容（.pt-origin 内）仍被跳过，不重复翻译
+    expect(shouldSkipNonVisual(origin)).toBe(true);
+    // 已翻译单元自身仍被跳过
+    expect(shouldSkipNonVisual(container)).toBe(true);
   });
 
   test('shouldSkipNonVisual > 含大量链接的 pre 切块 → false（#174）', () => {

--- a/docs/testing/unit/dom/observer.test.ts
+++ b/docs/testing/unit/dom/observer.test.ts
@@ -58,6 +58,112 @@ describe('startObserver 采集去重（#158）', () => {
     }
   });
 
+  test('characterData 变更（SPA 文本更新）→ 父元素被采集（#179）', async () => {
+    const restore = mockAllBoundingRects();
+    try {
+      const seen: Element[] = [];
+      const stop = startObserver((els) => seen.push(...els));
+
+      const p = document.createElement('p');
+      p.textContent = 'original text';
+      document.body.appendChild(p);
+
+      // React 式原地更新：直接改文本节点数据（无 DOM 增删）
+      p.firstChild!.nodeValue = 'updated by SPA';
+
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(seen).toContain(p);
+      stop();
+    } finally {
+      restore();
+    }
+  });
+
+  test('译文文本（.pt-trans 内）的变更 → 不触发采集（#179）', async () => {
+    const restore = mockAllBoundingRects();
+    try {
+      const seen: Element[] = [];
+      const stop = startObserver((els) => seen.push(...els));
+
+      const p = document.createElement('p');
+      p.textContent = '原文';
+      document.body.appendChild(p);
+      p.setAttribute('data-pt', 'done');
+      const origin = document.createElement('span');
+      origin.className = 'pt-origin';
+      origin.textContent = '原文';
+      const trans = document.createElement('span');
+      trans.className = 'pt-trans';
+      trans.textContent = '译文';
+      p.append(origin, trans);
+
+      // 页面 JS 改了译文文本 —— 不应再次采集（避免自激）
+      trans.firstChild!.nodeValue = '新译文';
+      await vi.advanceTimersByTimeAsync(300);
+      expect(seen).toHaveLength(0);
+
+      stop();
+    } finally {
+      restore();
+    }
+  });
+
+  test('已翻译单元的原文文本被更新（React 原地改）→ 还原并重新采集（#179）', async () => {
+    const restore = mockAllBoundingRects();
+    try {
+      const seen: Element[] = [];
+      const stop = startObserver((els) => seen.push(...els));
+
+      const p = document.createElement('p');
+      p.textContent = '旧原文';
+      document.body.appendChild(p);
+      p.setAttribute('data-pt', 'done');
+      const origin = document.createElement('span');
+      origin.className = 'pt-origin';
+      origin.textContent = '旧原文';
+      const trans = document.createElement('span');
+      trans.className = 'pt-trans';
+      trans.textContent = '旧译文';
+      p.append(origin, trans);
+
+      // React 式：更新原文文本节点数据（.pt-origin 内）
+      origin.firstChild!.nodeValue = '新原文';
+
+      await vi.advanceTimersByTimeAsync(300);
+
+      // 单元被还原（data-pt 清除）并重新采集
+      expect(p.getAttribute('data-pt')).toBeNull();
+      expect(seen).toContain(p);
+      stop();
+    } finally {
+      restore();
+    }
+  });
+
+  test('延迟 attachShadow（host 已在 DOM 后建 shadow）→ shadow 内容被采集（#179）', async () => {
+    const restore = mockAllBoundingRects();
+    try {
+      const seen: Element[] = [];
+      const stop = startObserver((els) => seen.push(...els));
+
+      // host 先入 DOM，随后才 attachShadow（模拟延迟初始化的 Web Component）
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const root = host.attachShadow({ mode: 'open' });
+      const p = document.createElement('p');
+      p.textContent = 'late shadow content';
+      root.appendChild(p);
+
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(seen).toContain(p);
+      stop();
+    } finally {
+      restore();
+    }
+  });
+
   test('pre 切块产生的 mutation 不进 pending：不二次收集未完成翻译的块', async () => {
     const restore = mockAllBoundingRects();
     try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.88",
+  "version": "0.6.89",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/classify.ts
+++ b/src/dom/classify.ts
@@ -84,7 +84,11 @@ export function shouldSkipNonVisual(el: Element): boolean {
 
   if (el.classList.contains('notranslate')) return true;
   if ((el as HTMLElement).isContentEditable) return true;
-  if (el.closest('[data-pt="done"]')) return true;
+  // #179: 已翻译单元自身与其原文内容（.pt-origin 内）不重复翻译；
+  // 但页面在已翻译容器内**新增**的段落（.pt-origin 之外）仍需采集补翻
+  // —— 旧的 closest('[data-pt="done"]') 会把新内容一并拦掉，永久漏翻
+  if (el.getAttribute('data-pt') === 'done') return true;
+  if (el.closest('.pt-origin')) return true;
 
   // 扩展自身注入的 UI —— 绝不能翻译自己的按钮文字
   if (el.closest('[data-pt-ui="1"]')) return true;
@@ -111,7 +115,13 @@ export function shouldSkipNonVisual(el: Element): boolean {
 /** 元素是否可见（非 display:none 且祖先均可见）。 */
 export function isVisible(el: Element): boolean {
   const rect = (el as HTMLElement).getBoundingClientRect?.();
-  if (rect && rect.width === 0 && rect.height === 0) return false;
+  if (rect && rect.width === 0 && rect.height === 0) {
+    // #179: display:contents 元素无盒（rect 恒 0×0），但其文本真实渲染
+    // 在页面上 —— 现代 grid/flex 布局骨架常见。按不可见处理会注册进
+    // IntersectionObserver 却永远等不到可见事件，内容永久漏翻。
+    if (getComputedStyle(el).display === 'contents') return true;
+    return false;
+  }
   return true;
 }
 

--- a/src/dom/observer.ts
+++ b/src/dom/observer.ts
@@ -18,7 +18,46 @@
 // - rootMargin 提前 300px 触发，让即将滚入视口的内容提前翻译。
 
 import { collect } from './walker';
+import { unrender } from './renderer';
 import { injectShadowStyles } from '~/src/styles/shadow';
+
+// #179: 延迟 attachShadow 漏翻 —— host 已入 DOM 后才建 shadow root 的
+// 组件（属性级操作，childList 捕不到、MutationObserver 不产生记录）。
+// 补丁 Element.prototype.attachShadow：创建 shadow root 时同步通知所有
+// 活跃 observer 挂载，shadow 内容不再永久漏翻。
+interface ObserverContext {
+  onMutationRecord: (records: MutationRecord[]) => void;
+  observedRoots: WeakSet<ShadowRoot>;
+  observers: MutationObserver[];
+}
+const observerContexts = new Set<ObserverContext>();
+
+const nativeAttachShadow = Element.prototype.attachShadow;
+if (
+  !(Element.prototype as unknown as { __ptShadowPatched?: boolean })
+    .__ptShadowPatched
+) {
+  (Element.prototype as unknown as { __ptShadowPatched: boolean })
+    .__ptShadowPatched = true;
+  Element.prototype.attachShadow = function (
+    this: Element,
+    init?: ShadowRootInit,
+  ): ShadowRoot {
+    // 原生实现允许省略 init，类型声明要求必填 —— 运行时原样透传
+    const root = nativeAttachShadow.call(this, init as ShadowRootInit);
+    for (const ctx of observerContexts) {
+      if (ctx.observedRoots.has(root)) continue;
+      ctx.observedRoots.add(root);
+      // 同步挂载：shadow 内容通常在 attachShadow 之后立即填充，
+      // 后续 childList 记录会被新 observer 捕获
+      injectShadowStyles(root);
+      const mo = new MutationObserver(ctx.onMutationRecord);
+      mo.observe(root, { childList: true, subtree: true });
+      ctx.observers.push(mo);
+    }
+    return root;
+  };
+}
 
 /**
  * 递归收集 root 下所有 shadowRoot，对每个挂载 observer。
@@ -164,7 +203,35 @@ export function startObserver(
 
   const onMutationRecord = (records: MutationRecord[]) => {
     for (const r of records) {
-      // 只看新增节点。属性变化、文本变化不触发重翻，
+      // #179: SPA 原地复用 DOM 仅改 textContent（React 式视图切换）——
+      // 只监 childList 会漏掉纯文本更新。characterData 的 target 是
+      // 文本节点，取父元素作候选；译文/UI/已翻译内容（.pt-origin 内）
+      // 的变更不补翻，不会与自身渲染互相激发。
+      if (r.type === 'characterData') {
+        const target = r.target;
+        const el = target instanceof Text ? target.parentElement : null;
+        if (!el) continue;
+        if (el.closest('[data-pt-ui="1"]')) continue;
+        if (el.closest('.pt-trans')) continue;
+        // #179: 页面更新了**已翻译单元**的原文文本（React 复用 DOM
+        // 原地改 nodeValue）—— 先还原该单元再重新采集翻译；否则
+        // 新文本永远显示旧译文。自己的渲染/还原只产生 childList，
+        // 不会经此路径自激。
+        const origin = el.closest('.pt-origin');
+        if (origin) {
+          const unit = origin.parentElement;
+          if (unit?.getAttribute('data-pt') === 'done') {
+            unrender(unit);
+            // unrender 已把 .pt-origin 移除 —— 采集目标是还原后的单元
+            pending.push(unit);
+            continue;
+          }
+        }
+        pending.push(el);
+        continue;
+      }
+
+      // 只看新增节点。属性变化不触发重翻，
       // 否则会与自身渲染互相激发
       for (const n of r.addedNodes) {
         if (n.nodeType !== Node.ELEMENT_NODE) continue;
@@ -186,18 +253,30 @@ export function startObserver(
   };
 
   // 主文档 observer
+  // #179: 监听 characterData —— SPA 原地更新文本（React nodeValue 更新）
+  // 产生 characterData 记录；译文/UI 变更已在上层过滤，不会自激
   const mainMo = new MutationObserver(onMutationRecord);
-  mainMo.observe(document.body, { childList: true, subtree: true });
+  mainMo.observe(document.body, {
+    childList: true,
+    subtree: true,
+    characterData: true,
+  });
   observers.push(mainMo);
 
   // 初始扫描：为文档中已存在的 shadow root 各挂 observer
   const initial = observeShadowRoots(document.body, onMutationRecord, observedRoots);
   observers.push(...initial);
 
+  // #179: 注册到 attachShadow 补丁的通知集合 —— 延迟建 shadow root 的
+  // 组件也能被增量补翻
+  const ctx: ObserverContext = { onMutationRecord, observedRoots, observers };
+  observerContexts.add(ctx);
+
   // #23：启动 IntersectionObserver，监听初次采集时因 display:none 被跳过的元素
   startWatching(onNewNodes);
 
   return () => {
+    observerContexts.delete(ctx);
     for (const mo of observers) mo.disconnect();
     if (timer) clearTimeout(timer);
     if (io) {


### PR DESCRIPTION
## 问题
四个采集盲区：display:contents 元素判不可见永不翻译；SPA 纯文本更新（React 原地改 nodeValue）漏翻；已翻译容器内新增段落被 closest(done) 拦掉；延迟 attachShadow 的组件内容捕不到。

## 修复
1. isVisible：display:contents 视为可见
2. observer 监听 characterData：未翻译内容直接采集；已翻译单元原文更新 → 先还原再重翻；译文/UI 变更过滤不自激
3. shouldSkipNonVisual：仅跳过 .pt-origin 内内容与单元自身，done 容器内新段落可采集
4. 补丁 Element.prototype.attachShadow：创建 shadow root 时同步挂载 observer + 样式

## 验证
- 新增单测 6 项、E2E TC-E2E-56（SPA 文本更新）与 TC-E2E-57（延迟 attachShadow）
- 单元测试 443 项、core E2E 31 项全部通过