### PR TITLE
类型化结果类型落地 (fix #232)

### DIFF
--- a/docs/testing/unit/engines/attempt-outcome.test.ts
+++ b/docs/testing/unit/engines/attempt-outcome.test.ts
@@ -1,0 +1,74 @@
+/**
+ * engines/types.ts — 类型化结果（AttemptOutcome / EngineError）单元测试（#232）
+ *
+ * 扩张阶段：EngineError 新增类别字段（category / invalidated / aborted），
+ * 旧构造签名（engineId, retryable, message）与旧字段在兼容期保持可用。
+ */
+import { describe, test, expect } from 'vitest';
+import { EngineError } from '~/src/engines/types';
+import type { AttemptOutcome, FailureCategory } from '~/src/engines/types';
+
+describe('EngineError 类型化结果字段', () => {
+  test('旧构造签名（3 参）→ 默认类别 transient，invalidated/aborted 为 false', () => {
+    const e = new EngineError('gemini', true, 'HTTP 500');
+    expect(e.category).toBe('transient');
+    expect(e.retryable).toBe(true);
+    expect(e.invalidated).toBe(false);
+    expect(e.aborted).toBe(false);
+    // 旧字段与属性在兼容期保持可用
+    expect(e.engineId).toBe('gemini');
+    expect(e.message).toBe('HTTP 500');
+    expect(e.name).toBe('EngineError');
+    expect(e).toBeInstanceOf(Error);
+  });
+
+  test('key 无效组合（invalid-key + retryable=false）', () => {
+    const e = new EngineError('openai', false, 'API key 无效', 'invalid-key');
+    expect(e.category).toBe('invalid-key');
+    expect(e.retryable).toBe(false);
+    expect(e.invalidated).toBe(false);
+    expect(e.aborted).toBe(false);
+  });
+
+  test('配额失效组合（quota + invalidated=true）', () => {
+    const e = new EngineError('deepl', false, '配额已用尽', 'quota', true);
+    expect(e.category).toBe('quota');
+    expect(e.retryable).toBe(false);
+    expect(e.invalidated).toBe(true);
+    expect(e.aborted).toBe(false);
+  });
+
+  test('已中止组合（aborted + aborted=true）', () => {
+    const e = new EngineError('router', true, '已中止', 'aborted', false, true);
+    expect(e.category).toBe('aborted');
+    expect(e.retryable).toBe(true);
+    expect(e.invalidated).toBe(false);
+    expect(e.aborted).toBe(true);
+  });
+});
+
+describe('AttemptOutcome 接口形状', () => {
+  test('四种失败类别均可构造类型化结果', () => {
+    const categories: FailureCategory[] = [
+      'invalid-key',
+      'quota',
+      'transient',
+      'aborted',
+    ];
+    for (const category of categories) {
+      const outcome: AttemptOutcome = {
+        category,
+        retryable: category === 'transient',
+        invalidated: category === 'quota',
+        aborted: category === 'aborted',
+      };
+      expect(outcome.category).toBe(category);
+      expect(Object.keys(outcome).sort()).toEqual([
+        'aborted',
+        'category',
+        'invalidated',
+        'retryable',
+      ]);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -32,16 +32,52 @@ export interface TranslateEngine {
 }
 
 /**
+ * 失败类别（显式枚举）—— #219 架构评审候选 2 的类型化结果核心。
+ * 失败在发生的唯一地点分类一次，后续各层只读透传，不再各自重推导。
+ */
+export type FailureCategory =
+  /** key 无效（401/403 等认证失败）—— 不重试，提示用户检查 key。 */
+  | 'invalid-key'
+  /** 配额失效（429 配额耗尽等）—— 不重试，提示配额问题。 */
+  | 'quota'
+  /** 瞬时故障（5xx / 超时 / 网络）—— 默认可重试。 */
+  | 'transient'
+  /** 已中止（用户还原 / 页面切换）—— 调用方不应记成失败。 */
+  | 'aborted';
+
+/**
+ * 每次翻译尝试的类型化结果（#232）。
+ * 失败类别 + 可重试 + 配额失效 + 已中止 在错误发生的唯一地点构造一次。
+ */
+export interface AttemptOutcome {
+  /** 失败类别（显式枚举）。 */
+  category: FailureCategory;
+  /** 是否可重试：不可重试仅由引擎显式判定，默认瞬时故障可重试。 */
+  retryable: boolean;
+  /** 配额失效（免费额度耗尽等）—— 不可恢复，无需等待退避序列。 */
+  invalidated: boolean;
+  /** 已中止（还原 / 导航）—— 不应记成真失败。 */
+  aborted: boolean;
+}
+
+/**
  * 翻译引擎错误。
  * router 依 retryable 决定是否尝试下一个引擎：
  * - true  = 换个引擎可能成功（网络/限流/端点变更）
  * - false = 换了也没用（语言不支持等永久失败）
+ *
+ * 扩张阶段（#232）：新增 category / invalidated / aborted 字段，
+ * 旧构造签名（engineId, retryable, message）在兼容期保持可用，
+ * 旧调用方不破坏。
  */
-export class EngineError extends Error {
+export class EngineError extends Error implements AttemptOutcome {
   constructor(
     public engineId: string,
     public retryable: boolean,
     message: string,
+    public category: FailureCategory = 'transient',
+    public invalidated = false,
+    public aborted = false,
   ) {
     super(message);
     this.name = 'EngineError';


### PR DESCRIPTION
## 问题

同一条失败信息（可重试 / 失败类别）在引擎适配器、路由、background、messaging 各层重复解释，缺少统一类型——每层自行推断导致语义漂移（#161 gemini 400 误判、#180 retryable 不透出都长在这条 seam 上）。

## 根因

`EngineError` 只有 `retryable` 布尔，失败类别（key 无效 / 配额 / 瞬时 / 已中止）无处表达，消费层只能靠错误文案自行判断。

## 修复

新增 `FailureCategory` 显式枚举（invalid-key / quota / transient / aborted）与 `AttemptOutcome` 类型化结果接口（类别 + 可重试 + 配额失效 + 已中止）；`EngineError` 扩展实现该接口，新增字段带默认值，旧构造签名在兼容期保持可用，现有调用方不破坏。

## 验证

- 新增类型单测 5 项：默认值（3 参旧签名 → transient / false / false）、各类别组合、接口形状
- typecheck 通过；全量 462 项单测通过