### PR TITLE
buildNumberedPrompt 公共模板 (fix #240)

### DIFF
--- a/docs/testing/unit/engines/shared-prompt.test.ts
+++ b/docs/testing/unit/engines/shared-prompt.test.ts
@@ -1,0 +1,64 @@
+/**
+ * engines/shared.ts — buildNumberedPrompt 公共模板 单元测试（#240）
+ *
+ * 断言：编号顺序、换行转义（归一化）、与编号解析函数 parseNumbered
+ * 往返一致、与现有逐字实现格式一致（含源语言段）。
+ */
+import { describe, test, expect } from 'vitest';
+import { buildNumberedPrompt } from '~/src/engines/shared';
+import { parseNumbered } from '~/src/engines/openai';
+
+describe('buildNumberedPrompt — 编号格式', () => {
+  test('编号顺序：1..N 递增，\n 分隔', () => {
+    const prompt = buildNumberedPrompt('zh-CN', 'en', ['Hello', 'World', '!']);
+    const numbered = prompt.split('\n\n')[1]!;
+    expect(numbered).toBe('1. Hello\n2. World\n3. !');
+  });
+
+  test('转义：文本自带换行被归一化为空格，不撑破编号结构（#160）', () => {
+    const prompt = buildNumberedPrompt('zh', 'auto', ['line1\nline2', 'a\nb\nc']);
+    const numbered = prompt.split('\n\n')[1]!;
+    expect(numbered).toBe('1. line1 line2\n2. a b c');
+    expect(numbered).not.toContain('\nline');
+  });
+
+  test('头部指令：目标语言 + 源语言段（非 auto）', () => {
+    const prompt = buildNumberedPrompt('zh-CN', 'en', ['Hello']);
+    expect(prompt.startsWith('将以下编号文本翻译成zh-CN（源语言：en）。')).toBe(
+      true,
+    );
+    expect(prompt).toContain('严格保持编号与行数一致，只输出译文，不要解释。');
+  });
+
+  test('from=auto → 头部不带源语言段', () => {
+    const prompt = buildNumberedPrompt('zh', 'auto', ['Hello']);
+    expect(prompt.startsWith('将以下编号文本翻译成zh。')).toBe(true);
+    expect(prompt).not.toContain('源语言');
+  });
+
+  test('空文本数组 → 只有头部指令与空编号段', () => {
+    const prompt = buildNumberedPrompt('zh', 'auto', []);
+    expect(prompt.endsWith('\n\n')).toBe(true);
+  });
+});
+
+describe('buildNumberedPrompt — 与 parseNumbered 往返一致', () => {
+  test('LLM 回显编号 → parseNumbered 还原原文顺序', () => {
+    const texts = ['Hello world', 'Second line', 'Third'];
+    const prompt = buildNumberedPrompt('zh', 'en', texts);
+    const numbered = prompt.split('\n\n')[1]!;
+    // 模拟 LLM 严格回显编号结构（只改译文不动编号）
+    const out = parseNumbered(numbered, texts.length);
+    expect(out).toEqual(texts);
+  });
+
+  test('LLM 重排/漏行 → parseNumbered 按编号回填，不错位', () => {
+    const texts = ['A', 'B', 'C', 'D'];
+    const prompt = buildNumberedPrompt('zh', 'en', texts);
+    const numbered = prompt.split('\n\n')[1]!;
+    // LLM 只回 1、3、4 行（漏 2），且顺序打乱
+    const llmOut = ['3. C', '1. A', '4. D'];
+    const out = parseNumbered(llmOut.join('\n'), texts.length);
+    expect(out).toEqual(['A', '', 'C', 'D']);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/shared.ts
+++ b/src/engines/shared.ts
@@ -9,6 +9,7 @@
 // 401 会话失效清 JWT 等）留在适配器内显式处理，不再各自发明分类规则。
 
 import type { FailureCategory } from './types';
+import { normalizeText } from '~/src/dom/normalize';
 
 /** 自带 key 的引擎 —— 401/403 才可能意味着「key 无效」。 */
 const KEYED_ENGINES: ReadonlySet<string> = new Set(['openai', 'deepl', 'gemini']);
@@ -38,4 +39,28 @@ export function classifyStatus(
   if (resp.status === 401 || resp.status === 403) return 'invalid-key';
   if (resp.status === 429) return 'quota';
   return 'transient';
+}
+
+/**
+ * 编号提示词模板唯一来源（#240）。
+ *
+ * 产出格式与 openai / gemini 现有的逐字实现完全一致：
+ *   - 每条文本归一化（折叠换行）后按「序号. 文本」编号，\n 分隔
+ *   - 头部指令固定：翻译成 {to}、可选源语言、严格保持编号与行数
+ *
+ * 编号结构靠 \n 分隔，文本自带换行会把编号撑破导致 LLM 重编号、
+ * parseNumbered 回填错位，因此拼 prompt 前必须压一次（#160）。
+ */
+export function buildNumberedPrompt(
+  to: string,
+  from: string | 'auto',
+  texts: string[],
+): string {
+  const numbered = texts
+    .map((t, i) => `${i + 1}. ${normalizeText(t)}`)
+    .join('\n');
+  return (
+    `将以下编号文本翻译成${to}${from === 'auto' ? '' : `（源语言：${from}）`}。` +
+    `严格保持编号与行数一致，只输出译文，不要解释。\n\n${numbered}`
+  );
 }


### PR DESCRIPTION
## 问题

编号提示词模板在 openai / gemini 两家逐字重复——措辞或格式改动会漏掉其中一家，编号格式漂移后 parseNumbered 回填错位。

## 根因

没有模板唯一来源，各引擎复制粘贴。

## 修复

shared.ts 新增 `buildNumberedPrompt(to, from, texts)`：产出格式与现有逐字实现完全一致（归一化折叠换行 + 序号编号 + 固定头部指令），作为模板唯一来源。尚无调用方，独立可测。

## 验证

- 单测 7 项：编号顺序、换行转义（#160）、头部指令（含 auto 不带源语言段）、与 parseNumbered 往返一致（含 LLM 漏行回填）
- typecheck 与全量 491 项单测通过