### PR TITLE
编排模块骨架与批次拆分 (fix #245)

### DIFF
--- a/docs/testing/unit/orchestration/orchestrator.test.ts
+++ b/docs/testing/unit/orchestration/orchestrator.test.ts
@@ -1,0 +1,91 @@
+/**
+ * orchestration/orchestrator.ts — 翻译编排模块骨架 单元测试（#245）
+ *
+ * 假消息层断言：批次拆分与现状一致（每批 ≤ FULL_PAGE_BATCH_SIZE、
+ * 余数进最后一批）、发送回调次数 = 批次数、单测不触碰 chrome。
+ */
+import { describe, test, expect, vi } from 'vitest';
+import {
+  createOrchestrator,
+  splitBatches,
+  FULL_PAGE_BATCH_SIZE,
+} from '~/src/orchestration/orchestrator';
+import type { TranslateItem } from '~/src/orchestration/orchestrator';
+import type { TranslateRequest } from '~/src/engines/types';
+
+function items(n: number): TranslateItem<number>[] {
+  return Array.from({ length: n }, (_, i) => ({ text: `text-${i}`, ctx: i }));
+}
+
+describe('splitBatches — 批次拆分', () => {
+  test('恰好一批：数量 ≤ 批次大小', () => {
+    const batches = splitBatches(items(10), FULL_PAGE_BATCH_SIZE);
+    expect(batches).toHaveLength(1);
+    expect(batches[0]!.map((b) => b.text)).toEqual(
+      Array.from({ length: 10 }, (_, i) => `text-${i}`),
+    );
+  });
+
+  test('40 项 → 3 批（15/15/10）：前 N-1 批满额，余数进最后一批', () => {
+    const batches = splitBatches(items(40), FULL_PAGE_BATCH_SIZE);
+    expect(batches.map((b) => b.length)).toEqual([15, 15, 10]);
+  });
+
+  test('批次顺序与文本顺序一致', () => {
+    const batches = splitBatches(items(31), FULL_PAGE_BATCH_SIZE);
+    const all = batches.flatMap((b) => b.map((x) => x.text));
+    expect(all).toEqual(Array.from({ length: 31 }, (_, i) => `text-${i}`));
+  });
+
+  test('空数组 → 0 批', () => {
+    expect(splitBatches([], FULL_PAGE_BATCH_SIZE)).toEqual([]);
+  });
+});
+
+describe('createOrchestrator — 假消息层', () => {
+  test('translatePage：发送回调次数 = 批次数，每批文本正确', async () => {
+    const send = vi.fn(async (_req: TranslateRequest) => ({ ok: true, data: { translations: [] } }));
+    const orch = createOrchestrator({ send });
+    orch.start();
+
+    await orch.translatePage(items(40), 'en', 'zh-CN');
+
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(send.mock.calls[0]![0]).toEqual({
+      texts: Array.from({ length: 15 }, (_, i) => `text-${i}`),
+      from: 'en',
+      to: 'zh-CN',
+    });
+    expect(send.mock.calls[2]![0]!.texts).toHaveLength(10);
+    expect(send.mock.calls[2]![0]!.texts[9]).toBe('text-39');
+  });
+
+  test('自定义 batchSize 生效', async () => {
+    const send = vi.fn(async (_req: TranslateRequest) => ({ ok: true, data: { translations: [] } }));
+    const orch = createOrchestrator({ send, batchSize: 7 });
+    orch.start();
+
+    await orch.translatePage(items(16), 'auto', 'zh');
+    expect(send.mock.calls.map((c) => c[0]!.texts.length)).toEqual([7, 7, 2]);
+  });
+
+  test('未启动 → 翻译入口抛错', async () => {
+    const send = vi.fn(async (_req: TranslateRequest) => ({ ok: true, data: { translations: [] } }));
+    const orch = createOrchestrator({ send });
+    await expect(orch.translatePage(items(1), 'en', 'zh')).rejects.toThrow(
+      '未启动',
+    );
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  test('stop 后翻译入口不再发送', async () => {
+    const send = vi.fn(async (_req: TranslateRequest) => ({ ok: true, data: { translations: [] } }));
+    const orch = createOrchestrator({ send });
+    orch.start();
+    orch.stop();
+    await expect(orch.translatePage(items(1), 'en', 'zh')).rejects.toThrow(
+      '未启动',
+    );
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/orchestration/orchestrator.ts
+++ b/src/orchestration/orchestrator.ts
@@ -1,0 +1,90 @@
+// 翻译编排模块 —— #221 架构评审候选 1（#245 骨架与批次拆分）。
+//
+// content 入口（约 585 行）一个闭包同时承担：翻译编排（批次拆分、
+// epoch 中止、渐进渲染）、UI 生命周期、消息路由 —— 编排逻辑完全
+// 没有单元测试，e2e 之外无法触达。本模块把编排收在小 interface
+// 后面（启动 / 停止 / 翻译入口），消息发送以回调注入，不直接触碰
+// chrome 全局，测试用假消息层即可断言批次拆分与回调次数。
+//
+// 本票落地骨架与批次拆分（#245）；渐进渲染回调注入与 epoch 中止
+// 语义由后续票承接（#256 / #262），尚无生产调用方。
+
+import type { TranslateRequest } from '~/src/engines/types';
+
+/** 全页翻译的批次大小 —— 与 content 现有 FULL_PAGE_BATCH_SIZE 一致（#25）。 */
+export const FULL_PAGE_BATCH_SIZE = 15;
+
+/** 翻译项：文本 + 调用方携带的渲染/还原上下文（#245 保持与现状同构）。 */
+export interface TranslateItem<TCtx> {
+  text: string;
+  ctx: TCtx;
+}
+
+/** 消息发送回调 —— 注入假消息层即可单测，模块不直接触碰 chrome。 */
+export type SendTranslate = (req: TranslateRequest) => Promise<unknown>;
+
+/** 翻译编排模块 —— 小 interface：启动 / 停止 / 翻译入口（#221）。 */
+export interface TranslationOrchestrator {
+  /** 启动编排（后续承接设置变更响应等初始化）。 */
+  start(): void;
+  /** 停止编排（清理订阅与在飞状态）。 */
+  stop(): void;
+  /** 全页翻译入口：按批次拆分发送，每批返回即渲染（渐进渲染见 #256）。 */
+  translatePage(
+    items: TranslateItem<unknown>[],
+    from: string,
+    to: string,
+  ): Promise<void>;
+}
+
+export interface OrchestratorOptions {
+  /** 消息发送层（测试注入假层）。 */
+  send: SendTranslate;
+  /** 批次大小，缺省与现状一致（15）。 */
+  batchSize?: number;
+}
+
+/**
+ * 按批次大小切分翻译项（#245）。
+ * 与 content 现有切片逻辑一致：前 N-1 批满额，最后一批为余数。
+ */
+export function splitBatches<T>(
+  items: TranslateItem<T>[],
+  size: number,
+): TranslateItem<T>[][] {
+  const batches: TranslateItem<T>[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    batches.push(items.slice(i, i + size));
+  }
+  return batches;
+}
+
+export function createOrchestrator(opts: OrchestratorOptions): TranslationOrchestrator {
+  const batchSize = opts.batchSize ?? FULL_PAGE_BATCH_SIZE;
+  let started = false;
+
+  return {
+    start(): void {
+      started = true;
+    },
+
+    stop(): void {
+      started = false;
+    },
+
+    async translatePage(items, from, to): Promise<void> {
+      if (!started) throw new Error('[PT] 编排未启动');
+      // 批次拆分（#245）：与现状一致，每批独立发送
+      const batches = splitBatches(items, batchSize);
+      await Promise.all(
+        batches.map((batch) =>
+          opts.send({
+            texts: batch.map((item) => item.text),
+            from,
+            to,
+          }),
+        ),
+      );
+    },
+  };
+}


### PR DESCRIPTION
## 问题

content 入口一个闭包同时承担翻译编排（批次拆分、epoch 中止、渐进渲染）、UI 生命周期、消息路由——编排逻辑完全无单元测试，e2e 之外无法触达。

## 根因

编排逻辑没有独立模块，混在 585 行入口里。

## 修复

新增 `src/orchestration/orchestrator.ts`：小 interface（启动 / 停止 / 翻译入口 translatePage），消息发送以回调注入（不触碰 chrome 全局）；批次拆分迁入（splitBatches，批次大小与现状 FULL_PAGE_BATCH_SIZE = 15 一致）。本票仅落地骨架与拆分，尚无生产调用方；渐进渲染与 epoch 中止由 #256/#262 承接。

## 验证

- 单测 8 项（假消息层）：批次拆分（满额/余数/顺序/空）、发送回调次数 = 批次数、自定义 batchSize、未启动/停止后拒绝发送
- typecheck 与全量 535 项单测通过