### PR TITLE
epoch 中止语义迁入 (fix #262)

### DIFF
--- a/docs/testing/unit/orchestration/orchestrator.test.ts
+++ b/docs/testing/unit/orchestration/orchestrator.test.ts
@@ -13,6 +13,11 @@ import {
 import type { TranslateItem } from '~/src/orchestration/orchestrator';
 import type { TranslateRequest } from '~/src/engines/types';
 
+/** 冲刷微任务 + 一个宏任务，让异步链（send → retry → 回调）完整推进。 */
+async function flush(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
 function items(n: number): TranslateItem<number>[] {
   return Array.from({ length: n }, (_, i) => ({ text: `text-${i}`, ctx: i }));
 }
@@ -161,5 +166,81 @@ describe('渐进渲染回调注入（#256）', () => {
       aborted: false,
     });
     expect(send).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('epoch 中止语义（#262）', () => {
+  test('abort 后：在飞批次完成也不触发渲染回调，汇总报 aborted', async () => {
+    const order: number[] = [];
+    let resolveSlow!: () => void;
+    const send = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((r) => {
+            resolveSlow = () => r({ ok: true, data: { translations: ['慢批'] } });
+          }),
+      )
+      .mockImplementation(async () => ({ ok: true, data: { translations: ['快批'] } }));
+
+    const orch = createOrchestrator({
+      send,
+      sleep: () => Promise.resolve(),
+      onBatchResult: (i) => order.push(i),
+    });
+    orch.start();
+
+    const pending = orch.translatePage(items(20), 'en', 'zh');
+    await flush();
+    // 快批已返回并渲染
+    expect(order).toEqual([1]);
+
+    // 还原：中止在途翻译
+    orch.abort();
+    resolveSlow();
+
+    const summary = await pending;
+    expect(summary.aborted).toBe(true);
+    // 中止后回调不再触发 —— 慢批完成但不渲染（过期译文丢弃）
+    expect(order).toEqual([1]);
+  });
+
+  test('abort 后新翻译不被旧批次干扰：新翻译正常完成', async () => {
+    const order: number[] = [];
+    let resolveOld!: () => void;
+    const send = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((r) => {
+            resolveOld = () => r({ ok: true, data: { translations: ['旧批'] } });
+          }),
+      )
+      .mockImplementation(async () => ({ ok: true, data: { translations: ['新批'] } }));
+
+    const orch = createOrchestrator({
+      send,
+      sleep: () => Promise.resolve(),
+      onBatchResult: (i) => order.push(i),
+    });
+    orch.start();
+
+    // 旧翻译在飞
+    const oldPending = orch.translatePage(items(20), 'en', 'zh');
+    await flush();
+    orch.abort();
+
+    // 新翻译开始 —— 不受旧批次干扰
+    const newSummary = await orch.translatePage(items(16), 'en', 'zh');
+    expect(newSummary.aborted).toBe(false);
+    expect(newSummary.allFailed).toBe(false);
+    // 新翻译的批次全部渲染
+    expect(order).toEqual([1, 0, 1]);
+
+    // 旧翻译收尾：aborted，不渲染
+    resolveOld();
+    const oldSummary = await oldPending;
+    expect(oldSummary.aborted).toBe(true);
+    expect(order).toEqual([1, 0, 1]);
   });
 });

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -164,11 +164,9 @@ export default defineContentScript({
     });
 
     // ── 翻译全页 ──
-    // #261: 批次拆分 / 有界重试 / 中止 / 渐进渲染收敛到编排模块，
-    // 这里只装配：消息发送（translateViaBackground）与渲染回调注入。
-
-    /** 还原纪元：doRestore 递增，在飞翻译据此放弃重试与渲染（#91）。 */
-    const translateEpoch = { value: 0 };
+    // #261/#262: 批次拆分 / 有界重试 / epoch 中止 / 渐进渲染全部收敛
+    // 到编排模块（还原纪元在模块内，abort() 递增）；这里只装配：
+    // 消息发送（translateViaBackground）与渲染回调注入。
 
     // #156: 整页翻译在飞互斥。悬浮球自身的 loading 守卫挡不住 popup 与
     // 快捷键路径 —— 它们直接调 togglePage。在飞期间忽略新的 toggle：
@@ -261,14 +259,11 @@ export default defineContentScript({
 
       renderStats.succeeded = 0;
       renderStats.rejected = 0;
-      const epochAtStart = translateEpoch.value;
 
-      // #261: 全页翻译经编排模块执行 —— 批次拆分（15/批）、有界重试、
-      // 失效全局短路、渐进渲染回调都在模块内；此处只注入中止谓词
-      // （还原纪元）与渲染回调
-      const summary = await orchestrator.translatePage(items, ns.from, ns.to, {
-        shouldAbort: () => translateEpoch.value !== epochAtStart,
-      });
+      // #261/#262: 全页翻译经编排模块执行 —— 批次拆分（15/批）、有界
+      // 重试、失效全局短路、epoch 中止、渐进渲染回调都在模块内；
+      // 还原（doRestore → orchestrator.abort()）自动中止在途批次
+      const summary = await orchestrator.translatePage(items, ns.from, ns.to);
 
       // #157: 还原发生在翻译进行中 —— 批次被中止不是失败：
       // 不弹“所有引擎均失败”、状态置 aborted（悬浮球回 idle、
@@ -312,9 +307,9 @@ export default defineContentScript({
       // #255: observer 经注册表停止（幂等，未启动为空操作）
       registry.ensure('observer', false);
 
-      // 递增还原纪元 —— 在飞翻译的批次重试检测到变化后放弃重试与
-      // 渲染，避免还原后把内容翻回来（#91）
-      translateEpoch.value++;
+      // #262: 还原纪元在编排模块内 —— abort() 递增，在飞翻译的批次
+      // 重试检测到变化后放弃重试与渲染，避免还原后把内容翻回来（#91）
+      orchestrator.abort();
 
       // #253: 还原收集走统一遍历模块（shadow 穿透 + 集中式跳过规则）。
       // skipTranslated: false —— 嵌套在已翻译单元内的已翻译单元

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.32",
+  "version": "2.0.33",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/orchestration/orchestrator.ts
+++ b/src/orchestration/orchestrator.ts
@@ -60,23 +60,20 @@ export interface TranslationOrchestrator {
   /** 停止编排（清理订阅与在飞状态）。 */
   stop(): void;
   /**
+   * 中止在途翻译（#262）—— 递增还原纪元：在飞批次的尝试、重试与
+   * 渲染回调全部放弃，过期译文不落 DOM；新翻译不受旧批次干扰。
+   */
+  abort(): void;
+  /**
    * 全页翻译入口：按批次拆分发送，每批返回即触发渲染回调（#256）；
-   * 批次级失败有界重试、失效全局短路、中止判定都在模块内（#261）。
+   * 批次级失败有界重试、失效全局短路、epoch 中止判定都在模块内
+   * （#261 / #262）。
    */
   translatePage(
     items: TranslateItem<unknown>[],
     from: string,
     to: string,
-    opts?: PageTranslateOptions,
   ): Promise<PageTranslateSummary>;
-}
-
-export interface PageTranslateOptions {
-  /**
-   * 中止谓词（#261 由调用方注入还原/导航状态；#262 迁入模块内部）。
-   * 每次尝试前后与渲染前检查，返回 true 则放弃该批与剩余重试。
-   */
-  shouldAbort?: () => boolean;
 }
 
 export interface OrchestratorOptions {
@@ -114,6 +111,9 @@ export function createOrchestrator(opts: OrchestratorOptions): TranslationOrches
   const sleepFn = opts.sleep ?? defaultSleep;
   const onBatchResult = opts.onBatchResult;
   let started = false;
+  // #262: 还原纪元在模块内 —— abort() 递增，在飞翻译据此放弃
+  // 尝试、重试与渲染；新翻译快照新纪元，不受旧批次干扰
+  let epoch = 0;
 
   return {
     start(): void {
@@ -124,9 +124,13 @@ export function createOrchestrator(opts: OrchestratorOptions): TranslationOrches
       started = false;
     },
 
-    async translatePage(items, from, to, pageOpts = {}): Promise<PageTranslateSummary> {
+    abort(): void {
+      epoch++;
+    },
+
+    async translatePage(items, from, to): Promise<PageTranslateSummary> {
       if (!started) throw new Error('[PT] 编排未启动');
-      const shouldAbort = pageOpts.shouldAbort;
+      const epochAtStart = epoch;
       // 批次拆分（#245）：与现状一致，每批独立发送
       const batches = splitBatches(items, batchSize);
 
@@ -136,10 +140,14 @@ export function createOrchestrator(opts: OrchestratorOptions): TranslationOrches
       let invalidated = false;
       let fatalError: string | null = null;
 
+      // #262: 中止谓词 —— 还原（abort 递增纪元）或他批已判失效
+      const isAborted = (): boolean =>
+        invalidated || epoch !== epochAtStart;
+
       await Promise.all(
         batches.map(async (batch, i) => {
           // 批次级失败有界重试（#91 语义由 batch-retry 承接）：
-          // 失效全局短路 + 调用方中止谓词在每次尝试前后检查
+          // 失效全局短路 + epoch 中止在每次尝试前后检查
           const result = await attemptBatchWithRetry(
             () =>
               opts.send({
@@ -149,14 +157,14 @@ export function createOrchestrator(opts: OrchestratorOptions): TranslationOrches
               }) as Promise<TranslateBatchResult>,
             {
               sleep: sleepFn,
-              shouldAbort: () => invalidated || (shouldAbort?.() ?? false),
+              shouldAbort: isAborted,
             },
           );
 
           if (result.ok) {
-            // #157: 本批在飞期间用户已还原（中止谓词命中）—— 放弃
-            // 渲染，否则还原后会把内容翻回来（#91 的渲染侧补漏）
-            if (shouldAbort?.()) {
+            // #157: 本批在飞期间用户已还原（纪元递增）—— 放弃渲染，
+            // 否则还原后会把内容翻回来（#91 的渲染侧补漏）
+            if (isAborted()) {
               aborted = true;
               return;
             }
@@ -190,7 +198,7 @@ export function createOrchestrator(opts: OrchestratorOptions): TranslationOrches
       );
 
       // #157: 还原恰在最后一批与返回之间发生 —— 也报 aborted
-      if (shouldAbort?.()) aborted = true;
+      if (isAborted()) aborted = true;
 
       return { allFailed, aborted, invalidated, fatalError };
     },


### PR DESCRIPTION
## 问题

还原纪元（translateEpoch）仍在 content 入口，中止谓词经 translatePage 选项注入——中止逻辑没有真正收进模块，模块接口带着调用方状态。

## 根因

epoch 状态未迁入模块。

## 修复

- 还原纪元移入 orchestrator（`abort()` 递增）
- translatePage 内部快照纪元并自行判定中止（失效短路 + 纪元变化），不再接受外部中止谓词
- content 的 translateEpoch 删除，doRestore 改调 `orchestrator.abort()`

页面切换 / 导航中止在途翻译，过期译文不落 DOM，新翻译不受旧批次干扰。

## 验证

- 新增单测 2 项：abort 后在飞批次完成不触发渲染回调、abort 后新翻译正常完成
- typecheck、全量 552 项单测、pnpm build 通过；本地 e2e core 32 项全绿（含 #157 还原 vs 在飞翻译场景）