### PR TITLE
渐进渲染回调注入 (fix #256)

### DIFF
--- a/docs/testing/unit/orchestration/orchestrator.test.ts
+++ b/docs/testing/unit/orchestration/orchestrator.test.ts
@@ -89,3 +89,69 @@ describe('createOrchestrator — 假消息层', () => {
     expect(send).not.toHaveBeenCalled();
   });
 });
+
+describe('渐进渲染回调注入（#256）', () => {
+  test('每批返回即触发回调，不等待最慢段（批次节奏）', async () => {
+    const order: number[] = [];
+    let resolveSlow!: () => void;
+    const slowResult = { ok: true, data: { translations: ['慢批'] } };
+    const fastResult = { ok: true, data: { translations: ['快批'] } };
+    const send = vi
+      .fn()
+      // 第 0 批（慢）：手动控制完成时机
+      .mockImplementationOnce(
+        () =>
+          new Promise((r) => {
+            resolveSlow = () => r(slowResult);
+          }),
+      )
+      // 第 1 批（快）：立即完成
+      .mockImplementation(async () => fastResult);
+
+    const orch = createOrchestrator({
+      send,
+      onBatchResult: (i) => order.push(i),
+    });
+    orch.start();
+
+    const pending = orch.translatePage(items(20), 'en', 'zh');
+    await Promise.resolve();
+    await Promise.resolve();
+    // 快批先返回并触发渲染回调 —— 首屏不等最慢段
+    expect(order).toEqual([1]);
+
+    resolveSlow();
+    await pending;
+    expect(order).toEqual([1, 0]);
+  });
+
+  test('渲染顺序 = 完成顺序，回调携带批次下标与结果', async () => {
+    const seen: Array<[number, string]> = [];
+    const send = vi
+      .fn()
+      .mockImplementationOnce(async () => ({ ok: false, error: '批0失败', retryable: true }))
+      .mockImplementationOnce(async () => ({ ok: true, data: { translations: ['批1'] } }));
+
+    const orch = createOrchestrator({
+      send,
+      onBatchResult: (i, result) => {
+        seen.push([i, result.ok ? 'ok' : result.error!]);
+      },
+    });
+    orch.start();
+
+    await orch.translatePage(items(20), 'en', 'zh');
+    expect(seen).toEqual([
+      [0, '批0失败'],
+      [1, 'ok'],
+    ]);
+  });
+
+  test('未提供渲染回调 → 仅发送（兼容无渲染场景）', async () => {
+    const send = vi.fn(async () => ({ ok: true, data: { translations: [] } }));
+    const orch = createOrchestrator({ send });
+    orch.start();
+    await expect(orch.translatePage(items(16), 'en', 'zh')).resolves.toBeUndefined();
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.26",
+  "version": "2.0.27",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/orchestration/orchestrator.ts
+++ b/src/orchestration/orchestrator.ts
@@ -9,7 +9,11 @@
 // 本票落地骨架与批次拆分（#245）；渐进渲染回调注入与 epoch 中止
 // 语义由后续票承接（#256 / #262），尚无生产调用方。
 
-import type { TranslateRequest } from '~/src/engines/types';
+import type {
+  TranslateRequest,
+  TranslateResponse,
+  FailureCategory,
+} from '~/src/engines/types';
 
 /** 全页翻译的批次大小 —— 与 content 现有 FULL_PAGE_BATCH_SIZE 一致（#25）。 */
 export const FULL_PAGE_BATCH_SIZE = 15;
@@ -42,6 +46,19 @@ export interface OrchestratorOptions {
   send: SendTranslate;
   /** 批次大小，缺省与现状一致（15）。 */
   batchSize?: number;
+  /** 渲染回调（#256 渐进渲染）：每批返回即触发，首屏不等待最慢段。 */
+  onBatchResult?: (batchIndex: number, result: TranslateBatchResult) => void;
+}
+
+/** 单批发送结果（#256）：渲染层按批消费，批次间不互相等待。 */
+export interface TranslateBatchResult {
+  ok: boolean;
+  data?: TranslateResponse;
+  error?: string;
+  invalidated?: boolean;
+  retryable?: boolean;
+  category?: FailureCategory;
+  aborted?: boolean;
 }
 
 /**
@@ -76,14 +93,17 @@ export function createOrchestrator(opts: OrchestratorOptions): TranslationOrches
       if (!started) throw new Error('[PT] 编排未启动');
       // 批次拆分（#245）：与现状一致，每批独立发送
       const batches = splitBatches(items, batchSize);
+      // #256 渐进渲染：每批返回即触发渲染回调，互不等待 ——
+      // 首屏译文不必等全页最慢段（#25 行为保持）
       await Promise.all(
-        batches.map((batch) =>
-          opts.send({
+        batches.map(async (batch, i) => {
+          const result = (await opts.send({
             texts: batch.map((item) => item.text),
             from,
             to,
-          }),
-        ),
+          })) as TranslateBatchResult;
+          opts.onBatchResult?.(i, result);
+        }),
       );
     },
   };


### PR DESCRIPTION
## 问题

编排模块只有发送无渲染出口，渐进渲染（#25 首屏不等最慢段）无法经模块表达，行为只能靠 content 内联实现。

## 根因

translatePage 没有渲染回调注入点。

## 修复

orchestrator 新增 `onBatchResult(batchIndex, result)` 渲染回调，每批返回即触发、批次间互不等待——首屏不等最慢段；回调携带批次下标与类型化结果（含类别），供渲染层按批消费。

## 验证

- 新增单测 3 项：批次节奏（快批先渲染、不等待慢批）、渲染顺序 = 完成顺序、无回调时仅发送
- typecheck 与全量 549 项单测通过