### PR TITLE
延迟 attachShadow 补丁入模块 (fix #238)

### DIFF
--- a/docs/testing/unit/dom/shadow-walk.test.ts
+++ b/docs/testing/unit/dom/shadow-walk.test.ts
@@ -1,11 +1,13 @@
 /**
- * dom/shadow-walk.ts — 统一 shadow 子树遍历模块 单元测试（#233）
+ * dom/shadow-walk.ts — 统一 shadow 子树遍历模块 单元测试（#233 / #238）
  *
  * 覆盖：普通 DOM 先序遍历、嵌套 shadow 递归、集中式跳过规则
- * （UI 自身子树 / 已翻译标记）命中与不命中、skip-subtree 与 stop 决策。
+ * （UI 自身子树 / 已翻译标记）命中与不命中、skip-subtree 与 stop 决策；
+ * 延迟 attachShadow 补丁（#238）：补丁与遍历同处本模块、共享已见集合，
+ * 动态建 shadow root 的宿主能被遍历命中且不重复通知。
  */
 import { describe, test, expect, beforeEach } from 'vitest';
-import { walkShadowTree } from '~/src/dom/shadow-walk';
+import { walkShadowTree, watchShadowRoots } from '~/src/dom/shadow-walk';
 
 function seenIds(root: ParentNode = document.body): string[] {
   const seen: string[] = [];
@@ -131,5 +133,90 @@ describe('walkShadowTree — visit 决策', () => {
       if (el.id) seen.push(el.id);
     });
     expect(seen).toEqual(['h1']);
+  });
+});
+
+describe('延迟 attachShadow 补丁（#238）', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('补丁后动态 attachShadow 的宿主被遍历命中', () => {
+    const host = document.createElement('div');
+    host.id = 'late-host';
+    document.body.appendChild(host);
+    // host 已入 DOM 后才建 shadow root —— 遍历仍能发现
+    const root = host.attachShadow({ mode: 'open' });
+    root.innerHTML = '<p id="late-content">late shadow content</p>';
+
+    expect(seenIds()).toEqual(['late-host', 'late-content']);
+  });
+
+  test('watchShadowRoots：动态创建的 root 被同步通知，且不重复', () => {
+    const seen = new WeakSet<ShadowRoot>();
+    const notified: string[] = [];
+    const unwatch = watchShadowRoots({
+      seen,
+      onShadowRoot: (root) => notified.push(root.host.id),
+    });
+    try {
+      const h1 = document.createElement('div');
+      h1.id = 'h1';
+      document.body.appendChild(h1);
+      h1.attachShadow({ mode: 'open' });
+
+      const h2 = document.createElement('div');
+      h2.id = 'h2';
+      document.body.appendChild(h2);
+      h2.attachShadow({ mode: 'open' });
+
+      // 每个新 root 各通知一次
+      expect(notified).toEqual(['h1', 'h2']);
+    } finally {
+      unwatch();
+    }
+  });
+
+  test('已见集合共享：注册前创建的 root 不再通知（防重复挂载）', () => {
+    const h1 = document.createElement('div');
+    h1.id = 'h1';
+    document.body.appendChild(h1);
+    const existing = h1.attachShadow({ mode: 'open' });
+
+    const seen = new WeakSet<ShadowRoot>();
+    const notified: string[] = [];
+    const unwatch = watchShadowRoots({
+      seen,
+      onShadowRoot: (root) => notified.push(root.host.id),
+    });
+    try {
+      // 注册前已存在的 root：seen 未含它，但不再有创建事件 —— 不通知
+      expect(notified).toEqual([]);
+      // 新创建的 root 正常通知
+      const h2 = document.createElement('div');
+      h2.id = 'h2';
+      document.body.appendChild(h2);
+      h2.attachShadow({ mode: 'open' });
+      expect(notified).toEqual(['h2']);
+    } finally {
+      unwatch();
+    }
+  });
+
+  test('取消注册后不再收到通知', () => {
+    const seen = new WeakSet<ShadowRoot>();
+    const notified: string[] = [];
+    const unwatch = watchShadowRoots({
+      seen,
+      onShadowRoot: (root) => notified.push(root.host.id),
+    });
+    unwatch();
+
+    const h1 = document.createElement('div');
+    h1.id = 'h1';
+    document.body.appendChild(h1);
+    h1.attachShadow({ mode: 'open' });
+
+    expect(notified).toEqual([]);
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/observer.ts
+++ b/src/dom/observer.ts
@@ -20,43 +20,29 @@
 import { collect } from './walker';
 import { unrender } from './renderer';
 import { injectShadowStyles } from '~/src/styles/shadow';
+import { watchShadowRoots } from './shadow-walk';
 
 // #179: 延迟 attachShadow 漏翻 —— host 已入 DOM 后才建 shadow root 的
 // 组件（属性级操作，childList 捕不到、MutationObserver 不产生记录）。
-// 补丁 Element.prototype.attachShadow：创建 shadow root 时同步通知所有
-// 活跃 observer 挂载，shadow 内容不再永久漏翻。
-interface ObserverContext {
-  onMutationRecord: (records: MutationRecord[]) => void;
-  observedRoots: WeakSet<ShadowRoot>;
-  observers: MutationObserver[];
-}
-const observerContexts = new Set<ObserverContext>();
+// attachShadow 补丁与遍历共享状态，由统一遍历模块持有（#238）——
+// 观察器只注册消费方，创建 shadow root 时同步挂载 observer，
+// shadow 内容不再永久漏翻。
 
-const nativeAttachShadow = Element.prototype.attachShadow;
-if (
-  !(Element.prototype as unknown as { __ptShadowPatched?: boolean })
-    .__ptShadowPatched
-) {
-  (Element.prototype as unknown as { __ptShadowPatched: boolean })
-    .__ptShadowPatched = true;
-  Element.prototype.attachShadow = function (
-    this: Element,
-    init?: ShadowRootInit,
-  ): ShadowRoot {
-    // 原生实现允许省略 init，类型声明要求必填 —— 运行时原样透传
-    const root = nativeAttachShadow.call(this, init as ShadowRootInit);
-    for (const ctx of observerContexts) {
-      if (ctx.observedRoots.has(root)) continue;
-      ctx.observedRoots.add(root);
-      // 同步挂载：shadow 内容通常在 attachShadow 之后立即填充，
-      // 后续 childList 记录会被新 observer 捕获
-      injectShadowStyles(root);
-      const mo = new MutationObserver(ctx.onMutationRecord);
-      mo.observe(root, { childList: true, subtree: true });
-      ctx.observers.push(mo);
-    }
-    return root;
-  };
+/** 新增 shadowRoot 的挂载动作：注入样式 + 挂 MutationObserver（#163/#238）。 */
+function mountShadowRoot(
+  root: ShadowRoot,
+  seen: WeakSet<ShadowRoot>,
+  onMutation: (records: MutationRecord[]) => void,
+  observers: MutationObserver[],
+): void {
+  if (seen.has(root)) return;
+  seen.add(root);
+  // 同步挂载：shadow 内容通常在 attachShadow 之后立即填充，
+  // 后续 childList 记录会被新 observer 捕获
+  injectShadowStyles(root);
+  const mo = new MutationObserver(onMutation);
+  mo.observe(root, { childList: true, subtree: true });
+  observers.push(mo);
 }
 
 /**
@@ -73,13 +59,7 @@ function observeShadowRoots(
 
   const attach = (el: Element): boolean => {
     if (!el.shadowRoot || seen.has(el.shadowRoot)) return false;
-    seen.add(el.shadowRoot);
-    // #163: 扩展样式不跨 shadow 边界 —— 先注入样式再挂 observer，
-    // 避免注入动作触发自身 mutation 记录
-    injectShadowStyles(el.shadowRoot);
-    const mo = new MutationObserver(onMutation);
-    mo.observe(el.shadowRoot, { childList: true, subtree: true });
-    observers.push(mo);
+    mountShadowRoot(el.shadowRoot, seen, onMutation, observers);
     return true;
   };
 
@@ -267,16 +247,21 @@ export function startObserver(
   const initial = observeShadowRoots(document.body, onMutationRecord, observedRoots);
   observers.push(...initial);
 
-  // #179: 注册到 attachShadow 补丁的通知集合 —— 延迟建 shadow root 的
-  // 组件也能被增量补翻
-  const ctx: ObserverContext = { onMutationRecord, observedRoots, observers };
-  observerContexts.add(ctx);
+  // #179: 注册到 attachShadow 补丁的通知集合（#238：补丁在统一遍历
+  // 模块持有，这里只注册消费方）—— 延迟建 shadow root 的组件也能
+  // 被增量补翻
+  const unwatch = watchShadowRoots({
+    seen: observedRoots,
+    onShadowRoot: (root) => {
+      mountShadowRoot(root, observedRoots, onMutationRecord, observers);
+    },
+  });
 
   // #23：启动 IntersectionObserver，监听初次采集时因 display:none 被跳过的元素
   startWatching(onNewNodes);
 
   return () => {
-    observerContexts.delete(ctx);
+    unwatch();
     for (const mo of observers) mo.disconnect();
     if (timer) clearTimeout(timer);
     if (io) {

--- a/src/dom/shadow-walk.ts
+++ b/src/dom/shadow-walk.ts
@@ -70,3 +70,54 @@ export function walkShadowTree(
 
   walk(root);
 }
+
+// ── 延迟 attachShadow 补丁（#238）──
+//
+// host 已入 DOM 后才建 shadow root 的组件（属性级操作，childList 捕不到、
+// MutationObserver 不产生记录）此前由观察器自行补丁监听。补丁与遍历
+// 同处本模块，共享已见集合等状态：shadowRoot 创建时同步通知已注册的
+// 消费方（观察器等），补丁后遍历能发现后建的 shadowRoot，且已见过的
+// root 不会重复通知。
+
+/** shadowRoot 创建通知的消费方（观察器等需同步挂载的上下文）。 */
+export interface ShadowRootSink {
+  /** 已见集合 —— 与遍历共享：已见过的 root 不再重复通知。 */
+  seen: WeakSet<ShadowRoot>;
+  /** root 创建时同步回调（shadow 内容通常在 attachShadow 之后立即填充）。 */
+  onShadowRoot: (root: ShadowRoot) => void;
+}
+
+const sinks = new Set<ShadowRootSink>();
+
+/**
+ * 注册 shadowRoot 创建通知（attachShadow 补丁驱动）。
+ * 返回取消注册函数。
+ */
+export function watchShadowRoots(sink: ShadowRootSink): () => void {
+  sinks.add(sink);
+  return () => {
+    sinks.delete(sink);
+  };
+}
+
+const nativeAttachShadow = Element.prototype.attachShadow;
+if (
+  !(Element.prototype as unknown as { __ptShadowPatched?: boolean })
+    .__ptShadowPatched
+) {
+  (Element.prototype as unknown as { __ptShadowPatched: boolean })
+    .__ptShadowPatched = true;
+  Element.prototype.attachShadow = function (
+    this: Element,
+    init?: ShadowRootInit,
+  ): ShadowRoot {
+    // 原生实现允许省略 init，类型声明要求必填 —— 运行时原样透传
+    const root = nativeAttachShadow.call(this, init as ShadowRootInit);
+    for (const sink of sinks) {
+      if (sink.seen.has(root)) continue;
+      sink.seen.add(root);
+      sink.onShadowRoot(root);
+    }
+    return root;
+  };
+}


### PR DESCRIPTION
## 问题

延迟 attachShadow 的补丁代码在观察器里自维护，与统一遍历模块（#233）各持一份状态——补丁与遍历的语义开始分叉。

## 根因

补丁与遍历不在同一模块，共享已见集合等状态无处安放。

## 修复

补丁移入 `src/dom/shadow-walk.ts`（与遍历同处一模块），新增 `watchShadowRoots` 消费方注册：shadowRoot 创建时同步通知，已见集合（WeakSet）与遍历共享、同一 root 不重复通知；观察器删除自维护补丁改为注册消费方，挂载行为不变（注入样式 + 挂 MutationObserver）。

## 验证

- 新增 4 项用例：动态 attachShadow 宿主被遍历命中、同步通知且不重复、已见集合共享、取消注册后不再通知
- 观察器既有单测与 typecheck 通过；全量 491 项单测通过