### PR TITLE
gemini 产出类型化结果 (fix #236)

### DIFF
--- a/docs/testing/unit/engines/gemini-http.test.ts
+++ b/docs/testing/unit/engines/gemini-http.test.ts
@@ -56,7 +56,12 @@ describe('gemini HTTP 路径', () => {
     const { gemini } = await import('~/src/engines/gemini');
     await expect(
       gemini.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
-    ).rejects.toMatchObject({ engineId: 'gemini', retryable: false, message: '未配置 API key' });
+    ).rejects.toMatchObject({
+      engineId: 'gemini',
+      retryable: false,
+      category: 'invalid-key',
+      message: '未配置 API key',
+    });
     expect(getKey).toHaveBeenCalledWith('gemini');
   });
 
@@ -118,7 +123,32 @@ describe('gemini HTTP 路径', () => {
     const { gemini } = await import('~/src/engines/gemini');
     await expect(
       gemini.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
-    ).rejects.toMatchObject({ retryable: false, message: 'API key 无效' });
+    ).rejects.toMatchObject({ retryable: false, category: 'invalid-key', message: 'API key 无效' });
+  });
+
+  test('401 → invalid-key（#236 新增类别）', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('bad');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('err', { status: 401 })));
+    const { gemini } = await import('~/src/engines/gemini');
+    await expect(
+      gemini.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({ retryable: false, category: 'invalid-key', message: 'API key 无效' });
+  });
+
+  test('429 → quota + invalidated（#236 新增类别）', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('err', { status: 429 })));
+    const { gemini } = await import('~/src/engines/gemini');
+    await expect(
+      gemini.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({
+      retryable: false,
+      category: 'quota',
+      invalidated: true,
+      aborted: false,
+    });
   });
 
   test('400 带「API key not valid」错误体 → retryable=false，key 无效（#161）', async () => {
@@ -142,7 +172,7 @@ describe('gemini HTTP 路径', () => {
     const { gemini } = await import('~/src/engines/gemini');
     await expect(
       gemini.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
-    ).rejects.toMatchObject({ retryable: false, message: 'API key 无效' });
+    ).rejects.toMatchObject({ retryable: false, category: 'invalid-key', message: 'API key 无效' });
   });
 
   test('400 带「input too large」错误体 → retryable，交给下一引擎降级（#161）', async () => {
@@ -168,6 +198,7 @@ describe('gemini HTTP 路径', () => {
       gemini.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
     ).rejects.toMatchObject({
       retryable: true,
+      category: 'transient',
       message: /exceeds the maximum token limit/,
     });
   });
@@ -193,7 +224,7 @@ describe('gemini HTTP 路径', () => {
     const { gemini } = await import('~/src/engines/gemini');
     await expect(
       gemini.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
-    ).rejects.toMatchObject({ retryable: true, message: /is not found/ });
+    ).rejects.toMatchObject({ retryable: true, category: 'transient', message: /is not found/ });
   });
 
   test('其他非 200 → EngineError（retryable）', async () => {
@@ -203,7 +234,7 @@ describe('gemini HTTP 路径', () => {
     const { gemini } = await import('~/src/engines/gemini');
     await expect(
       gemini.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
-    ).rejects.toMatchObject({ retryable: true, message: 'HTTP 503' });
+    ).rejects.toMatchObject({ retryable: true, category: 'transient', message: 'HTTP 503' });
   });
 
   test('空 candidates → 长度一致的空白译文数组', async () => {

--- a/docs/testing/unit/runtime/messaging.test.ts
+++ b/docs/testing/unit/runtime/messaging.test.ts
@@ -192,9 +192,38 @@ describe('translateViaBackground — 失败语义', () => {
       invalidated: false,
       // #180: 未携带 retryable 的响应按可重试处理
       retryable: true,
+      // #236: 未携带类型化字段 → 按瞬时处理（旧路径兼容）
+      category: 'transient',
+      aborted: false,
     });
     // 1 ping + 1 translate，translate 没有重试
     expect(sendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  test('SW 响应携带类型化类别 → 原样透传（#236 新形态端到端）', async () => {
+    sendMessage.mockImplementation(async (msg: unknown) => {
+      const m = msg as { type?: string };
+      if (m.type === 'pt:ping') return { ok: true };
+      return {
+        ok: false,
+        error: 'API key 无效',
+        retryable: false,
+        category: 'invalid-key',
+        invalidated: false,
+        aborted: false,
+      };
+    });
+
+    const result = await translateViaBackground(PAYLOAD);
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'API key 无效',
+      retryable: false,
+      invalidated: false,
+      category: 'invalid-key',
+      aborted: false,
+    });
   });
 
   test('SW 始终无响应：ping 预算耗尽 → {ok:false}，不发送 translate', async () => {

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -122,6 +122,11 @@ export default defineBackground(() => {
             ok: false,
             error: e instanceof Error ? e.message : String(e),
             retryable: !nonRetryable,
+            // #236: 新形态端到端 —— 引擎产出的类型化字段原样透传，
+            // 扩张阶段与旧字段并存（旧字段清理在收尾票 #263）
+            category: e instanceof EngineError ? e.category : 'transient',
+            invalidated: e instanceof EngineError ? e.invalidated : false,
+            aborted: e instanceof EngineError ? e.aborted : false,
           });
         });
     } catch (e) {
@@ -130,6 +135,9 @@ export default defineBackground(() => {
         ok: false,
         error: e instanceof Error ? e.message : String(e),
         retryable: !nonRetryable,
+        category: e instanceof EngineError ? e.category : 'transient',
+        invalidated: e instanceof EngineError ? e.invalidated : false,
+        aborted: e instanceof EngineError ? e.aborted : false,
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/gemini.ts
+++ b/src/engines/gemini.ts
@@ -15,13 +15,18 @@ import type { TranslateEngine } from './types';
 const getGate = engineGate();
 
 /**
- * 按 Gemini 错误体区分错误类别 —— #161。
+ * 按 Gemini 错误响应区分失败类别 —— #161 / #236。
  *
  * Gemini 的 400 覆盖多种情况：key 无效、上下文过长（input too large）、
  * 内容被安全拦截；403 也不只来自 key。此前一律判「key 无效」且
  * retryable=false，router 直接抛错不尝试后续引擎，超长文本/模型名错误
- * 会让整页翻译失败。这里只对确凿的认证错误置 non-retryable，
- * 其余 400/404（超长、模型名、安全拦截）交给下一引擎降级。
+ * 会让整页翻译失败。这里只对确凿的认证错误置 invalid-key（不重试），
+ * 其余 400/404（超长、模型名、安全拦截）与 5xx 归为瞬时，交给下一
+ * 引擎降级或批次重试。
+ *
+ * 类别口径（#236）：401/403 → invalid-key；429 → quota；其余非 2xx
+ * → transient；错误体明示认证失败（#161 的 400 + API key 文案）仍按
+ * invalid-key 处理，现有单测行为保持。
  */
 async function classifyError(resp: Response): Promise<EngineError> {
   let status = '';
@@ -37,21 +42,27 @@ async function classifyError(resp: Response): Promise<EngineError> {
     // 非 JSON 错误体，按状态码兜底
   }
 
-  // 确凿的认证错误 → 立即提示用户，不浪费后续引擎
+  // 确凿的认证错误 → key 无效：立即提示用户，不浪费后续引擎与退避序列
   const isAuth =
+    resp.status === 401 ||
     resp.status === 403 ||
     status === 'UNAUTHENTICATED' ||
     status === 'PERMISSION_DENIED' ||
     /API key/i.test(message) ||
     /API_KEY_INVALID/i.test(message);
   if (isAuth) {
-    return new EngineError('gemini', false, 'API key 无效');
+    return new EngineError('gemini', false, 'API key 无效', 'invalid-key');
   }
 
-  // 其余错误（上下文过长 / 模型名错误 / 安全拦截等）→ retryable，
+  // 429 → 配额失效：不重试（批次层不再白等退避序列），提示配额问题
+  if (resp.status === 429) {
+    return new EngineError('gemini', false, '配额已用尽', 'quota', true);
+  }
+
+  // 其余错误（上下文过长 / 模型名错误 / 安全拦截 / 5xx 等）→ 瞬时，
   // router 降级到下一引擎，页面翻译不中断
   const detail = message ? `：${message}` : '';
-  return new EngineError('gemini', true, `HTTP ${resp.status}${detail}`);
+  return new EngineError('gemini', true, `HTTP ${resp.status}${detail}`, 'transient');
 }
 
 export const gemini: TranslateEngine = {
@@ -64,7 +75,8 @@ export const gemini: TranslateEngine = {
     // #159: 整个请求体过闸门，限制并发在飞请求数
     return getGate()(async () => {
       const key = await getKey('gemini');
-      if (!key) throw new EngineError('gemini', false, '未配置 API key');
+      if (!key)
+        throw new EngineError('gemini', false, '未配置 API key', 'invalid-key');
 
       const model = getSettings().models?.gemini ?? DEFAULT_MODELS.gemini!;
       // key 走 x-goog-api-key 请求头而非 ?key= query。

--- a/src/runtime/messaging.ts
+++ b/src/runtime/messaging.ts
@@ -17,7 +17,11 @@
 // 3. SW 已响应的 {ok:false} 是引擎级失败（router 已做过引擎降级），不重试
 // 4. 预算耗尽返回 {ok:false} + 错误说明，永不抛出 —— 调用方按原约定处理
 
-import type { TranslateRequest, TranslateResponse } from '~/src/engines/types';
+import type {
+  TranslateRequest,
+  TranslateResponse,
+  FailureCategory,
+} from '~/src/engines/types';
 import { sleep } from '~/src/runtime/sleep';
 
 export type TranslateResult =
@@ -28,6 +32,10 @@ export type TranslateResult =
       invalidated: boolean;
       /** #180: 引擎不可恢复错误（key 无效等）—— 批次重试层不重试。 */
       retryable: boolean;
+      /** #236: 类型化失败类别（新字段，扩张阶段与旧字段并存）。 */
+      category: FailureCategory;
+      /** #236: 已中止（新字段）。 */
+      aborted: boolean;
     };
 
 /** SW 就绪等待预算（ping 阶段）。覆盖 CI 中 SW 冷启动的常见耗时。 */
@@ -167,6 +175,9 @@ export async function translateViaBackground(
       data?: TranslateResponse;
       error?: string;
       retryable?: boolean;
+      category?: FailureCategory;
+      invalidated?: boolean;
+      aborted?: boolean;
     };
 
     if (resp?.ok === true && resp.data) {
@@ -175,8 +186,11 @@ export async function translateViaBackground(
     return {
       ok: false,
       error: resp?.error ?? '未知错误',
-      invalidated: false,
+      invalidated: resp?.invalidated ?? false,
       retryable: resp?.retryable ?? true,
+      // #236: 类型化字段原样透传，缺省按瞬时处理（旧路径兼容）
+      category: resp?.category ?? 'transient',
+      aborted: resp?.aborted ?? false,
     };
   } catch (e) {
     // #116: 上下文失效以类型化标志透出，调用方无需匹配文案
@@ -185,6 +199,8 @@ export async function translateViaBackground(
       error: e instanceof Error ? e.message : String(e),
       invalidated: e instanceof ContextInvalidatedError,
       retryable: true,
+      category: 'transient',
+      aborted: false,
     };
   }
 }


### PR DESCRIPTION
## 问题

gemini 的错误只有 retryable 布尔——401 落到「其余错误」被当作瞬时故障白等退避序列，429 也没有配额语义，失败类别无处表达。

## 根因

#232 的类型化结果已落地，但 gemini 适配器尚未按类别产出。

## 修复

`classifyError` 按类别产出 EngineError：401/403（及错误体明示认证失败，#161 行为保持）→ invalid-key；429 → quota + invalidated；其余非 2xx → transient；旧字段兼容。background 两处 catch 与 messaging 原样透传新字段（category / invalidated / aborted），缺省按瞬时处理——新形态第一条端到端路径打通。

## 验证

- 新增 401 → invalid-key、429 → quota 用例；既有 gemini HTTP 用例补类别断言
- messaging 新增类型化透传用例（含旧路径兼容）
- typecheck 与全量 489 项单测通过