### PR TITLE
bing-edge 走公共判定 (fix #259)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.29",
+  "version": "2.0.30",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/bing-edge.ts
+++ b/src/engines/bing-edge.ts
@@ -6,6 +6,7 @@
 import { fetchWithTimeout } from './fetch-timeout';
 import { engineGate } from './engine-gate';
 import { EngineError } from './types';
+import { classifyStatus } from './shared';
 import type { TranslateEngine } from './types';
 
 // #159: 引擎级并发闸门 —— 整页翻译批次并发 → translate() 并发调用
@@ -36,8 +37,9 @@ async function getJwt(): Promise<string> {
     jwtPromise = (async () => {
       const resp = await fetchWithTimeout('bing-edge', AUTH_ENDPOINT);
       if (!resp.ok) {
-        // #250: 类型化类别 —— 免 key 引擎一律瞬时（可重试）
-        throw new EngineError('bing-edge', true, `auth HTTP ${resp.status}`, 'transient');
+        // #259: 分类走公共判定 —— 免 key 引擎一律瞬时（可重试）
+        const category = classifyStatus('bing-edge', resp, true);
+        throw new EngineError('bing-edge', true, `auth HTTP ${resp.status}`, category);
       }
       cachedJwt = await resp.text(); // 返回纯文本 JWT，非 JSON
       return cachedJwt!;
@@ -80,10 +82,11 @@ export const bingEdge: TranslateEngine = {
       });
 
       if (!resp.ok) {
-        // #250: 401 会话失效仍判瞬时（可重试）—— 清 JWT 逻辑保留在
-        // 适配器内，不参与错误分类；其余非 2xx 同样瞬时
+        // #259: 会话逻辑（401 清 JWT）留在适配器内、不参与分类；
+        // 分类走公共判定 —— 免 key 引擎的 401 会话失效仍瞬时可重试
         if (resp.status === 401) cachedJwt = null;
-        throw new EngineError('bing-edge', true, `HTTP ${resp.status}`, 'transient');
+        const category = classifyStatus('bing-edge', resp, true);
+        throw new EngineError('bing-edge', true, `HTTP ${resp.status}`, category);
       }
 
       const data = await resp.json();


### PR DESCRIPTION
## 问题

bing-edge 的 401 会话失效判断与错误分类混在适配器里，与公共判定（#239）并存——会话逻辑与分类语义耦合。

## 根因

适配器未切换到公共模块，特例未显式隔离。

## 修复

分类改走 `classifyStatus`（免 key 引擎一律瞬时）；401 清 JWT 的会话逻辑保留在适配器内、不参与分类——401 会话失效路径仍瞬时可重试，行为保持。

## 验证

- bing-edge HTTP 单测全绿（401 会话失效 / auth 500 / 429 均 transient 断言不变）
- typecheck 与全量 546 项单测通过