### PR TITLE
批次重试层读新字段 (fix #246)

### DIFF
--- a/docs/testing/unit/runtime/batch-retry.test.ts
+++ b/docs/testing/unit/runtime/batch-retry.test.ts
@@ -182,3 +182,89 @@ describe('attemptBatchWithRetry — 中止（还原 / 全局短路）', () => {
     expect(send).toHaveBeenCalledTimes(BATCH_RETRY_LIMIT + 1);
   });
 });
+
+describe('attemptBatchWithRetry — 新字段优先（#246）', () => {
+  test('category=invalid-key（新字段）→ 立即失败，0 次重试', async () => {
+    const send = vi.fn(async () => ({
+      ok: false,
+      error: 'API key 无效',
+      retryable: false,
+      category: 'invalid-key' as const,
+      invalidated: false,
+      aborted: false,
+    }));
+    const result = await attemptBatchWithRetry(send, { sleep: noopSleep });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('API key 无效');
+      expect(result.invalidated).toBe(false);
+      expect(result.aborted).toBe(false);
+    }
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  test('category=quota（新字段）→ 立即失败，0 次重试', async () => {
+    const send = vi.fn(async () => ({
+      ok: false,
+      error: '配额已用尽',
+      retryable: false,
+      category: 'quota' as const,
+      invalidated: true,
+      aborted: false,
+    }));
+    const result = await attemptBatchWithRetry(send, { sleep: noopSleep });
+
+    expect(result.ok).toBe(false);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  test('aborted=true（新字段）→ 立即停止，报 aborted 不记失败', async () => {
+    const send = vi.fn(async () => ({
+      ok: false,
+      error: '已中止',
+      retryable: true,
+      category: 'transient' as const,
+      invalidated: false,
+      aborted: true,
+    }));
+    const result = await attemptBatchWithRetry(send, { sleep: noopSleep });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.aborted).toBe(true);
+      expect(result.invalidated).toBe(false);
+    }
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  test('category=transient（新字段）→ 照常进入重试序列', async () => {
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        error: '瞬时故障',
+        retryable: true,
+        category: 'transient' as const,
+        invalidated: false,
+        aborted: false,
+      })
+      .mockResolvedValueOnce({ ok: true, data: TRANSLATED });
+    const result = await attemptBatchWithRetry(send, { sleep: noopSleep });
+
+    expect(result.ok).toBe(true);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  test('旧字段路径兼容：仅 retryable=false（无 category）→ 立即失败', async () => {
+    const send = vi.fn(async () => ({
+      ok: false,
+      error: 'API key 无效',
+      retryable: false,
+    }));
+    const result = await attemptBatchWithRetry(send, { sleep: noopSleep });
+
+    expect(result.ok).toBe(false);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.16",
+  "version": "2.0.17",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/runtime/batch-retry.ts
+++ b/src/runtime/batch-retry.ts
@@ -14,7 +14,7 @@
 // #116：失效判定用 messaging 透出的类型化 invalidated 标志，
 // 不匹配错误文案 —— 文案改写不影响短路行为。
 
-import type { TranslateResponse } from '~/src/engines/types';
+import type { TranslateResponse, FailureCategory } from '~/src/engines/types';
 import { sleep as defaultSleep } from '~/src/runtime/sleep';
 
 /** #91: 批次级引擎失败最大重试次数。 */
@@ -55,6 +55,10 @@ export async function attemptBatchWithRetry(
     invalidated?: boolean;
     /** #180: 引擎不可恢复错误（key 无效等）—— 不重试。 */
     retryable?: boolean;
+    /** #236/#246: 类型化失败类别（新字段，存在时优先于 retryable）。 */
+    category?: FailureCategory;
+    /** #236/#246: 已中止（新字段）。 */
+    aborted?: boolean;
   }>,
   opts: BatchRetryOptions = {},
 ): Promise<BatchRetryResult> {
@@ -76,9 +80,17 @@ export async function attemptBatchWithRetry(
     if (resp?.invalidated) {
       return { ok: false, invalidated: true, aborted: false, error: lastError };
     }
-    // #180: 不可恢复错误（key 无效等）重试只会白等退避序列后仍失败 ——
-    // 立即返回，错误 toast 马上出现
-    if (resp?.retryable === false) {
+    // #246: 新字段 aborted（用户中止）→ 立即停止，不记成失败
+    if (resp?.aborted) {
+      return { ok: false, invalidated: false, aborted: true, error: lastError };
+    }
+    // #246: 新字段类别优先 —— invalid-key / quota 不可恢复，立即失败；
+    // 旧字段 retryable=false 在兼容期同样生效（#180）
+    if (
+      resp?.category === 'invalid-key' ||
+      resp?.category === 'quota' ||
+      resp?.retryable === false
+    ) {
       return { ok: false, invalidated: false, aborted: false, error: lastError };
     }
     if (attempt >= BATCH_RETRY_LIMIT) break;


### PR DESCRIPTION
## 问题

批次重试层只认 retryable 布尔，类型化结果（#236 已透传的 category / aborted）不消费——key 无效仍按旧路径走，中止语义无处表达。

## 根因

batch-retry 的 send 结果类型没有新字段，判定逻辑未更新。

## 修复

send 结果类型扩展 `category` / `aborted`（新字段）；重试判定改为新字段优先——invalid-key / quota 立即失败不进入退避序列、aborted 立即停止不记失败、transient 照常重试；旧字段 invalidated / retryable=false 在兼容期继续生效。

## 验证

- 新增 5 项用例：invalid-key / quota / aborted / transient / 旧字段仅 retryable=false 兼容路径
- 既有 11 项批次重试单测全绿；typecheck 与全量 532 项单测通过