### PR TITLE
段落按钮迁移注册表 (fix #243)

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -62,9 +62,8 @@ export default defineContentScript({
     let stopObserving: (() => void) | null = null;
     let stopHotkeys: (() => void) | null = null;
     let stopDrag: (() => void) | null = null;
-    let stopParaBtn: (() => void) | null = null;
 
-    // #242: UI 生命周期注册表 —— 悬浮球等经注册表启停，
+    // #242/#243: UI 生命周期注册表 —— 悬浮球、段落按钮等经注册表启停，
     // 设置变更由 ensure() 驱动，启停成对、重复注册幂等
     const registry = createLifecycleRegistry();
 
@@ -84,12 +83,16 @@ export default defineContentScript({
       });
       registry.ensure('ball', s.showFloatingBall);
 
-      if (s.showParagraphBtn) {
-        stopParaBtn = createParaBtn({
-          translate: (el) => translateOne(el),
-          restore: (el) => unrender(el),
-        });
-      }
+      // #243: 段落按钮经注册表启停；showParagraphBtn 决定是否启动
+      registry.register('para-btn', {
+        create: () =>
+          createParaBtn({
+            translate: (el) => translateOne(el),
+            restore: (el) => unrender(el),
+          }),
+        stop: (stopParaBtn) => stopParaBtn(),
+      });
+      registry.ensure('para-btn', s.showParagraphBtn);
     }
 
     // ── 快捷键（仅主文档，避免与 iframe 内输入冲突）──
@@ -133,16 +136,8 @@ export default defineContentScript({
         // #242: 悬浮球开关经注册表 ensure —— 启停幂等、即时生效
         registry.ensure('ball', ns.showFloatingBall);
 
-        // 段落按钮开关
-        if (ns.showParagraphBtn && !stopParaBtn) {
-          stopParaBtn = createParaBtn({
-          translate: (el) => translateOne(el),
-          restore: (el) => unrender(el),
-        });
-        } else if (!ns.showParagraphBtn && stopParaBtn) {
-          stopParaBtn();
-          stopParaBtn = null;
-        }
+        // #243: 段落按钮开关经注册表 ensure —— 启停幂等、即时生效
+        registry.ensure('para-btn', ns.showParagraphBtn);
       }
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## 问题

段落按钮用 stopParaBtn 变量手写生命周期，设置变更处把创建块整体重抄一遍（初始化块 vs 变更块两份）。

## 根因

没有走生命周期注册表（#235），启停逻辑散落在 content 入口。

## 修复

段落按钮改为 `registry.register('para-btn', { create, stop })` 声明 + `registry.ensure('para-btn', showParagraphBtn)` 驱动；初始化与设置变更共用同一创建路径，stopParaBtn 变量与重复创建块删除；悬停出现、点击翻译/还原行为不变，设置变更开关即时生效。

## 验证

- typecheck、全量 527 项单测、pnpm build 通过
- 逐段翻译 e2e 场景由 CI e2e-core 回归（TC 全绿）