### PR TITLE
content 瘦身与重复创建块合并 (fix #255)

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -60,11 +60,9 @@ export default defineContentScript({
     await detectOS();
     const s = getSettings();
 
-    let stopObserving: (() => void) | null = null;
-    let stopHotkeys: (() => void) | null = null;
-
-    // #242/#243: UI 生命周期注册表 —— 悬浮球、段落按钮等经注册表启停，
-    // 设置变更由 ensure() 驱动，启停成对、重复注册幂等
+    // #242/#243/#255: UI 生命周期注册表 —— 悬浮球、段落按钮、划词拖拽、
+    // 快捷键、observer 全部经注册表启停；设置变更由 ensure() 驱动，
+    // 启停成对、重复注册幂等；五个 stop 变量与重复创建块已删除
     const registry = createLifecycleRegistry();
 
     const isMainFrame = window.top === window;
@@ -96,31 +94,37 @@ export default defineContentScript({
     }
 
     // ── 快捷键（仅主文档，避免与 iframe 内输入冲突）──
+    // #255: 快捷键经注册表启停（无设置开关，恒启用）
     if (isMainFrame) {
-      stopHotkeys = startHotkeys({
-        'toggle-translate': () => void togglePage(),
-        'toggle-mode': () => {
-          // 只翻转全局显示模式。paraDisplayMode 为 'follow' 时跟着变；
-          // 显式设过独立值的不受快捷键影响。
-          const next: 'bilingual' | 'translation-only' =
-            getSettings().displayMode === 'bilingual'
-              ? 'translation-only'
-              : 'bilingual';
-          patchSettings({ displayMode: next }).catch(() => {});
-        },
-        'translate-paragraph': () => {
-          const sel = window.getSelection();
-          if (sel?.rangeCount) {
-            const el = sel.getRangeAt(0).startContainer?.parentElement;
-            if (el) translateOne(el);
-          }
-        },
-        'toggle-extension': () => {
-          const cur = getSettings().enabled;
-          patchSettings({ enabled: !cur }).catch(() => {});
-          toast(cur ? tf('toastExtOff', '扩展已关闭') : tf('toastExtOn', '扩展已开启'));
-        },
+      registry.register('hotkeys', {
+        create: () =>
+          startHotkeys({
+            'toggle-translate': () => void togglePage(),
+            'toggle-mode': () => {
+              // 只翻转全局显示模式。paraDisplayMode 为 'follow' 时跟着变；
+              // 显式设过独立值的不受快捷键影响。
+              const next: 'bilingual' | 'translation-only' =
+                getSettings().displayMode === 'bilingual'
+                  ? 'translation-only'
+                  : 'bilingual';
+              patchSettings({ displayMode: next }).catch(() => {});
+            },
+            'translate-paragraph': () => {
+              const sel = window.getSelection();
+              if (sel?.rangeCount) {
+                const el = sel.getRangeAt(0).startContainer?.parentElement;
+                if (el) translateOne(el);
+              }
+            },
+            'toggle-extension': () => {
+              const cur = getSettings().enabled;
+              patchSettings({ enabled: !cur }).catch(() => {});
+              toast(cur ? tf('toastExtOff', '扩展已关闭') : tf('toastExtOn', '扩展已开启'));
+            },
+          }),
+        stop: (stopHotkeys) => stopHotkeys(),
       });
+      registry.ensure('hotkeys', true);
     }
 
     // ── 划词拖动 ──
@@ -130,6 +134,19 @@ export default defineContentScript({
       stop: (stopDrag) => stopDrag(),
     });
     registry.ensure('drag', true);
+
+    // ── 增量补翻 observer ──
+    // #255: observer 经注册表启停 —— 整页翻译完成时启动，还原时停止；
+    // 启停幂等，不再手写 stopObserving 判空
+    registry.register('observer', {
+      create: () =>
+        startObserver((els) => {
+          doTranslate(els).catch((e) =>
+            console.error('[PT] 增量补翻失败:', e),
+          );
+        }),
+      stop: (stopObserving) => stopObserving(),
+    });
 
     // ── 设置变更监听 ──
     onSettingsChanged((ns: Settings) => {
@@ -365,10 +382,8 @@ export default defineContentScript({
 
     // ── 还原 ──
     function doRestore(): void {
-      if (stopObserving) {
-        stopObserving();
-        stopObserving = null;
-      }
+      // #255: observer 经注册表停止（幂等，未启动为空操作）
+      registry.ensure('observer', false);
 
       // 递增还原纪元 —— 在飞翻译的批次重试检测到变化后放弃重试与
       // 渲染，避免还原后把内容翻回来（#91）
@@ -445,15 +460,9 @@ export default defineContentScript({
       }
 
       if (status === 'translated') {
-        // 增量补翻对三个入口一视同仁 —— 无限滚动/SPA 不该因为
-        // 用户点的是悬浮球而失效
-        if (!stopObserving) {
-          stopObserving = startObserver((els) => {
-            doTranslate(els).catch((e) =>
-              console.error('[PT] 增量补翻失败:', e),
-            );
-          });
-        }
+        // #255: 增量补翻 observer 经注册表启动（幂等）—— 无限滚动/SPA
+        // 不该因为用户点的是悬浮球而失效
+        registry.ensure('observer', true);
       }
 
       if (isMainFrame) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.25",
+  "version": "2.0.26",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## 问题

content 入口剩余 stopObserving / stopHotkeys 两个 stop 变量手写启停，初始化与设置变更的创建块仍可能重复（#242-244 已迁移三个 UI）——启停全靠自觉。

## 根因

快捷键与 observer 生命周期没有走注册表，入口仍有多余状态。

## 修复

快捷键与增量补翻 observer 改经注册表声明：注册 'hotkeys' / 'observer' 生命周期，设置无关的恒 ensure(true)，observer 在整页翻译完成时 ensure(true)、还原时 ensure(false)；五个 stop 变量全部删除，初始化与设置变更共用同一创建路径。

## 验证

- typecheck、全量 543 项单测、pnpm build 通过
- e2e 全量回归（核心 + 扩展流程）由 CI 校验