### PR TITLE
bing-edge 迁移类型化结果 (fix #250)

### DIFF
--- a/docs/testing/unit/engines/bing-edge-http.test.ts
+++ b/docs/testing/unit/engines/bing-edge-http.test.ts
@@ -205,7 +205,7 @@ describe('bing-edge HTTP 路径', () => {
     const { bingEdge } = await import('~/src/engines/bing-edge');
     await expect(
       bingEdge.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
-    ).rejects.toMatchObject({ retryable: true, message: 'HTTP 401' });
+    ).rejects.toMatchObject({ retryable: true, category: 'transient', message: 'HTTP 401' });
     const resp = await bingEdge.translate({ texts: ['a'], from: 'auto', to: 'zh' });
     expect(resp.translations).toEqual(['你好']);
 
@@ -225,7 +225,7 @@ describe('bing-edge HTTP 路径', () => {
     const { bingEdge } = await import('~/src/engines/bing-edge');
     await expect(
       bingEdge.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
-    ).rejects.toMatchObject({ name: 'EngineError', retryable: true, message: 'HTTP 401' });
+    ).rejects.toMatchObject({ name: 'EngineError', retryable: true, category: 'transient', message: 'HTTP 401' });
     // 缓存已清 → 第二次翻译重新取 auth
     const resp = await bingEdge.translate({ texts: ['a'], from: 'auto', to: 'zh' });
     expect(resp.translations).toEqual(['你好']);
@@ -239,7 +239,12 @@ describe('bing-edge HTTP 路径', () => {
     const { bingEdge } = await import('~/src/engines/bing-edge');
     await expect(
       bingEdge.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
-    ).rejects.toMatchObject({ engineId: 'bing-edge', retryable: true, message: 'auth HTTP 500' });
+    ).rejects.toMatchObject({
+      engineId: 'bing-edge',
+      retryable: true,
+      category: 'transient',
+      message: 'auth HTTP 500',
+    });
   });
 
   test('翻译非 200 → EngineError（retryable）', async () => {
@@ -252,7 +257,7 @@ describe('bing-edge HTTP 路径', () => {
     const { bingEdge } = await import('~/src/engines/bing-edge');
     await expect(
       bingEdge.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
-    ).rejects.toMatchObject({ retryable: true, message: 'HTTP 429' });
+    ).rejects.toMatchObject({ retryable: true, category: 'transient', message: 'HTTP 429' });
   });
 
   test('坏 JSON → 抛错', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/bing-edge.ts
+++ b/src/engines/bing-edge.ts
@@ -36,7 +36,8 @@ async function getJwt(): Promise<string> {
     jwtPromise = (async () => {
       const resp = await fetchWithTimeout('bing-edge', AUTH_ENDPOINT);
       if (!resp.ok) {
-        throw new EngineError('bing-edge', true, `auth HTTP ${resp.status}`);
+        // #250: 类型化类别 —— 免 key 引擎一律瞬时（可重试）
+        throw new EngineError('bing-edge', true, `auth HTTP ${resp.status}`, 'transient');
       }
       cachedJwt = await resp.text(); // 返回纯文本 JWT，非 JSON
       return cachedJwt!;
@@ -79,8 +80,10 @@ export const bingEdge: TranslateEngine = {
       });
 
       if (!resp.ok) {
+        // #250: 401 会话失效仍判瞬时（可重试）—— 清 JWT 逻辑保留在
+        // 适配器内，不参与错误分类；其余非 2xx 同样瞬时
         if (resp.status === 401) cachedJwt = null;
-        throw new EngineError('bing-edge', true, `HTTP ${resp.status}`);
+        throw new EngineError('bing-edge', true, `HTTP ${resp.status}`, 'transient');
       }
 
       const data = await resp.json();


### PR DESCRIPTION
## 问题

bing-edge 适配器错误只有 retryable 布尔，与 gemini（#236）的迁移不一致，401 会话失效的类别语义没有显式表达。

## 根因

适配器未按 #232 的类型化结果产出类别。

## 修复

bing-edge 各错误分支产出类型化 EngineError——401 会话失效仍判瞬时（可重试，清 JWT 逻辑保留在适配器内不参与分类）、auth 与其余非 2xx 同样瞬时；旧字段兼容。

## 验证

- bing-edge HTTP 单测补类别断言（401 会话失效 / auth 500 / 429 均 transient）
- typecheck 与全量 540 项单测通过