### PR TITLE
openai 迁移类型化结果 (fix #248)

### DIFF
--- a/docs/testing/unit/engines/openai-http.test.ts
+++ b/docs/testing/unit/engines/openai-http.test.ts
@@ -56,7 +56,12 @@ describe('openai HTTP 路径', () => {
     const { openai } = await import('~/src/engines/openai');
     await expect(
       openai.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
-    ).rejects.toMatchObject({ engineId: 'openai', retryable: false, message: '未配置 API key' });
+    ).rejects.toMatchObject({
+      engineId: 'openai',
+      retryable: false,
+      category: 'invalid-key',
+      message: '未配置 API key',
+    });
     expect(getKey).toHaveBeenCalledWith('openai');
   });
 
@@ -108,18 +113,18 @@ describe('openai HTTP 路径', () => {
       const { openai } = await import('~/src/engines/openai');
       await expect(
         openai.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
-      ).rejects.toMatchObject({ retryable: false, message: 'API key 无效' });
+      ).rejects.toMatchObject({ retryable: false, category: 'invalid-key', message: 'API key 无效' });
     }
   });
 
-  test('其他非 200 → EngineError（retryable）', async () => {
+  test('其他非 200 → EngineError（retryable，transient）', async () => {
     const { getKey } = await import('~/src/storage/keys');
     vi.mocked(getKey).mockResolvedValue('k');
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('err', { status: 429 })));
     const { openai } = await import('~/src/engines/openai');
     await expect(
       openai.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
-    ).rejects.toMatchObject({ retryable: true, message: 'HTTP 429' });
+    ).rejects.toMatchObject({ retryable: true, category: 'transient', message: 'HTTP 429' });
   });
 
   test('空 choices → 长度一致的空白译文数组', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/openai.ts
+++ b/src/engines/openai.ts
@@ -40,7 +40,8 @@ export const openai: TranslateEngine = {
     // #159: 整个请求体过闸门，限制并发在飞请求数
     return getGate()(async () => {
       const key = await getKey('openai');
-      if (!key) throw new EngineError('openai', false, '未配置 API key');
+      if (!key)
+        throw new EngineError('openai', false, '未配置 API key', 'invalid-key');
 
       const model = getSettings().models?.openai ?? DEFAULT_MODELS.openai!;
 
@@ -66,11 +67,13 @@ export const openai: TranslateEngine = {
         }),
       });
 
+      // #248: 类型化类别 —— 401/403 → key 无效（不重试）；其余非 2xx
+      // → 瞬时（可重试，路由降级下一引擎）
       if (resp.status === 401 || resp.status === 403) {
-        throw new EngineError('openai', false, 'API key 无效');
+        throw new EngineError('openai', false, 'API key 无效', 'invalid-key');
       }
       if (!resp.ok) {
-        throw new EngineError('openai', true, `HTTP ${resp.status}`);
+        throw new EngineError('openai', true, `HTTP ${resp.status}`, 'transient');
       }
 
       const data = await resp.json();


### PR DESCRIPTION
## 问题

openai 适配器错误只有 retryable 布尔，401/403 的 key 无效类别无处表达，与 gemini（#236）的迁移不一致。

## 根因

适配器未按 #232 的类型化结果产出类别。

## 修复

openai 各错误分支产出类型化 EngineError——401/403 → invalid-key（不重试）、其余非 2xx → transient（可重试降级下一引擎）、未配置 key → invalid-key；旧字段兼容，调用方不破坏。

## 验证

- openai HTTP 单测补类别断言（401/403 → invalid-key、429 → transient）
- typecheck 与全量 540 项单测通过