### PR TITLE
deepl 迁移类型化结果 (fix #249)

### DIFF
--- a/docs/testing/unit/engines/deepl-http.test.ts
+++ b/docs/testing/unit/engines/deepl-http.test.ts
@@ -61,7 +61,12 @@ describe('deepl HTTP 路径', () => {
     const { deepl } = await import('~/src/engines/deepl');
     await expect(
       deepl.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
-    ).rejects.toMatchObject({ engineId: 'deepl', retryable: false, message: '未配置 API key' });
+    ).rejects.toMatchObject({
+      engineId: 'deepl',
+      retryable: false,
+      category: 'invalid-key',
+      message: '未配置 API key',
+    });
     expect(getKey).toHaveBeenCalledWith('deepl');
   });
 
@@ -142,8 +147,23 @@ describe('deepl HTTP 路径', () => {
       const { deepl } = await import('~/src/engines/deepl');
       await expect(
         deepl.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
-      ).rejects.toMatchObject({ retryable: false, message: 'API key 无效' });
+      ).rejects.toMatchObject({ retryable: false, category: 'invalid-key', message: 'API key 无效' });
     }
+  });
+
+  test('429 → quota + invalidated（#249 新增类别）', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('err', { status: 429 })));
+    const { deepl } = await import('~/src/engines/deepl');
+    await expect(
+      deepl.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({
+      retryable: false,
+      category: 'quota',
+      invalidated: true,
+      aborted: false,
+    });
   });
 
   test('其他非 200 → EngineError（retryable）', async () => {
@@ -153,7 +173,7 @@ describe('deepl HTTP 路径', () => {
     const { deepl } = await import('~/src/engines/deepl');
     await expect(
       deepl.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
-    ).rejects.toMatchObject({ retryable: true, message: 'HTTP 456' });
+    ).rejects.toMatchObject({ retryable: true, category: 'transient', message: 'HTTP 456' });
   });
 
   test('坏 JSON → 抛错', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/deepl.ts
+++ b/src/engines/deepl.ts
@@ -65,7 +65,8 @@ export const deepl: TranslateEngine = {
     // #159: 整个请求体过闸门，限制并发在飞请求数
     return getGate()(async () => {
       const key = await getKey('deepl');
-      if (!key) throw new EngineError('deepl', false, '未配置 API key');
+      if (!key)
+        throw new EngineError('deepl', false, '未配置 API key', 'invalid-key');
 
       const endpoint = endpointFor(key);
 
@@ -95,11 +96,16 @@ export const deepl: TranslateEngine = {
         body: body.toString(),
       });
 
+      // #249: 类型化类别 —— 401/403 → key 无效；429 → 配额（免费额度
+      // 耗尽，不重试）；其余非 2xx → 瞬时（可重试，降级下一引擎）
       if (resp.status === 403 || resp.status === 401) {
-        throw new EngineError('deepl', false, 'API key 无效');
+        throw new EngineError('deepl', false, 'API key 无效', 'invalid-key');
+      }
+      if (resp.status === 429) {
+        throw new EngineError('deepl', false, '配额已用尽', 'quota', true);
       }
       if (!resp.ok) {
-        throw new EngineError('deepl', true, `HTTP ${resp.status}`);
+        throw new EngineError('deepl', true, `HTTP ${resp.status}`, 'transient');
       }
 
       const data = await resp.json();


### PR DESCRIPTION
## 问题

deepl 适配器错误只有 retryable 布尔，429（免费额度耗尽）的配额语义无处表达，与 gemini（#236）的迁移不一致。

## 根因

适配器未按 #232 的类型化结果产出类别。

## 修复

deepl 各错误分支产出类型化 EngineError——401/403 → invalid-key（不重试）、429 → quota + invalidated（不重试，提示配额）、其余非 2xx → transient（可重试降级下一引擎）、未配置 key → invalid-key；旧字段兼容。

## 验证

- deepl HTTP 单测补类别断言（401/403 → invalid-key、429 → quota、456 → transient），新增 429 配额用例
- typecheck 与全量 540 项单测通过