### PR TITLE
google-web 迁移类型化结果 (fix #251)

### DIFF
--- a/docs/testing/unit/engines/google-web-http.test.ts
+++ b/docs/testing/unit/engines/google-web-http.test.ts
@@ -96,7 +96,7 @@ describe('google-web HTTP 路径', () => {
     const { googleWeb } = await import('~/src/engines/google-web');
     await expect(
       googleWeb.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
-    ).rejects.toMatchObject({ name: 'EngineError', engineId: 'google-web', retryable: true });
+    ).rejects.toMatchObject({ name: 'EngineError', engineId: 'google-web', retryable: true, category: 'transient' });
   });
 
   test('坏 JSON → 全部失败抛 EngineError', async () => {
@@ -104,7 +104,7 @@ describe('google-web HTTP 路径', () => {
     const { googleWeb } = await import('~/src/engines/google-web');
     await expect(
       googleWeb.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
-    ).rejects.toMatchObject({ name: 'EngineError', retryable: true });
+    ).rejects.toMatchObject({ name: 'EngineError', retryable: true, category: 'transient' });
   });
 
   test('部分失败：失败槽位进 failedIndices，成功槽位保留', async () => {
@@ -130,7 +130,7 @@ describe('google-web HTTP 路径', () => {
     const { googleWeb } = await import('~/src/engines/google-web');
     await expect(
       googleWeb.translate({ texts: ['a', 'b'], from: 'auto', to: 'zh' }),
-    ).rejects.toMatchObject({ retryable: true, message: '全部 2 条翻译失败' });
+    ).rejects.toMatchObject({ retryable: true, category: 'transient', message: '全部 2 条翻译失败' });
   });
 
   test('并发闸门：maxConcurrency 生效（设置读取于首次翻译）', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/google-web.ts
+++ b/src/engines/google-web.ts
@@ -26,7 +26,8 @@ async function fetchOne(
 
   const resp = await fetchWithTimeout('google-web', `${ENDPOINT}?${qs}`);
   if (!resp.ok) {
-    throw new EngineError('google-web', true, `HTTP ${resp.status}`);
+    // #251: 类型化类别 —— 免 key 引擎一律瞬时（可重试）
+    throw new EngineError('google-web', true, `HTTP ${resp.status}`, 'transient');
   }
 
   const data = await resp.json();
@@ -68,7 +69,7 @@ export const googleWeb: TranslateEngine = {
 
     // 全部失败 → 抛出让 router 整体切换到下一个引擎
     if (failedIndices.length === texts.length) {
-      throw new EngineError('google-web', true, `全部 ${texts.length} 条翻译失败`);
+      throw new EngineError('google-web', true, `全部 ${texts.length} 条翻译失败`, 'transient');
     }
 
     return {


### PR DESCRIPTION
## 问题

google-web 适配器错误只有 retryable 布尔，与 gemini（#236）的迁移不一致。

## 根因

适配器未按 #232 的类型化结果产出类别。

## 修复

google-web 各错误分支产出类型化 EngineError——非 2xx 与全部失败均瞬时（可重试，降级下一引擎）；旧字段兼容。

## 验证

- google-web HTTP 单测补类别断言（非 2xx / 全部失败均 transient）
- typecheck 与全量 540 项单测通过