### PR TITLE
docs(store): 商店描述许可证字样改为「待定」

### DIFF
--- a/store/description-en.md
+++ b/store/description-en.md
@@ -35,4 +35,4 @@ Chrome · Edge · Firefox (Manifest V3)
 
 https://github.com/Teeeeeeeerry/Parallel-Translation
 
-MIT License
+(License pending)

--- a/store/description-zh.md
+++ b/store/description-zh.md
@@ -35,4 +35,4 @@ Chrome · Edge · Firefox（Manifest V3）
 
 https://github.com/Teeeeeeeerry/Parallel-Translation
 
-MIT License
+（许可证待定）


### PR DESCRIPTION
## 问题
商店描述（zh/en）末尾声明 MIT License，但 README 许可段为「尚未确定」—— 虚假声明，上架审核或用户问询时会出问题。

## 修复
两处 MIT 字样改为「许可证待定 / License pending」，与 README 一致。