### PR TITLE
deepl 走公共判定 (fix #260)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.30",
+  "version": "2.0.31",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/deepl.ts
+++ b/src/engines/deepl.ts
@@ -6,6 +6,7 @@ import { getKey } from '~/src/storage/keys';
 import { fetchWithTimeout } from './fetch-timeout';
 import { engineGate } from './engine-gate';
 import { EngineError } from './types';
+import { classifyStatus } from './shared';
 import type { TranslateEngine } from './types';
 
 // #159: 引擎级并发闸门 —— 整页翻译批次并发 → translate() 并发调用
@@ -96,12 +97,13 @@ export const deepl: TranslateEngine = {
         body: body.toString(),
       });
 
-      // #249: 类型化类别 —— 401/403 → key 无效；429 → 配额（免费额度
-      // 耗尽，不重试）；其余非 2xx → 瞬时（可重试，降级下一引擎）
-      if (resp.status === 403 || resp.status === 401) {
+      // #260: 状态分类走公共判定（口径：#239）—— 401/403 → key 无效、
+      // 429 → 配额（免费额度耗尽，不重试）、其余非 2xx → 瞬时
+      const category = classifyStatus('deepl', resp, true);
+      if (category === 'invalid-key') {
         throw new EngineError('deepl', false, 'API key 无效', 'invalid-key');
       }
-      if (resp.status === 429) {
+      if (category === 'quota') {
         throw new EngineError('deepl', false, '配额已用尽', 'quota', true);
       }
       if (!resp.ok) {


### PR DESCRIPTION
## 问题

deepl 的状态分类硬编码在适配器里，与公共判定（#239）并存——判定口径存在第二份，改动会漏同步。

## 根因

适配器未切换到公共模块。

## 修复

deepl 状态分类改走 `classifyStatus`（401/403 → invalid-key、429 → quota、其余非 2xx → transient），429 配额提示走公共口径；DeepL 走表单参数无编号提示词，模板迁移不适用。

## 验证

- deepl HTTP 单测全绿（401/403 → invalid-key、429 → quota、456 → transient 断言不变）
- typecheck 与全量 546 项单测通过