### PR TITLE
聚合失败显式分类 (fix #237)

### DIFF
--- a/docs/testing/unit/engines/router.test.ts
+++ b/docs/testing/unit/engines/router.test.ts
@@ -80,7 +80,7 @@ vi.mock('~/src/engines/gemini', () => ({
 import { route } from '~/src/engines/router';
 import { getSettings } from '~/src/storage/settings';
 import { cacheGet, cacheSet } from '~/src/storage/cache';
-import { EngineError } from '~/src/engines/types';
+import { EngineError, AllEnginesFailedError } from '~/src/engines/types';
 
 describe('route', () => {
   beforeEach(() => {
@@ -222,6 +222,57 @@ describe('route', () => {
         to: 'zh-CN',
       }),
     ).rejects.toThrow(/所有引擎均失败/);
+  });
+
+  test('全部引擎失败 → 显式类型化结果：瞬时、可重试（#237）', async () => {
+    mockGoogleTranslate.mockRejectedValue(new Error('Google fail'));
+    mockBingTranslate.mockRejectedValue(new Error('Bing fail'));
+
+    try {
+      await route({
+        texts: ['Hello'],
+        from: 'auto',
+        to: 'zh-CN',
+      });
+      expect.unreachable('应抛出 AllEnginesFailedError');
+    } catch (e) {
+      const err = e as AllEnginesFailedError;
+      expect(e).toBeInstanceOf(AllEnginesFailedError);
+      expect(e).toBeInstanceOf(EngineError);
+      expect(err.category).toBe('transient');
+      expect(err.retryable).toBe(true);
+      expect(err.invalidated).toBe(false);
+      expect(err.aborted).toBe(false);
+      // 携带各引擎原始失败
+      expect(err.engineErrors.map((x) => x.engineId)).toEqual([
+        'google-web',
+        'bing-edge',
+      ]);
+    }
+  });
+
+  test('单引擎 non-retryable 失败 → 原样抛出不改写类别（#237）', async () => {
+    vi.mocked(getSettings).mockReturnValue({
+      ...vi.mocked(getSettings)(),
+      enginePriority: ['openai', 'google-web'],
+    });
+
+    const { openai } = await import('~/src/engines/openai');
+    vi.mocked(openai.translate).mockRejectedValue(
+      new EngineError('openai', false, 'API key 无效', 'invalid-key'),
+    );
+    mockGoogleTranslate.mockResolvedValue({ translations: ['你好'] });
+
+    try {
+      await route({ texts: ['Hello'], from: 'auto', to: 'zh-CN' });
+      expect.unreachable('应抛出 EngineError');
+    } catch (e) {
+      expect(e).toBeInstanceOf(EngineError);
+      expect((e as EngineError).category).toBe('invalid-key');
+      expect((e as EngineError).retryable).toBe(false);
+      // non-retryable 不尝试后续引擎
+      expect(mockGoogleTranslate).not.toHaveBeenCalled();
+    }
   });
 
   test('useCache=false → 跳过缓存查询', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/router.ts
+++ b/src/engines/router.ts
@@ -10,7 +10,7 @@ import { bingEdge } from './bing-edge';
 import { openai } from './openai';
 import { deepl } from './deepl';
 import { gemini } from './gemini';
-import { EngineError } from './types';
+import { EngineError, AllEnginesFailedError } from './types';
 import type { TranslateEngine, TranslateRequest, TranslateResponse } from './types';
 
 const REGISTRY: Record<string, TranslateEngine> = {
@@ -161,7 +161,10 @@ export async function route(req: TranslateRequest): Promise<TranslateResponse> {
     }
   }
 
-  throw new Error(
-    `所有引擎均失败: ${errors.map((e) => `${e.engineId}(${e.message})`).join(', ')}`,
+  // #237: 聚合失败显式构造类型化结果（瞬时、可重试）—— 不再抛裸普通
+  // Error，消除「普通 Error 即隐式可重试」的启发式
+  throw new AllEnginesFailedError(
+    errors.map((e) => `${e.engineId}(${e.message})`).join(', '),
+    errors,
   );
 }

--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -83,3 +83,20 @@ export class EngineError extends Error implements AttemptOutcome {
     this.name = 'EngineError';
   }
 }
+
+/**
+ * router 的「所有引擎均失败」聚合错误 —— #237。
+ * 显式构造类型化结果（瞬时、可重试），不再抛裸普通 Error ——
+ * 消除「普通 Error 即隐式可重试」的启发式：聚合失败的可重试性
+ * 由这里显式声明，各消费层无需再自行推断。
+ */
+export class AllEnginesFailedError extends EngineError {
+  /** 各引擎的原始失败（调试与透传用）。 */
+  public readonly engineErrors: readonly EngineError[];
+
+  constructor(detail: string, engineErrors: readonly EngineError[] = []) {
+    super('router', true, `所有引擎均失败: ${detail}`, 'transient');
+    this.name = 'AllEnginesFailedError';
+    this.engineErrors = engineErrors;
+  }
+}


### PR DESCRIPTION
## 问题

router 的「所有引擎均失败」抛普通 Error，消费层只能靠「普通 Error 即隐式可重试」的启发式推断——语义不显式。

## 根因

聚合失败没有走类型化结果（#232），类别与可重试性未显式声明。

## 修复

新增 `AllEnginesFailedError`（extends EngineError）：显式构造瞬时 + 可重试的类型化结果，并携带各引擎原始失败；router 全失败路径改抛该类型，消息格式与现状一致。

## 验证

- 路由单测新增 2 项：全失败路径的类别 / 可重试性 / 引擎错误列表断言；单引擎 non-retryable 原样抛出不改写类别
- 既有 12 项路由单测全绿；typecheck 与全量 491 项单测通过