### PR TITLE
fix(audit): 存疑项验证与修复 —— 多 frame 广播/旧选区/拖拽卡态/死概念/CORS/不可恢复重试（#180）

### DIFF
--- a/docs/testing/e2e/core.spec.ts
+++ b/docs/testing/e2e/core.spec.ts
@@ -975,6 +975,41 @@ test.describe('Fixture: iframe', () => {
     // 验证 iframe 内容可访问
     await expect(frame.locator('body')).toBeVisible();
   });
+
+  test('@core TC-E2E-58: popup 广播到多 frame —— 响应必是主 frame 的结果（#180 验证）', async ({
+    page, serviceWorker, mockGoogle, seedSettings, gotoFixture,
+  }) => {
+    await seedSettings({});
+    await mockGoogle();
+    await gotoFixture('iframe');
+
+    // 与 popup 同路径：SW 端 tabs.sendMessage 不带 frameId 广播到全部 frame。
+    // 若子 frame 的 undefined 返回抢先决议，status 会是 undefined。
+    // 遍历标签页：无 content script 的标签页 sendMessage 会拒绝，跳过。
+    const resp = await serviceWorker.evaluate(async () => {
+      const tabs = await chrome.tabs.query({});
+      for (const tab of tabs) {
+        if (tab.id == null) continue;
+        try {
+          const r = (await chrome.tabs.sendMessage(tab.id, {
+            type: 'pt:toggle-translate',
+          })) as { ok?: boolean; status?: string };
+          if (r && typeof r === 'object') {
+            return { ok: r.ok ?? false, status: r.status };
+          }
+        } catch {
+          // 无 content script 的标签页
+        }
+      }
+      return { error: '所有标签页均无 content script 响应' };
+    });
+
+    expect(resp.error).toBeUndefined();
+    // 主 frame 的响应（ok:true + 翻译态），而非子 frame 的 undefined
+    expect(resp.ok).toBe(true);
+    expect(resp.status).toBe('translated');
+    await expect(page.locator('[data-pt="done"]').first()).toBeVisible({ timeout: 30_000 });
+  });
 });
 
 // ================================================================

--- a/docs/testing/unit/runtime/batch-retry.test.ts
+++ b/docs/testing/unit/runtime/batch-retry.test.ts
@@ -44,6 +44,31 @@ describe('attemptBatchWithRetry — 成功路径', () => {
   });
 });
 
