### PR TITLE
划词拖拽迁移注册表 (fix #244)

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -61,7 +61,6 @@ export default defineContentScript({
 
     let stopObserving: (() => void) | null = null;
     let stopHotkeys: (() => void) | null = null;
-    let stopDrag: (() => void) | null = null;
 
     // #242/#243: UI 生命周期注册表 —— 悬浮球、段落按钮等经注册表启停，
     // 设置变更由 ensure() 驱动，启停成对、重复注册幂等
@@ -124,7 +123,12 @@ export default defineContentScript({
     }
 
     // ── 划词拖动 ──
-    stopDrag = startSelectionDrag((text) => translateSelection(text));
+    // #244: 划词拖拽经注册表启停（无设置开关，恒启用）
+    registry.register('drag', {
+      create: () => startSelectionDrag((text) => translateSelection(text)),
+      stop: (stopDrag) => stopDrag(),
+    });
+    registry.ensure('drag', true);
 
     // ── 设置变更监听 ──
     onSettingsChanged((ns: Settings) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## 问题

划词拖拽的启停由 content 入口直接调用 startSelectionDrag，不经过生命周期注册表——启停不成对、无兜底，与悬浮球/段落按钮的迁移（#242/#243）不一致。

## 根因

没有走生命周期注册表（#235）。

## 修复

划词拖拽改为 `registry.register('drag', { create, stop })` 声明 + `registry.ensure('drag', true)` 启动（无设置开关，恒启用）；stopDrag 变量删除；拖拽选择与翻译行为不变。

## 验证

- typecheck、全量 535 项单测、pnpm build 通过
- 划词 e2e 场景由 CI e2e-core 回归（TC 全绿）