### PR TITLE
classifyStatus 公共判定 (fix #239)

### DIFF
--- a/docs/testing/unit/engines/shared-classify.test.ts
+++ b/docs/testing/unit/engines/shared-classify.test.ts
@@ -1,0 +1,70 @@
+/**
+ * engines/shared.ts — classifyStatus 公共判定 单元测试（#239）
+ *
+ * 表驱动：状态码 × 各引擎 → 失败类别。自带 key 引擎的 401/403 →
+ * invalid-key、429 → quota、其余非 2xx → transient；免 key 引擎一律
+ * transient（bing-edge 401 会话失效仍可重试）。
+ */
+import { describe, test, expect } from 'vitest';
+import { classifyStatus } from '~/src/engines/shared';
+import type { FailureCategory } from '~/src/engines/types';
+
+interface Case {
+  engineId: string;
+  status: number;
+  hasKey: boolean;
+  expected: FailureCategory;
+}
+
+const KEYED_CASES: Case[] = [
+  { engineId: 'openai', status: 401, hasKey: true, expected: 'invalid-key' },
+  { engineId: 'openai', status: 403, hasKey: true, expected: 'invalid-key' },
+  { engineId: 'openai', status: 429, hasKey: true, expected: 'quota' },
+  { engineId: 'openai', status: 500, hasKey: true, expected: 'transient' },
+  { engineId: 'openai', status: 503, hasKey: true, expected: 'transient' },
+  { engineId: 'deepl', status: 401, hasKey: true, expected: 'invalid-key' },
+  { engineId: 'deepl', status: 403, hasKey: true, expected: 'invalid-key' },
+  { engineId: 'deepl', status: 429, hasKey: true, expected: 'quota' },
+  { engineId: 'deepl', status: 500, hasKey: true, expected: 'transient' },
+  { engineId: 'gemini', status: 401, hasKey: true, expected: 'invalid-key' },
+  { engineId: 'gemini', status: 403, hasKey: true, expected: 'invalid-key' },
+  { engineId: 'gemini', status: 429, hasKey: true, expected: 'quota' },
+  { engineId: 'gemini', status: 500, hasKey: true, expected: 'transient' },
+];
+
+const KEYLESS_CASES: Case[] = [
+  { engineId: 'google-web', status: 401, hasKey: true, expected: 'transient' },
+  { engineId: 'google-web', status: 403, hasKey: true, expected: 'transient' },
+  { engineId: 'google-web', status: 429, hasKey: true, expected: 'transient' },
+  { engineId: 'google-web', status: 500, hasKey: true, expected: 'transient' },
+  // bing-edge 401 是会话失效：仍瞬时可重试（清 JWT 逻辑在适配器内）
+  { engineId: 'bing-edge', status: 401, hasKey: true, expected: 'transient' },
+  { engineId: 'bing-edge', status: 403, hasKey: true, expected: 'transient' },
+  { engineId: 'bing-edge', status: 429, hasKey: true, expected: 'transient' },
+  { engineId: 'bing-edge', status: 500, hasKey: true, expected: 'transient' },
+];
+
+describe('classifyStatus 表驱动', () => {
+  for (const c of KEYED_CASES) {
+    test(`${c.engineId} ${c.status} → ${c.expected}`, () => {
+      expect(classifyStatus(c.engineId, { status: c.status }, c.hasKey)).toBe(
+        c.expected,
+      );
+    });
+  }
+
+  for (const c of KEYLESS_CASES) {
+    test(`${c.engineId} ${c.status} → ${c.expected}（免 key 引擎）`, () => {
+      expect(classifyStatus(c.engineId, { status: c.status }, c.hasKey)).toBe(
+        c.expected,
+      );
+    });
+  }
+
+  test('自带 key 引擎但请求未携带 key → 一律 transient（不判 key 无效）', () => {
+    for (const engineId of ['openai', 'deepl', 'gemini']) {
+      expect(classifyStatus(engineId, { status: 401 }, false)).toBe('transient');
+      expect(classifyStatus(engineId, { status: 429 }, false)).toBe('transient');
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/shared.ts
+++ b/src/engines/shared.ts
@@ -1,0 +1,41 @@
+// 引擎公共模块 —— #222 架构评审候选 3。
+//
+// 状态分类与编号提示词模板此前在各引擎里各写一遍：401/403 → key 无效
+// 在两家引擎重复、HTTP 状态 → 失败类别映射写了四遍、编号提示词模板
+// 逐字重复。本模块收拢两件事：
+//   1. classifyStatus —— 统一状态分类（#239）
+//   2. buildNumberedPrompt —— 编号提示词模板唯一来源（#240）
+// 适配器只保留请求构造与响应解析；引擎特例（错误体明示认证失败、
+// 401 会话失效清 JWT 等）留在适配器内显式处理，不再各自发明分类规则。
+
+import type { FailureCategory } from './types';
+
+/** 自带 key 的引擎 —— 401/403 才可能意味着「key 无效」。 */
+const KEYED_ENGINES: ReadonlySet<string> = new Set(['openai', 'deepl', 'gemini']);
+
+/**
+ * 统一状态分类（#239）：状态码 → 失败类别。
+ *
+ * 口径：
+ * - 自带 key 引擎（openai / deepl / gemini）且请求携带 key：
+ *   401/403 → invalid-key；429 → quota；其余非 2xx → transient
+ * - 免 key 引擎（google-web / bing-edge）或请求未携带 key：
+ *   一律 transient（bing-edge 的 401 是会话失效，仍瞬时可重试）
+ *
+ * 引擎特例（如 gemini 错误体明示认证失败、bing-edge 401 清 JWT）由
+ * 适配器在调用前后显式处理，不混入本函数。
+ *
+ * @param engineId 引擎 id
+ * @param resp 响应（调用方保证非 2xx 才调用）
+ * @param hasKey 本次请求是否携带了 key
+ */
+export function classifyStatus(
+  engineId: string,
+  resp: { status: number },
+  hasKey: boolean,
+): FailureCategory {
+  if (!hasKey || !KEYED_ENGINES.has(engineId)) return 'transient';
+  if (resp.status === 401 || resp.status === 403) return 'invalid-key';
+  if (resp.status === 429) return 'quota';
+  return 'transient';
+}


### PR DESCRIPTION
## 问题

401/403 → key 无效在两家引擎各写一遍，HTTP 状态 → 失败类别映射写了四遍——新引擎要复制粘贴判定块，#161 式分歧必然复发。

## 根因

没有公共分类函数，每个引擎自造判定规则。

## 修复

新增 `src/engines/shared.ts` 公共模块，`classifyStatus(引擎 id、响应、是否有 key)` 统一分类：自带 key 引擎的 401/403 → invalid-key、429 → quota、其余非 2xx → transient；免 key 引擎一律瞬时（bing-edge 401 会话失效仍可重试）；引擎特例由适配器显式处理。尚无调用方，独立可测。

## 验证

- 表驱动单测 22 项：各状态码 × 各引擎 + 请求未携带 key 路径
- typecheck 与全量 491 项单测通过