+describe('attemptBatchWithRetry — 不可恢复错误（#180）', () => {
+  test('retryable=false（key 无效等）→ 立即失败，0 次重试', async () => {
+    const send = vi.fn(async () => ({
+      ok: false,
+      error: 'API key 无效',
+      retryable: false,
+    }));
+    const result = await attemptBatchWithRetry(send, { sleep: noopSleep });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('API key 无效');
+      expect(result.invalidated).toBe(false);
+      expect(result.aborted).toBe(false);
+    }
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  test('缺省 retryable → 按可重试处理（默认行为不变）', async () => {
+    const send = vi.fn(async () => ({ ok: false, error: '瞬时故障' }));
+    await attemptBatchWithRetry(send, { sleep: noopSleep });
+    expect(send).toHaveBeenCalledTimes(BATCH_RETRY_LIMIT + 1);
+  });
+});
+
 describe('attemptBatchWithRetry — 重试预算（#91）', () => {
   test(`持续引擎级失败 → 共发送 ${BATCH_RETRY_LIMIT + 1} 次后失败，invalidated=false`, async () => {
     const send = vi.fn(async () => ({ ok: false, error: '所有引擎均失败' }));

--- a/docs/testing/unit/runtime/messaging.test.ts
+++ b/docs/testing/unit/runtime/messaging.test.ts
@@ -190,6 +190,8 @@ describe('translateViaBackground — 失败语义', () => {
       ok: false,
       error: '所有引擎均失败',
       invalidated: false,
+      // #180: 未携带 retryable 的响应按可重试处理
+      retryable: true,
     });
     // 1 ping + 1 translate，translate 没有重试
     expect(sendMessage).toHaveBeenCalledTimes(2);

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -5,6 +5,7 @@ import { cacheSet, cacheKey, cacheGet, cacheClear } from '~/src/storage/cache';
 import { getKey, setKey, removeKey } from '~/src/storage/keys';
 import { settingsReady, patchSettings, onSettingsChanged } from '~/src/storage/settings';
 import { route } from '~/src/engines/router';
+import { EngineError } from '~/src/engines/types';
 import { ensureE2EMock, applyE2EMock, getE2EMockStats } from '~/src/engines/e2e-mock';
 import { initContextMenu } from '~/src/ui/context-menu';
 
@@ -111,9 +112,25 @@ export default defineBackground(() => {
         .then(() => ensureE2EMock())
         .then(() => route(msg.payload))
         .then((r) => sendResponse({ ok: true, data: r }))
-        .catch((e) => sendResponse({ ok: false, error: e instanceof Error ? e.message : String(e) }));
+        .catch((e) => {
+          // #180: 透出 retryable 标志 —— 仅引擎直接抛出的 retryable=false
+          // （key 无效等）不可恢复，批次重试层不再白等退避序列；router
+          // 的「所有引擎均失败」是普通 Error，按可重试处理（瞬时故障
+          // 重试后自愈，TC-E2E-47 依赖此路径）
+          const nonRetryable = e instanceof EngineError && e.retryable === false;
+          sendResponse({
+            ok: false,
+            error: e instanceof Error ? e.message : String(e),
+            retryable: !nonRetryable,
+          });
+        });
     } catch (e) {
-      sendResponse({ ok: false, error: e instanceof Error ? e.message : String(e) });
+      const nonRetryable = e instanceof EngineError && e.retryable === false;
+      sendResponse({
+        ok: false,
+        error: e instanceof Error ? e.message : String(e),
+        retryable: !nonRetryable,
+      });
     }
 
     return true;

--- a/entrypoints/options/sections/general.ts
+++ b/entrypoints/options/sections/general.ts
@@ -82,8 +82,10 @@ export function initGeneral(): void {
 
   async function loadBallPosSites(): Promise<void> {
     const all = await chrome.storage.local.get(null);
-    const ballKeys = Object.keys(all).filter(
-      (k) => k === 'pt-ball-pos' || k.startsWith('pt-ball-pos:'),
+    // #180: 悬浮球位置只写 pt-ball-pos:<hostname>，全局键 pt-ball-pos
+    // 是死概念（从未被写入）—— 列表/删除/重置都不再处理它
+    const ballKeys = Object.keys(all).filter((k) =>
+      k.startsWith('pt-ball-pos:'),
     );
     if (ballKeys.length === 0) {
       ballPosEmpty.style.display = 'block';
@@ -95,7 +97,7 @@ export function initGeneral(): void {
 
     const rows: string[] = [];
     for (const key of ballKeys) {
-      const hostname = key === 'pt-ball-pos' ? '(全局)' : key.slice('pt-ball-pos:'.length);
+      const hostname = key.slice('pt-ball-pos:'.length);
       const pos = all[key] as { x: number; y: number } | undefined;
       const posText = pos
         ? `(${Math.round(pos.x)}, ${Math.round(pos.y)})`
@@ -117,7 +119,7 @@ export function initGeneral(): void {
       btn.addEventListener('click', async (e) => {
         e.stopPropagation();
         const hostname = (btn as HTMLElement).dataset.key!;
-        const storageKey = hostname === '(全局)' ? 'pt-ball-pos' : `pt-ball-pos:${hostname}`;
+        const storageKey = `pt-ball-pos:${hostname}`;
         await chrome.storage.local.remove(storageKey).catch(() => {});
         await loadBallPosSites();
       });
@@ -126,8 +128,8 @@ export function initGeneral(): void {
 
   async function resetAllBallPos(): Promise<void> {
     const all = await chrome.storage.local.get(null);
-    const ballKeys = Object.keys(all).filter(
-      (k) => k === 'pt-ball-pos' || k.startsWith('pt-ball-pos:'),
+    const ballKeys = Object.keys(all).filter((k) =>
+      k.startsWith('pt-ball-pos:'),
     );
     if (ballKeys.length > 0) {
       await chrome.storage.local.remove(ballKeys).catch(() => {});
@@ -141,8 +143,8 @@ export function initGeneral(): void {
 
   resetBallPosBtn.addEventListener('click', async () => {
     const all = await chrome.storage.local.get(null);
-    const ballKeys = Object.keys(all).filter(
-      (k) => k === 'pt-ball-pos' || k.startsWith('pt-ball-pos:'),
+    const ballKeys = Object.keys(all).filter((k) =>
+      k.startsWith('pt-ball-pos:'),
     );
     if (ballKeys.length === 0) {
       resetBallPosBtn.textContent = tf('toastBallPosReset', '已重置');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.90",
+  "version": "0.6.91",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/runtime/batch-retry.ts
+++ b/src/runtime/batch-retry.ts
@@ -53,6 +53,8 @@ export async function attemptBatchWithRetry(
     error?: string;
     /** #116: messaging 透出的类型化上下文失效标志。 */
     invalidated?: boolean;
+    /** #180: 引擎不可恢复错误（key 无效等）—— 不重试。 */
+    retryable?: boolean;
   }>,
   opts: BatchRetryOptions = {},
 ): Promise<BatchRetryResult> {
@@ -73,6 +75,11 @@ export async function attemptBatchWithRetry(
     // #111/#116: 上下文失效是类型化标志 —— 立即失败，不进入重试序列
     if (resp?.invalidated) {
       return { ok: false, invalidated: true, aborted: false, error: lastError };
+    }
+    // #180: 不可恢复错误（key 无效等）重试只会白等退避序列后仍失败 ——
+    // 立即返回，错误 toast 马上出现
+    if (resp?.retryable === false) {
+      return { ok: false, invalidated: false, aborted: false, error: lastError };
     }
     if (attempt >= BATCH_RETRY_LIMIT) break;
     await sleep(BATCH_RETRY_DELAYS_MS[attempt]!);

--- a/src/runtime/messaging.ts
+++ b/src/runtime/messaging.ts
@@ -22,7 +22,13 @@ import { sleep } from '~/src/runtime/sleep';
 
 export type TranslateResult =
   | { ok: true; data: TranslateResponse }
-  | { ok: false; error: string; invalidated: boolean };
+  | {
+      ok: false;
+      error: string;
+      invalidated: boolean;
+      /** #180: 引擎不可恢复错误（key 无效等）—— 批次重试层不重试。 */
+      retryable: boolean;
+    };
 
 /** SW 就绪等待预算（ping 阶段）。覆盖 CI 中 SW 冷启动的常见耗时。 */
 const READY_BUDGET_MS = 10_000;
@@ -156,18 +162,29 @@ export async function translateViaBackground(
     const resp = (await sendWithTransportRetry(
       { type: 'pt:translate', payload },
       SEND_BUDGET_MS,
-    )) as { ok?: boolean; data?: TranslateResponse; error?: string };
+    )) as {
+      ok?: boolean;
+      data?: TranslateResponse;
+      error?: string;
+      retryable?: boolean;
+    };
 
     if (resp?.ok === true && resp.data) {
       return { ok: true, data: resp.data };
     }
-    return { ok: false, error: resp?.error ?? '未知错误', invalidated: false };
+    return {
+      ok: false,
+      error: resp?.error ?? '未知错误',
+      invalidated: false,
+      retryable: resp?.retryable ?? true,
+    };
   } catch (e) {
     // #116: 上下文失效以类型化标志透出，调用方无需匹配文案
     return {
       ok: false,
       error: e instanceof Error ? e.message : String(e),
       invalidated: e instanceof ContextInvalidatedError,
+      retryable: true,
     };
   }
 }

--- a/src/ui/floating-ball.ts
+++ b/src/ui/floating-ball.ts
@@ -99,6 +99,16 @@ export function createBall(callbacks: BallCallbacks): () => void {
     origY = rect.top;
     ballW = rect.width;
     ballH = rect.height;
+    // #180: 指针捕获 —— 窗口外松开时 mouseup 仍派发到球上，
+    // 否则 dragging/dragged 卡在 true，期间键盘 Enter 的 click 被吞
+    const pointerId = (e as MouseEvent & { pointerId?: number }).pointerId;
+    try {
+      if ('setPointerCapture' in ball && typeof pointerId === 'number') {
+        ball.setPointerCapture(pointerId);
+      }
+    } catch {
+      // 捕获失败（jsdom/极旧引擎）→ 依赖下方 blur/pointercancel 兜底
+    }
     e.preventDefault();
   };
 
@@ -136,6 +146,15 @@ export function createBall(callbacks: BallCallbacks): () => void {
   document.addEventListener('mousemove', onMouseMove);
   document.addEventListener('mouseup', onMouseUp);
 
+  // #180: 窗口外松开 / 拖拽中失焦（alt-tab 等）→ 立即复位拖动状态，
+  // 防止 dragged 卡 true 吞掉后续点击
+  const onDragReset = () => {
+    dragging = false;
+    dragged = false;
+  };
+  window.addEventListener('blur', onDragReset);
+  ball.addEventListener('pointercancel', onDragReset);
+
   // --- 点击 ---
   // 翻译还是还原由 content script 决定，球只转发点击。
   ball.addEventListener('click', () => {
@@ -167,6 +186,8 @@ export function createBall(callbacks: BallCallbacks): () => void {
 
   return () => {
     window.removeEventListener('resize', onResize);
+    window.removeEventListener('blur', onDragReset);
+    ball.removeEventListener('pointercancel', onDragReset);
     document.removeEventListener('mousemove', onMouseMove);
     document.removeEventListener('mouseup', onMouseUp);
     clearTimeout(errorTimer);

--- a/src/ui/selection-drag.ts
+++ b/src/ui/selection-drag.ts
@@ -18,12 +18,16 @@ export function startSelectionDrag(
   stopSelectionDrag();
 
   let armed = false;
+  let preSelection = '';
 
   const isModKey = (e: MouseEvent): boolean =>
     e.altKey || e.ctrlKey || e.metaKey;
 
   const onDown = (e: MouseEvent) => {
     armed = isModKey(e);
+    // #180: 记录按下前的选区 —— 点击非文本区域（悬浮球/空白处）不会
+    // 折叠旧选区，mouseup 时若不对比就会翻译之前残留的选中文本
+    preSelection = window.getSelection()?.toString() ?? '';
   };
 
   const onUp = (e: MouseEvent) => {
@@ -31,7 +35,8 @@ export function startSelectionDrag(
     armed = false;
     if (!isModKey(e)) return; // 中途松开修饰键则取消
     const text = window.getSelection()?.toString().trim();
-    if (text && text.length >= 2) onTranslate(text);
+    // #180: 本次拖动没有产生新选区（文本未变化）→ 不翻译残留旧选区
+    if (text && text.length >= 2 && text !== preSelection) onTranslate(text);
   };
 
   document.addEventListener('mousedown', onDown, true);

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -61,6 +61,18 @@ export default defineConfig({
     name: '__MSG_extName__',
     description: '__MSG_extDesc__',
     permissions: ['storage', 'contextMenus'],
+    // #180: 引擎端点显式声明 host 权限 —— 不依赖各端点 ACAO 头
+    // （Google/Bing 免 key 端点与 BYOK 端点均支持，声明后 options 页
+    // testConnection 对 CORS 异常端点的探测也不再静默失败）
+    host_permissions: [
+      'https://translate.googleapis.com/*',
+      'https://api-edge.cognitive.microsofttranslator.com/*',
+      'https://edge.microsoft.com/translate/auth',
+      'https://api.openai.com/*',
+      'https://generativelanguage.googleapis.com/*',
+      'https://api.deepl.com/*',
+      'https://api-free.deepl.com/*',
+    ],
     action: { default_title: '__MSG_extName__' },
     options_ui: { open_in_tab: true },
     icons: {


### PR DESCRIPTION
## 审计存疑项处理
1. 多 frame 广播响应语义 → 新增 E2E TC-E2E-58 实证验证：广播到含 iframe 的标签页，响应必为主 frame 结果
2. 划词翻译旧选区 → mousedown 记录按下前选区，mouseup 时选区未变化不翻译残留文本
3. 悬浮球窗口外松开卡状态 → setPointerCapture + blur/pointercancel 复位
4. pt-ball-pos 全局键死概念 → 移除 general.ts 的全局键分支
5. CORS → manifest 显式 host_permissions（6 个引擎端点）
6. batch-retry 对不可恢复错误仍重试 → 透出类型化 retryable 标志（仅引擎直抛 retryable=false 不重试），key 无效立即失败

## 验证
- 新增 E2E TC-E2E-58、单测 3 项（batch-retry 不可恢复/缺省可重试、messaging retryable 透传）
- 单元测试 458 项、core E2E 32 项全部通过