### PR TITLE
渲染分支消费新结果 (fix #247)

### DIFF
--- a/docs/testing/unit/runtime/batch-retry.test.ts
+++ b/docs/testing/unit/runtime/batch-retry.test.ts
@@ -268,3 +268,41 @@ describe('attemptBatchWithRetry — 新字段优先（#246）', () => {
     expect(send).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('BatchRetryResult 类别透传（#247）', () => {
+  test('invalid-key 失败 → 结果携带 category，供渲染层分支提示', async () => {
+    const send = vi.fn(async () => ({
+      ok: false,
+      error: 'API key 无效',
+      retryable: false,
+      category: 'invalid-key' as const,
+      invalidated: false,
+      aborted: false,
+    }));
+    const result = await attemptBatchWithRetry(send, { sleep: noopSleep });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.category).toBe('invalid-key');
+      expect(result.error).toBe('API key 无效');
+    }
+  });
+
+  test('quota 失败 → 结果携带 category（invalidated 短路分支）', async () => {
+    const send = vi.fn(async () => ({
+      ok: false,
+      error: '配额已用尽',
+      retryable: false,
+      category: 'quota' as const,
+      invalidated: true,
+      aborted: false,
+    }));
+    const result = await attemptBatchWithRetry(send, { sleep: noopSleep });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.invalidated).toBe(true);
+      expect(result.category).toBe('quota');
+    }
+  });
+});

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -263,6 +263,14 @@ export default defineContentScript({
             invalidated = true;
             fatalError = result.error;
           }
+          // #247: 按类型化类别给出提示分支 —— key 无效 / 配额失效
+          // 记录为致命原因（全失败时展示真实原因），不再落到泛化文案
+          if (
+            result.category === 'invalid-key' ||
+            result.category === 'quota'
+          ) {
+            fatalError = result.error;
+          }
           if (!result.aborted) {
             console.error('[PT] 批次翻译失败:', result.error);
           }
@@ -514,7 +522,13 @@ export default defineContentScript({
       });
 
       if (!resp?.ok) {
-        toast(tf('toastTranslateFail', '翻译失败'), 'error');
+        // #247: 按类型化类别给出提示分支 —— key 无效 / 配额失效展示
+        // 真实原因；瞬时故障保持现有泛化文案
+        if (resp.category === 'invalid-key' || resp.category === 'quota') {
+          toast(resp.error, 'error');
+        } else {
+          toast(tf('toastTranslateFail', '翻译失败'), 'error');
+        }
         return;
       }
 
@@ -551,7 +565,13 @@ export default defineContentScript({
       });
 
       if (!resp?.ok) {
-        toast(tf('toastTranslateFail', '翻译失败'), 'error');
+        // #247: 按类型化类别给出提示分支 —— key 无效 / 配额失效展示
+        // 真实原因；瞬时故障保持现有泛化文案
+        if (resp.category === 'invalid-key' || resp.category === 'quota') {
+          toast(resp.error, 'error');
+        } else {
+          toast(tf('toastTranslateFail', '翻译失败'), 'error');
+        }
         return;
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/runtime/batch-retry.ts
+++ b/src/runtime/batch-retry.ts
@@ -31,6 +31,8 @@ export type BatchRetryResult =
       /** 中止（还原 / 其他批次已判失效）—— 未完成。 */
       aborted: boolean;
       error: string;
+      /** #247: 类型化失败类别（供渲染层按类别分支提示）。 */
+      category?: FailureCategory;
     };
 
 export interface BatchRetryOptions {
@@ -78,7 +80,13 @@ export async function attemptBatchWithRetry(
     lastError = resp?.error ?? '未知错误';
     // #111/#116: 上下文失效是类型化标志 —— 立即失败，不进入重试序列
     if (resp?.invalidated) {
-      return { ok: false, invalidated: true, aborted: false, error: lastError };
+      return {
+        ok: false,
+        invalidated: true,
+        aborted: false,
+        error: lastError,
+        category: resp.category,
+      };
     }
     // #246: 新字段 aborted（用户中止）→ 立即停止，不记成失败
     if (resp?.aborted) {
@@ -91,7 +99,13 @@ export async function attemptBatchWithRetry(
       resp?.category === 'quota' ||
       resp?.retryable === false
     ) {
-      return { ok: false, invalidated: false, aborted: false, error: lastError };
+      return {
+        ok: false,
+        invalidated: false,
+        aborted: false,
+        error: lastError,
+        category: resp.category,
+      };
     }
     if (attempt >= BATCH_RETRY_LIMIT) break;
     await sleep(BATCH_RETRY_DELAYS_MS[attempt]!);


### PR DESCRIPTION
## 问题

渲染层不消费类型化结果——key 无效/配额失效时整页翻译落到「所有引擎均失败」泛化文案，单段/划词翻译落到「翻译失败」，用户看不到真实原因。

## 根因

batch-retry 的结果未透传类别，渲染分支无从按类别提示。

## 修复

`BatchRetryResult` 增加 `category` 字段并透传（invalidated 短路与不可重试分支）；渲染层按类别分支——整页批次 key 无效/配额记入 fatalError（全失败时展示真实原因），单段/划词翻译对 key 无效/配额展示错误原文案，瞬时故障保持现有泛化文案与行为。

## 验证

- 新增类别透传用例 2 项（invalid-key / quota 分支）
- 既有批次重试单测全绿；typecheck 与全量 542 项单测、pnpm build 通过