### PR TITLE
统一遍历模块核心 (fix #233)

### DIFF
--- a/docs/testing/unit/dom/shadow-walk.test.ts
+++ b/docs/testing/unit/dom/shadow-walk.test.ts
@@ -1,0 +1,135 @@
+/**
+ * dom/shadow-walk.ts — 统一 shadow 子树遍历模块 单元测试（#233）
+ *
+ * 覆盖：普通 DOM 先序遍历、嵌套 shadow 递归、集中式跳过规则
+ * （UI 自身子树 / 已翻译标记）命中与不命中、skip-subtree 与 stop 决策。
+ */
+import { describe, test, expect, beforeEach } from 'vitest';
+import { walkShadowTree } from '~/src/dom/shadow-walk';
+
+function seenIds(root: ParentNode = document.body): string[] {
+  const seen: string[] = [];
+  walkShadowTree(root, (el) => {
+    if (el.id) seen.push(el.id);
+  });
+  return seen;
+}
+
+describe('walkShadowTree — 基础遍历', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('普通 DOM：先序命中全部元素', () => {
+    document.body.innerHTML =
+      '<div id="a"><p id="b">x</p></div><span id="c">y</span>';
+    expect(seenIds()).toEqual(['a', 'b', 'c']);
+  });
+
+  test('嵌套 shadow：递归下沉命中各层', () => {
+    const host = document.createElement('div');
+    host.id = 'h1';
+    document.body.appendChild(host);
+    const r1 = host.attachShadow({ mode: 'open' });
+    r1.innerHTML =
+      '<div id="s1"><p id="p1">shadow1</p><div id="h2"></div></div>';
+    const h2 = r1.getElementById('h2')!;
+    const r2 = h2.attachShadow({ mode: 'open' });
+    r2.innerHTML = '<p id="p2">shadow2</p>';
+
+    expect(seenIds()).toEqual(['h1', 's1', 'p1', 'h2', 'p2']);
+  });
+
+  test('Document 作为根：同样生效', () => {
+    document.body.innerHTML = '<p id="a">x</p>';
+    expect(seenIds(document)).toContain('a');
+  });
+});
+
+describe('walkShadowTree — 集中式跳过规则', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('UI 自身子树（data-pt-ui=1）：整棵子树跳过，含根容器自身', () => {
+    document.body.innerHTML =
+      '<div data-pt-ui="1" id="ui"><p id="inner">x</p></div><p id="ok">y</p>';
+    expect(seenIds()).toEqual(['ok']);
+  });
+
+  test('shadow 内的 UI 子树同样跳过', () => {
+    const host = document.createElement('div');
+    host.id = 'host';
+    document.body.appendChild(host);
+    const root = host.attachShadow({ mode: 'open' });
+    root.innerHTML =
+      '<div data-pt-ui="1"><p id="ui-s">x</p></div><p id="ok-s">y</p>';
+    expect(seenIds()).toEqual(['host', 'ok-s']);
+  });
+
+  test('已翻译标记（data-pt=done）：元素自身命中，子树默认跳过', () => {
+    document.body.innerHTML =
+      '<div data-pt="done" id="d"><p id="inner">x</p></div><p id="after">y</p>';
+    expect(seenIds()).toEqual(['d', 'after']);
+  });
+
+  test('已翻译标记：skipTranslated=false 时子树内元素也命中', () => {
+    document.body.innerHTML =
+      '<div data-pt="done" id="d"><p id="inner">x</p></div><p id="after">y</p>';
+    const seen: string[] = [];
+    walkShadowTree(
+      document.body,
+      (el) => {
+        if (el.id) seen.push(el.id);
+      },
+      { skipTranslated: false },
+    );
+    expect(seen).toEqual(['d', 'inner', 'after']);
+  });
+});
+
+describe('walkShadowTree — visit 决策', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('skip-subtree：跳过当前子树，兄弟继续', () => {
+    document.body.innerHTML =
+      '<div id="wrap"><p id="inner">x</p></div><p id="after">y</p>';
+    const seen: string[] = [];
+    walkShadowTree(document.body, (el) => {
+      if (el.id === 'wrap') return 'skip-subtree';
+      if (el.id) seen.push(el.id);
+    });
+    expect(seen).toEqual(['after']);
+  });
+
+  test('stop：立即终止整个遍历', () => {
+    document.body.innerHTML = '<p id="a">1</p><p id="b">2</p>';
+    const seen: string[] = [];
+    walkShadowTree(document.body, (el) => {
+      if (el.id === 'a') return 'stop';
+      if (el.id) seen.push(el.id);
+    });
+    expect(seen).toEqual([]);
+  });
+
+  test('stop 在 shadow 深处命中：light DOM 剩余部分不再访问', () => {
+    const host = document.createElement('div');
+    host.id = 'h1';
+    document.body.appendChild(host);
+    const r1 = host.attachShadow({ mode: 'open' });
+    r1.innerHTML = '<p id="deep">x</p>';
+    const after = document.createElement('p');
+    after.id = 'after';
+    after.textContent = 'y';
+    document.body.appendChild(after);
+
+    const seen: string[] = [];
+    walkShadowTree(document.body, (el) => {
+      if (el.id === 'deep') return 'stop';
+      if (el.id) seen.push(el.id);
+    });
+    expect(seen).toEqual(['h1']);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/shadow-walk.ts
+++ b/src/dom/shadow-walk.ts
@@ -1,0 +1,72 @@
+// 统一 shadow 子树遍历模块 —— #220 架构评审候选 4 的核心（#233）。
+//
+// Shadow-DOM 的递归遍历此前在还原流程、已翻译判定、观察器三处各写一遍，
+// 终止条件互不相同 —— 同一份遍历语义散落多处，漏一处就复发。本模块把
+// 递归遍历（含 shadowRoot）与集中式跳过 / 终止规则收敛为一处：
+//   - UI 自身子树（[data-pt-ui="1"]）：整棵子树跳过，不访问内部元素
+//   - 已翻译标记（[data-pt="done"]）：元素自身可被 visit 命中，
+//     其子树默认不再深入（skipTranslated: false 可关闭，供还原流程
+//     收集嵌套已翻译单元）
+//
+// 遍历顺序：先序。根元素自身也会被 visit（root 为 Document /
+// ShadowRoot 时从第一个子元素开始）。visit 返回值：
+//   - 'continue'（或 undefined）：继续遍历
+//   - 'skip-subtree'：跳过当前元素的整棵子树（含其 shadowRoot）
+//   - 'stop'：终止整个遍历（短路返回）
+
+export type WalkDecision = 'continue' | 'skip-subtree' | 'stop';
+
+export interface ShadowWalkOptions {
+  /**
+   * 已翻译单元（[data-pt="done"]）的子树是否跳过，默认 true。
+   * 需要收集「已翻译单元内部的嵌套已翻译单元」时传 false。
+   */
+  skipTranslated?: boolean;
+}
+
+export function walkShadowTree(
+  root: ParentNode,
+  visit: (el: Element) => WalkDecision | void,
+  opts: ShadowWalkOptions = {},
+): void {
+  const skipTranslated = opts.skipTranslated !== false;
+
+  const visitElement = (el: Element): WalkDecision => {
+    // 集中式跳过规则一：扩展自身 UI —— 整棵子树拒绝，不下沉 shadowRoot
+    if ((el as HTMLElement).dataset?.ptUi === '1') return 'skip-subtree';
+
+    const decision = visit(el);
+    if (decision === 'stop' || decision === 'skip-subtree') return decision;
+
+    // 集中式跳过规则二：已翻译标记 —— 元素已 visit，子树不再深入
+    if (skipTranslated && el.getAttribute('data-pt') === 'done') {
+      return 'skip-subtree';
+    }
+
+    // 递归下沉 shadowRoot（TreeWalker / querySelectorAll 都不穿透 shadow 边界）
+    if (el.shadowRoot && walk(el.shadowRoot) === 'stop') return 'stop';
+
+    // light DOM 子树
+    for (const child of el.children) {
+      const d = visitElement(child);
+      if (d === 'stop') return 'stop';
+      if (d === 'skip-subtree') continue;
+    }
+    return 'continue';
+  };
+
+  const walk = (scope: ParentNode): WalkDecision => {
+    // 根元素自身也走同一套 visit + 跳过规则；其子树由 visitElement 递归
+    if (scope.nodeType === Node.ELEMENT_NODE) {
+      return visitElement(scope as Element);
+    }
+    for (const child of scope.children) {
+      const d = visitElement(child);
+      if (d === 'stop') return 'stop';
+      if (d === 'skip-subtree') continue;
+    }
+    return 'continue';
+  };
+
+  walk(root);
+}


### PR DESCRIPTION
## 问题

Shadow-DOM 递归遍历在还原流程、已翻译判定、观察器三处各写一遍，终止条件互不相同——同一份遍历语义散落多处，修复一处漏一处（#179 修复需同步改四个文件）。

## 根因

没有共用的遍历原语，每个调用方自造递归并自定跳过规则。

## 修复

新增 `src/dom/shadow-walk.ts`：`walkShadowTree(root, visit)` 以 visit 回调式接口递归穿透 shadowRoot；集中式跳过规则（UI 自身子树 `[data-pt-ui=1]`、已翻译标记 `[data-pt=done]`）只此一处；visit 可返回 `skip-subtree` / `stop`。本票仅落地模块核心与单测，无生产调用方。

## 验证

- 新增单测 10 项：普通 DOM 先序、嵌套 shadow 递归、跳过规则命中与不命中、skip-subtree、stop（含 shadow 深处短路）
- shadow-walk.ts 覆盖率 100%；typecheck 通过；全量 477 项单测通过，覆盖率门槛达标