### PR TITLE
并发钳制单点化与写入口契约 (fix #254)

### DIFF
--- a/docs/testing/unit/storage/clamp-contract.test.ts
+++ b/docs/testing/unit/storage/clamp-contract.test.ts
@@ -1,0 +1,62 @@
+/**
+ * storage/settings.ts — 并发钳制写入口契约测试（#254）
+ *
+ * 钳制只留 schema.clampConcurrency 一处定义；合并函数不再钳制、
+ * 并发闸门只保留结构性防御。本契约钉死所有写入口（导入 / 跨上下文
+ * 写入走 patchSettings、恢复默认走 replaceSettings）产出的并发数
+ * 恒在合法范围 [1, 10]，#172 不回归。
+ */
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { resetStorage } from '~/docs/testing/setup';
+import { DEFAULT_SETTINGS, CONCURRENCY_MIN, CONCURRENCY_MAX } from '~/src/storage/schema';
+
+describe('并发钳制写入口契约（#254）', () => {
+  beforeEach(async () => {
+    resetStorage();
+    vi.resetModules();
+  });
+
+  function assertInRange(v: number): void {
+    expect(v).toBeGreaterThanOrEqual(CONCURRENCY_MIN);
+    expect(v).toBeLessThanOrEqual(CONCURRENCY_MAX);
+  }
+
+  test('patchSettings（导入 / 跨上下文写入路径）：非法值一律钳制', async () => {
+    const { patchSettings } = await import('~/src/storage/settings');
+    const { settingsReady, getSettings } = await import('~/src/storage/settings');
+    await settingsReady();
+
+    for (const bad of [0, -5, 999, 2.7, Number.NaN]) {
+      await patchSettings({ maxConcurrency: bad as never });
+      assertInRange(getSettings().maxConcurrency);
+    }
+    // 合法值原样保留
+    await patchSettings({ maxConcurrency: 3 });
+    expect(getSettings().maxConcurrency).toBe(3);
+  });
+
+  test('replaceSettings（恢复默认路径）：越界值同样钳制', async () => {
+    const { replaceSettings } = await import('~/src/storage/settings');
+    const { settingsReady, getSettings } = await import('~/src/storage/settings');
+    await settingsReady();
+
+    await replaceSettings({ ...DEFAULT_SETTINGS, maxConcurrency: 0 });
+    expect(getSettings().maxConcurrency).toBe(1);
+    await replaceSettings({ ...DEFAULT_SETTINGS, maxConcurrency: 999 });
+    expect(getSettings().maxConcurrency).toBe(10);
+    // 恢复默认本身在合法范围
+    await replaceSettings(DEFAULT_SETTINGS);
+    assertInRange(getSettings().maxConcurrency);
+  });
+
+  test('patch 未携带 maxConcurrency（含显式 undefined）→ 保持原值', async () => {
+    const { patchSettings } = await import('~/src/storage/settings');
+    const { settingsReady, getSettings } = await import('~/src/storage/settings');
+    await settingsReady();
+    await patchSettings({ maxConcurrency: 4 });
+    await patchSettings({ style: 'bold' });
+    expect(getSettings().maxConcurrency).toBe(4);
+    await patchSettings({ maxConcurrency: undefined });
+    expect(getSettings().maxConcurrency).toBe(4);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/storage/settings.ts
+++ b/src/storage/settings.ts
@@ -68,13 +68,20 @@ function mergeInto(base: Settings, patch: SettingsPatch): Settings {
     (merged as Record<NestedSettingsKey, unknown>)[key] = mergedValue;
   }
 
-  // #172: 任何写入口（导入/跨上下文 patch）都可能绕过 UI 下拉 ——
-  // maxConcurrency <= 0 会让并发闸门永久饿死，统一钳制到合法范围
-  merged.maxConcurrency =
-    patch.maxConcurrency === undefined
-      ? base.maxConcurrency
-      : clampConcurrency(patch.maxConcurrency);
+  // 显式 undefined 的 maxConcurrency 视同未携带（保持 base 原值）
+  if (patch.maxConcurrency === undefined) {
+    merged.maxConcurrency = base.maxConcurrency;
+  }
+
   return merged;
+}
+
+/**
+ * 写入口钳制（#254）—— 并发钳制唯一生效点，定义只在 schema 一处。
+ * 合并函数不再负责语义钳制（纯合并）；并发闸门只保留结构性防御。
+ */
+function clampWriteEntry(s: Settings): Settings {
+  return { ...s, maxConcurrency: clampConcurrency(s.maxConcurrency) };
 }
 
 /**
@@ -120,7 +127,8 @@ export async function patchSettings(patch: SettingsPatch): Promise<void> {
   const stored = ((await chrome.storage.sync.get(KEY))[KEY] as
     | Partial<Settings>
     | undefined);
-  current = mergeInto(merge(stored), patch);
+  // #254: 写入口单点钳制 —— 导入/跨上下文写入的并发数恒在合法范围
+  current = clampWriteEntry(mergeInto(merge(stored), patch));
   await chrome.storage.sync.set({ [KEY]: current });
 }
 
@@ -138,7 +146,8 @@ export async function replaceSettings(next: Settings): Promise<void> {
   for (const key of Object.keys(NESTED_KEYS) as NestedSettingsKey[]) {
     (merged as Record<NestedSettingsKey, unknown>)[key] = next[key];
   }
-  current = merged;
+  // #254: 恢复默认同样走写入口钳制 —— 并发数恒在合法范围
+  current = clampWriteEntry(merged);
   await chrome.storage.sync.set({ [KEY]: current });
 }
 


### PR DESCRIPTION
## 问题

并发数钳制在合并函数、并发闸门、引擎闸门各守一遍——#172（0/负数饿死并发闸门）正是不变量没被守住的产物，职责边界模糊。

## 根因

钳制逻辑散落多处，没有唯一生效点。

## 修复

- 钳制收敛到 `schema.clampConcurrency` 唯一定义，合并函数不再负责语义钳制（纯合并）
- 并发闸门只保留结构性防御（非法值兜底）
- 写入口（patchSettings 导入/跨上下文写入、replaceSettings 恢复默认）统一经 `clampWriteEntry` 钳制
- 新增契约测试把所有写入口的钳制不变量钉死

## 验证

- 契约测试 3 项：patchSettings 非法值一律钳制、replaceSettings 越界钳制、未携带/显式 undefined 保持原值
- 设置单测与设置同步集成、并发闸门测试全绿；typecheck 与全量 546 项单测通过