### PR TITLE
openai 走公共判定与模板 (fix #258)

### DIFF
--- a/docs/testing/unit/engines/openai-http.test.ts
+++ b/docs/testing/unit/engines/openai-http.test.ts
@@ -117,14 +117,29 @@ describe('openai HTTP 路径', () => {
     }
   });
 
-  test('其他非 200 → EngineError（retryable，transient）', async () => {
+  test('429 → quota（公共判定口径，#258）', async () => {
     const { getKey } = await import('~/src/storage/keys');
     vi.mocked(getKey).mockResolvedValue('k');
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('err', { status: 429 })));
     const { openai } = await import('~/src/engines/openai');
     await expect(
       openai.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
-    ).rejects.toMatchObject({ retryable: true, category: 'transient', message: 'HTTP 429' });
+    ).rejects.toMatchObject({
+      retryable: false,
+      category: 'quota',
+      invalidated: true,
+      aborted: false,
+    });
+  });
+
+  test('500 → EngineError（retryable，transient）', async () => {
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('err', { status: 500 })));
+    const { openai } = await import('~/src/engines/openai');
+    await expect(
+      openai.translate({ texts: ['a'], from: 'auto', to: 'zh' }),
+    ).rejects.toMatchObject({ retryable: true, category: 'transient', message: 'HTTP 500' });
   });
 
   test('空 choices → 长度一致的空白译文数组', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.28",
+  "version": "2.0.29",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/openai.ts
+++ b/src/engines/openai.ts
@@ -5,10 +5,10 @@
 import { getKey } from '~/src/storage/keys';
 import { getSettings } from '~/src/storage/settings';
 import { DEFAULT_MODELS } from '~/src/storage/schema';
-import { normalizeText } from '~/src/dom/normalize';
 import { fetchWithTimeout } from './fetch-timeout';
 import { engineGate } from './engine-gate';
 import { EngineError } from './types';
+import { classifyStatus, buildNumberedPrompt } from './shared';
 import type { TranslateEngine } from './types';
 
 const DEFAULT_ENDPOINT = 'https://api.openai.com/v1/chat/completions';
@@ -45,14 +45,8 @@ export const openai: TranslateEngine = {
 
       const model = getSettings().models?.openai ?? DEFAULT_MODELS.openai!;
 
-      // 纵深防御：编号结构靠 \n 分隔，文本自带的换行会把编号撑破导致错位。
-      // 即便入口采集漏了归一化，这里也必须兜住，拼 prompt 前再压一次。
-      const numbered = texts
-        .map((t, i) => `${i + 1}. ${normalizeText(t)}`)
-        .join('\n');
-      const prompt =
-        `将以下编号文本翻译成${to}${from === 'auto' ? '' : `（源语言：${from}）`}。` +
-        `严格保持编号与行数一致，只输出译文，不要解释。\n\n${numbered}`;
+      // #258: 编号提示词走公共模板（模板唯一来源）—— 格式与现状逐字一致
+      const prompt = buildNumberedPrompt(to, from, texts);
 
       const resp = await fetchWithTimeout('openai', DEFAULT_ENDPOINT, {
         method: 'POST',
@@ -67,10 +61,14 @@ export const openai: TranslateEngine = {
         }),
       });
 
-      // #248: 类型化类别 —— 401/403 → key 无效（不重试）；其余非 2xx
-      // → 瞬时（可重试，路由降级下一引擎）
-      if (resp.status === 401 || resp.status === 403) {
+      // #258: 状态分类走公共判定（口径：#239）—— 401/403 → key 无效、
+      // 429 → 配额、其余非 2xx → 瞬时
+      const category = classifyStatus('openai', resp, true);
+      if (category === 'invalid-key') {
         throw new EngineError('openai', false, 'API key 无效', 'invalid-key');
+      }
+      if (category === 'quota') {
+        throw new EngineError('openai', false, '配额已用尽', 'quota', true);
       }
       if (!resp.ok) {
         throw new EngineError('openai', true, `HTTP ${resp.status}`, 'transient');


### PR DESCRIPTION
## 问题

openai 的状态分类与编号提示词是自造实现，与公共模块（classifyStatus / buildNumberedPrompt，#239/#240）并存——判定口径存在第二份，429 的配额语义与公共口径不一致。

## 根因

适配器未切换到公共模块。

## 修复

- 状态分类改走 `classifyStatus`（401/403 → invalid-key、429 → quota、其余非 2xx → transient），429 按公共口径判配额（retryable=false + invalidated）
- 编号提示词改用 `buildNumberedPrompt`（格式逐字一致）；normalizeText 不再直接引用

## 验证

- openai HTTP 单测全绿（429 用例更新为公共口径 quota，新增 500 → transient 用例），模板往返单测通过
- typecheck 与全量 547 项单测通过