### PR TITLE
生命周期注册表核心 (fix #235)

### DIFF
--- a/docs/testing/unit/ui/lifecycle-registry.test.ts
+++ b/docs/testing/unit/ui/lifecycle-registry.test.ts
@@ -1,0 +1,134 @@
+/**
+ * ui/lifecycle-registry.ts — UI 生命周期注册表 单元测试（#235）
+ *
+ * 用假 create/stop 断言：启停成对、重复注册幂等、停止后不重复执行、
+ * ensure 设置变更钩子幂等、dispose 全量停止。
+ */
+import { describe, test, expect, vi } from 'vitest';
+import { createLifecycleRegistry } from '~/src/ui/lifecycle-registry';
+
+interface FakeCtx {
+  id: string;
+}
+
+function fakeLifecycle(id: string, log: string[]) {
+  return {
+    create: vi.fn((): FakeCtx => {
+      log.push(`create:${id}`);
+      return { id };
+    }),
+    stop: vi.fn((ctx: FakeCtx) => {
+      log.push(`stop:${ctx.id}`);
+    }),
+  };
+}
+
+describe('register — 启停成对', () => {
+  test('register 立即 create，返回的停止函数触发对应 stop', () => {
+    const log: string[] = [];
+    const lc = fakeLifecycle('ball', log);
+    const registry = createLifecycleRegistry();
+
+    const stop = registry.register('ball', lc);
+    expect(lc.create).toHaveBeenCalledTimes(1);
+    expect(registry.isRunning('ball')).toBe(true);
+
+    stop();
+    expect(log).toEqual(['create:ball', 'stop:ball']);
+    expect(registry.isRunning('ball')).toBe(false);
+    // 停止函数幂等：再次调用不重复执行 stop
+    stop();
+    expect(lc.stop).toHaveBeenCalledTimes(1);
+  });
+
+  test('unregister 停止并移除，未注册 id 为空操作', () => {
+    const log: string[] = [];
+    const lc = fakeLifecycle('ball', log);
+    const registry = createLifecycleRegistry();
+
+    registry.register('ball', lc);
+    registry.unregister('ball');
+    expect(log).toEqual(['create:ball', 'stop:ball']);
+    registry.unregister('ball'); // 空操作，不抛
+    expect(lc.stop).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('register — 重复注册幂等', () => {
+  test('同一 id 重复注册：旧实例先停止，同一时刻仅一个实例在跑', () => {
+    const log: string[] = [];
+    const lc1 = fakeLifecycle('a1', log);
+    const lc2 = fakeLifecycle('a2', log);
+    const registry = createLifecycleRegistry();
+
+    registry.register('ball', lc1);
+    expect(registry.isRunning('ball')).toBe(true);
+
+    registry.register('ball', lc2);
+    expect(log).toEqual(['create:a1', 'stop:a1', 'create:a2']);
+    expect(registry.isRunning('ball')).toBe(true);
+
+    // 旧实例不会被二次停止
+    registry.unregister('ball');
+    expect(log).toEqual(['create:a1', 'stop:a1', 'create:a2', 'stop:a2']);
+  });
+});
+
+describe('ensure — 设置变更驱动的启停钩子', () => {
+  test('ensure(true) 幂等：连续调用只 create 一次', () => {
+    const log: string[] = [];
+    const lc = fakeLifecycle('ball', log);
+    const registry = createLifecycleRegistry();
+    registry.register('ball', lc);
+
+    registry.ensure('ball', true);
+    registry.ensure('ball', true);
+    expect(lc.create).toHaveBeenCalledTimes(1); // 注册时一次，ensure 不再重复
+    expect(registry.isRunning('ball')).toBe(true);
+  });
+
+  test('ensure(false) 停止；再 ensure(true) 重新创建', () => {
+    const log: string[] = [];
+    const lc = fakeLifecycle('ball', log);
+    const registry = createLifecycleRegistry();
+    registry.register('ball', lc);
+
+    registry.ensure('ball', false);
+    expect(log).toEqual(['create:ball', 'stop:ball']);
+    expect(registry.isRunning('ball')).toBe(false);
+
+    // 停止后不重复执行：再 ensure(false) 不触发二次 stop
+    registry.ensure('ball', false);
+    expect(lc.stop).toHaveBeenCalledTimes(1);
+
+    // 重新启用 → 重新创建（启停成对）
+    registry.ensure('ball', true);
+    expect(log).toEqual(['create:ball', 'stop:ball', 'create:ball']);
+    expect(registry.isRunning('ball')).toBe(true);
+  });
+
+  test('未注册的 id：ensure 为空操作', () => {
+    const registry = createLifecycleRegistry();
+    registry.ensure('ghost', true);
+    registry.ensure('ghost', false);
+    expect(registry.isRunning('ghost')).toBe(false);
+  });
+});
+
+describe('dispose', () => {
+  test('停止全部实例并清空注册表', () => {
+    const log: string[] = [];
+    const registry = createLifecycleRegistry();
+    registry.register('ball', fakeLifecycle('ball', log));
+    registry.register('para-btn', fakeLifecycle('para-btn', log));
+
+    registry.dispose();
+    expect(log).toEqual(['create:ball', 'create:para-btn', 'stop:ball', 'stop:para-btn']);
+    expect(registry.isRunning('ball')).toBe(false);
+    expect(registry.isRunning('para-btn')).toBe(false);
+
+    // 清空后 ensure 不再复活
+    registry.ensure('ball', true);
+    expect(registry.isRunning('ball')).toBe(false);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/ui/lifecycle-registry.ts
+++ b/src/ui/lifecycle-registry.ts
@@ -1,0 +1,90 @@
+// UI 生命周期注册表 —— #224 架构评审候选 6 的核心（#235）。
+//
+// mount/unmount 样板在每个 UI 模块里重复，content 入口用五个 stop 变量
+// 手写生命周期，设置变更处把创建块整体重抄一遍 —— teardown 全靠自觉，
+// 没有任何一处兜底保证启停成对。本模块以 register(id, create, stop)
+// 收敛生命周期：
+//   - 启停成对：每个 create 恰对应一次 stop，stop 幂等、未启动为空操作
+//   - 重复注册幂等：同一 id 至多一个实例在跑，重注册先停止旧实例
+//   - 设置变更驱动的启停钩子 ensure(id, enabled)：开关即时生效
+
+export interface RegistryLifecycle<T> {
+  /** 创建实例，返回实例上下文（通常是该 UI 的停止函数）。 */
+  create: () => T;
+  /** 停止实例。与 create 严格成对，每个实例恰好停止一次。 */
+  stop: (ctx: T) => void;
+}
+
+export interface LifecycleRegistry {
+  /**
+   * 注册一个 UI 生命周期并立即创建实例。
+   * 重复注册同一 id：先停止旧实例再创建新实例（幂等）。
+   * 返回该注册的停止函数（停止并移除）。
+   */
+  register<T>(id: string, lifecycle: RegistryLifecycle<T>): () => void;
+  /**
+   * 设置变更驱动的启停钩子（幂等）：
+   * enabled 为 true 且未运行 → 启动；false 且运行中 → 停止。
+   * 未注册的 id 为空操作。
+   */
+  ensure(id: string, enabled: boolean): void;
+  /** 停止并移除指定 id。未注册 / 未启动为空操作。 */
+  unregister(id: string): void;
+  /** 当前是否运行中。 */
+  isRunning(id: string): boolean;
+  /** 停止全部实例并清空注册表。 */
+  dispose(): void;
+}
+
+export function createLifecycleRegistry(): LifecycleRegistry {
+  /** 声明（跨启停保留）。 */
+  const decls = new Map<string, RegistryLifecycle<unknown>>();
+  /** 运行中的实例上下文。 */
+  const instances = new Map<string, unknown>();
+
+  const stopInstance = (id: string): void => {
+    const ctx = instances.get(id);
+    if (ctx === undefined) return;
+    instances.delete(id);
+    decls.get(id)!.stop(ctx as never);
+  };
+
+  const registry: LifecycleRegistry = {
+    register<T>(id: string, lifecycle: RegistryLifecycle<T>): () => void {
+      // 重复注册幂等：旧实例先停止，同一 id 至多一个实例在跑
+      stopInstance(id);
+      decls.set(id, lifecycle as RegistryLifecycle<unknown>);
+      instances.set(id, lifecycle.create());
+      return () => registry.unregister(id);
+    },
+
+    ensure(id: string, enabled: boolean): void {
+      if (enabled) {
+        if (instances.has(id)) return; // 已在运行 —— 幂等
+        const decl = decls.get(id);
+        if (!decl) return; // 未注册 —— 空操作
+        instances.set(id, decl.create());
+      } else {
+        stopInstance(id);
+      }
+    },
+
+    unregister(id: string): void {
+      stopInstance(id);
+      decls.delete(id);
+    },
+
+    isRunning(id: string): boolean {
+      return instances.has(id);
+    },
+
+    dispose(): void {
+      for (const id of [...instances.keys()]) {
+        stopInstance(id);
+      }
+      decls.clear();
+    },
+  };
+
+  return registry;
+}


### PR DESCRIPTION
## 问题

mount/unmount 样板在每个 UI 模块里重复，content 入口用五个 stop 变量手写生命周期——teardown 全靠自觉，没有任何一处兜底保证启停成对。

## 根因

没有共用的生命周期原语，启停逻辑散落在各调用方。

## 修复

新增 `src/ui/lifecycle-registry.ts`：`register(id, create, stop)` 返回停止函数；启停成对（每个 create 恰对应一次 stop，stop 幂等）；重复注册幂等（旧实例先停止）；提供设置变更驱动的 `ensure(id, enabled)` 启停钩子。本票仅落地模块与单测，尚无生产调用方。

## 验证

- 新增 UI 单测目录（7 项用例）：假 create/stop 断言启停成对、重复注册幂等、停止后不重复执行、ensure 幂等、dispose 全量停止
- typecheck 通过；全量 479 项单测通过