### PR TITLE
docs(readme): 同步版本号与权限描述 —— 发布前准备

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 对照式网页翻译浏览器扩展。原文与译文并排呈现，让阅读外语内容不必在两个界面之间来回切换。
 
-Chrome / Edge / Firefox，Manifest V3，当前 v0.6.19。
+Chrome / Edge / Firefox，Manifest V3，当前 v0.6.93。
 
 ## 特性
 
@@ -24,7 +24,7 @@ Chrome / Edge / Firefox，Manifest V3，当前 v0.6.19。
 
 **三语界面** —— 简体中文、繁体中文、English，随浏览器界面语言自动切换。
 
-**最小权限** —— 只申请 `storage` 与 `contextMenus`，无 `host_permissions`。
+**最小权限** —— 只申请 `storage` 与 `contextMenus`；`host_permissions` 仅限七个翻译端点域名（Google/Bing 免 key 端点与 OpenAI/DeepL/Gemini BYOK 端点），不申请任意站点权限，页面数据读取仍由 <all_urls> 内容脚本按翻译功能所需注入。
 
 ## 安装与开发
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "0.6.92",
+  "version": "0.6.93",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## 问题
README 停留在 v0.6.19，且 #180 新增 host_permissions 后仍声称「无 host_permissions」—— 商店上架时权限描述与实际 manifest 不一致。

## 修复
同步版本号 v0.6.93，权限说明更新为七个翻译端点域名。