### PR TITLE
删除重算与旧形态收尾 (fix #263)

### DIFF
--- a/docs/testing/unit/orchestration/orchestrator.test.ts
+++ b/docs/testing/unit/orchestration/orchestrator.test.ts
@@ -137,7 +137,7 @@ describe('渐进渲染回调注入（#256）', () => {
       .mockImplementationOnce(async () => ({
         ok: false,
         error: '批0失败',
-        retryable: false,
+        category: 'invalid-key' as const,
       }))
       .mockImplementationOnce(async () => ({ ok: true, data: { translations: ['批1'] } }));
 

--- a/docs/testing/unit/runtime/batch-retry.test.ts
+++ b/docs/testing/unit/runtime/batch-retry.test.ts
@@ -44,12 +44,12 @@ describe('attemptBatchWithRetry — 成功路径', () => {
   });
 });
 
-describe('attemptBatchWithRetry — 不可恢复错误（#180）', () => {
-  test('retryable=false（key 无效等）→ 立即失败，0 次重试', async () => {
+describe('attemptBatchWithRetry — 不可恢复错误（#180 → #263）', () => {
+  test('category=invalid-key → 立即失败，0 次重试', async () => {
     const send = vi.fn(async () => ({
       ok: false,
       error: 'API key 无效',
-      retryable: false,
+      category: 'invalid-key' as const,
     }));
     const result = await attemptBatchWithRetry(send, { sleep: noopSleep });
 
@@ -62,8 +62,19 @@ describe('attemptBatchWithRetry — 不可恢复错误（#180）', () => {
     expect(send).toHaveBeenCalledTimes(1);
   });
 
-  test('缺省 retryable → 按可重试处理（默认行为不变）', async () => {
+  test('缺省类别 → 按可重试处理（默认行为不变）', async () => {
     const send = vi.fn(async () => ({ ok: false, error: '瞬时故障' }));
+    await attemptBatchWithRetry(send, { sleep: noopSleep });
+    expect(send).toHaveBeenCalledTimes(BATCH_RETRY_LIMIT + 1);
+  });
+
+  test('旧字段 retryable=false 已清理：无类别时不再短路（#263）', async () => {
+    const send = vi.fn(async () => ({
+      ok: false,
+      error: 'API key 无效',
+      retryable: false,
+    }));
+    // 旧形态不再生效 —— 按可重试处理进入重试序列
     await attemptBatchWithRetry(send, { sleep: noopSleep });
     expect(send).toHaveBeenCalledTimes(BATCH_RETRY_LIMIT + 1);
   });
@@ -256,17 +267,6 @@ describe('attemptBatchWithRetry — 新字段优先（#246）', () => {
     expect(send).toHaveBeenCalledTimes(2);
   });
 
-  test('旧字段路径兼容：仅 retryable=false（无 category）→ 立即失败', async () => {
-    const send = vi.fn(async () => ({
-      ok: false,
-      error: 'API key 无效',
-      retryable: false,
-    }));
-    const result = await attemptBatchWithRetry(send, { sleep: noopSleep });
-
-    expect(result.ok).toBe(false);
-    expect(send).toHaveBeenCalledTimes(1);
-  });
 });
 
 describe('BatchRetryResult 类别透传（#247）', () => {

--- a/docs/testing/unit/runtime/messaging.test.ts
+++ b/docs/testing/unit/runtime/messaging.test.ts
@@ -190,9 +190,7 @@ describe('translateViaBackground — 失败语义', () => {
       ok: false,
       error: '所有引擎均失败',
       invalidated: false,
-      // #180: 未携带 retryable 的响应按可重试处理
-      retryable: true,
-      // #236: 未携带类型化字段 → 按瞬时处理（旧路径兼容）
+      // #263: 未携带类型化字段 → 按瞬时处理；不再转述 retryable
       category: 'transient',
       aborted: false,
     });
@@ -219,7 +217,6 @@ describe('translateViaBackground — 失败语义', () => {
     expect(result).toEqual({
       ok: false,
       error: 'API key 无效',
-      retryable: false,
       invalidated: false,
       category: 'invalid-key',
       aborted: false,

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -113,28 +113,23 @@ export default defineBackground(() => {
         .then(() => route(msg.payload))
         .then((r) => sendResponse({ ok: true, data: r }))
         .catch((e) => {
-          // #180: 透出 retryable 标志 —— 仅引擎直接抛出的 retryable=false
-          // （key 无效等）不可恢复，批次重试层不再白等退避序列；router
-          // 的「所有引擎均失败」是普通 Error，按可重试处理（瞬时故障
-          // 重试后自愈，TC-E2E-47 依赖此路径）
-          const nonRetryable = e instanceof EngineError && e.retryable === false;
+          // #263: 纯透传 —— background 不再重算可重试性；引擎产出的
+          // 类型化字段（category / retryable / invalidated / aborted）
+          // 原样透出，语义判定只在错误发生的唯一地点做一次
           sendResponse({
             ok: false,
             error: e instanceof Error ? e.message : String(e),
-            retryable: !nonRetryable,
-            // #236: 新形态端到端 —— 引擎产出的类型化字段原样透传，
-            // 扩张阶段与旧字段并存（旧字段清理在收尾票 #263）
+            retryable: e instanceof EngineError ? e.retryable : true,
             category: e instanceof EngineError ? e.category : 'transient',
             invalidated: e instanceof EngineError ? e.invalidated : false,
             aborted: e instanceof EngineError ? e.aborted : false,
           });
         });
     } catch (e) {
-      const nonRetryable = e instanceof EngineError && e.retryable === false;
       sendResponse({
         ok: false,
         error: e instanceof Error ? e.message : String(e),
-        retryable: !nonRetryable,
+        retryable: e instanceof EngineError ? e.retryable : true,
         category: e instanceof EngineError ? e.category : 'transient',
         invalidated: e instanceof EngineError ? e.invalidated : false,
         aborted: e instanceof EngineError ? e.aborted : false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.33",
+  "version": "2.0.34",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/runtime/batch-retry.ts
+++ b/src/runtime/batch-retry.ts
@@ -55,11 +55,9 @@ export async function attemptBatchWithRetry(
     error?: string;
     /** #116: messaging 透出的类型化上下文失效标志。 */
     invalidated?: boolean;
-    /** #180: 引擎不可恢复错误（key 无效等）—— 不重试。 */
-    retryable?: boolean;
-    /** #236/#246: 类型化失败类别（新字段，存在时优先于 retryable）。 */
+    /** #236/#246: 类型化失败类别 —— 不可重试语义的唯一来源。 */
     category?: FailureCategory;
-    /** #236/#246: 已中止（新字段）。 */
+    /** #236/#246: 已中止。 */
     aborted?: boolean;
   }>,
   opts: BatchRetryOptions = {},
@@ -88,17 +86,13 @@ export async function attemptBatchWithRetry(
         category: resp.category,
       };
     }
-    // #246: 新字段 aborted（用户中止）→ 立即停止，不记成失败
+    // #246: aborted（用户中止）→ 立即停止，不记成失败
     if (resp?.aborted) {
       return { ok: false, invalidated: false, aborted: true, error: lastError };
     }
-    // #246: 新字段类别优先 —— invalid-key / quota 不可恢复，立即失败；
-    // 旧字段 retryable=false 在兼容期同样生效（#180）
-    if (
-      resp?.category === 'invalid-key' ||
-      resp?.category === 'quota' ||
-      resp?.retryable === false
-    ) {
+    // #246/#263: 类型化类别 —— invalid-key / quota 不可恢复，立即失败
+    // （旧字段 retryable 已清理，#180 语义由类别承载）
+    if (resp?.category === 'invalid-key' || resp?.category === 'quota') {
       return {
         ok: false,
         invalidated: false,

--- a/src/runtime/messaging.ts
+++ b/src/runtime/messaging.ts
@@ -30,11 +30,9 @@ export type TranslateResult =
       ok: false;
       error: string;
       invalidated: boolean;
-      /** #180: 引擎不可恢复错误（key 无效等）—— 批次重试层不重试。 */
-      retryable: boolean;
-      /** #236: 类型化失败类别（新字段，扩张阶段与旧字段并存）。 */
+      /** #236: 类型化失败类别 —— 语义判定只在引擎处做一次，原样透传。 */
       category: FailureCategory;
-      /** #236: 已中止（新字段）。 */
+      /** #236: 已中止。 */
       aborted: boolean;
     };
 
@@ -174,7 +172,6 @@ export async function translateViaBackground(
       ok?: boolean;
       data?: TranslateResponse;
       error?: string;
-      retryable?: boolean;
       category?: FailureCategory;
       invalidated?: boolean;
       aborted?: boolean;
@@ -187,8 +184,7 @@ export async function translateViaBackground(
       ok: false,
       error: resp?.error ?? '未知错误',
       invalidated: resp?.invalidated ?? false,
-      retryable: resp?.retryable ?? true,
-      // #236: 类型化字段原样透传，缺省按瞬时处理（旧路径兼容）
+      // #263: 类型化字段原样透传，缺省按瞬时处理；不再转述 retryable
       category: resp?.category ?? 'transient',
       aborted: resp?.aborted ?? false,
     };
@@ -198,7 +194,6 @@ export async function translateViaBackground(
       ok: false,
       error: e instanceof Error ? e.message : String(e),
       invalidated: e instanceof ContextInvalidatedError,
-      retryable: true,
       category: 'transient',
       aborted: false,
     };


### PR DESCRIPTION
## 问题

background 两处 catch 仍在重算可重试性（nonRetryable 启发式），messaging / batch-retry 保留旧 retryable 字段与旧路径——收尾阶段应只透传类型化结果，旧形态删除。

## 根因

扩张期的兼容字段与重算逻辑未清理。

## 修复

- background 两处 catch 改纯透传（不再重算，类型化字段原样透出）
- messaging TranslateResult 删除 retryable 字段与转述逻辑
- batch-retry send 类型删除 retryable、判定只认类型化类别（#180 语义由类别承载）
- 相关测试同步更新（旧字段不再短路）

## 验证

- typecheck、全量 550 项单测、pnpm build 通过；本地 e2e core 32 项全绿