### PR TITLE
设置变更收敛与 content 收尾 (fix #265)

### DIFF
--- a/docs/testing/unit/orchestration/orchestrator.test.ts
+++ b/docs/testing/unit/orchestration/orchestrator.test.ts
@@ -244,3 +244,41 @@ describe('epoch 中止语义（#262）', () => {
     expect(order).toEqual([1, 0, 1]);
   });
 });
+
+describe('设置变更订阅（#265）', () => {
+  test('start 订阅设置变更、stop 退订；回调转发 onSettingsChange', async () => {
+    let handler: ((s: unknown) => void) | null = null;
+    let unsubscribed = false;
+    const seen: unknown[] = [];
+    const send = vi.fn(async () => ({ ok: true, data: { translations: [] } }));
+
+    const orch = createOrchestrator({
+      send,
+      subscribeSettings: (fn) => {
+        handler = fn;
+        return () => {
+          unsubscribed = true;
+        };
+      },
+      onSettingsChange: (s) => seen.push(s),
+    });
+
+    orch.start();
+    expect(handler).not.toBeNull();
+
+    handler!({ style: 'bold' });
+    expect(seen).toEqual([{ style: 'bold' }]);
+
+    orch.stop();
+    expect(unsubscribed).toBe(true);
+  });
+
+  test('未注入订阅 → start/stop 为空操作', async () => {
+    const send = vi.fn(async () => ({ ok: true, data: { translations: [] } }));
+    const orch = createOrchestrator({ send });
+    expect(() => {
+      orch.start();
+      orch.stop();
+    }).not.toThrow();
+  });
+});

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -67,11 +67,6 @@ export default defineContentScript({
 
     const isMainFrame = window.top === window;
 
-    // ── 初始模式/样式 ──
-    applyMode(s.displayMode, s.paraDisplayMode);
-    applyStyle(s.style);
-    if (s.customCss) applyCustomCss(s.customCss);
-
     // ── 注入 UI（仅主文档）──
     if (isMainFrame) {
       // #242: 悬浮球经注册表启停；showFloatingBall 决定是否启动
@@ -79,7 +74,6 @@ export default defineContentScript({
         create: () => createBall({ onToggle: () => void togglePage() }),
         stop: (stopBall) => stopBall(),
       });
-      registry.ensure('ball', s.showFloatingBall);
 
       // #243: 段落按钮经注册表启停；showParagraphBtn 决定是否启动
       registry.register('para-btn', {
@@ -90,7 +84,6 @@ export default defineContentScript({
           }),
         stop: (stopParaBtn) => stopParaBtn(),
       });
-      registry.ensure('para-btn', s.showParagraphBtn);
     }
 
     // ── 快捷键（仅主文档，避免与 iframe 内输入冲突）──
@@ -148,20 +141,22 @@ export default defineContentScript({
       stop: (stopObserving) => stopObserving(),
     });
 
-    // ── 设置变更监听 ──
-    onSettingsChanged((ns: Settings) => {
+    // ── 设置变更统一入口（#265）──
+    // 初始化与设置变更共用：样式应用 + UI 启停（经注册表 ensure）。
+    // 订阅由编排模块持有（start 订阅 / stop 退订），此处只有一份
+    // 响应代码，无重复的创建 / 变更处理块。
+    function applySettings(ns: Settings): void {
       applyMode(ns.displayMode, ns.paraDisplayMode);
       applyStyle(ns.style);
       applyCustomCss(ns.customCss);
 
       if (isMainFrame) {
-        // #242: 悬浮球开关经注册表 ensure —— 启停幂等、即时生效
+        // #242/#243: 悬浮球 / 段落按钮开关经注册表 ensure —— 启停幂等、即时生效
         registry.ensure('ball', ns.showFloatingBall);
-
-        // #243: 段落按钮开关经注册表 ensure —— 启停幂等、即时生效
         registry.ensure('para-btn', ns.showParagraphBtn);
       }
-    });
+    }
+    applySettings(s);
 
     // ── 翻译全页 ──
     // #261/#262: 批次拆分 / 有界重试 / epoch 中止 / 渐进渲染全部收敛
@@ -188,6 +183,10 @@ export default defineContentScript({
     // 渲染回调按批触发（#256 渐进渲染，首屏不等最慢段）
     const orchestrator = createOrchestrator({
       send: translateViaBackground,
+      // #265: 设置变更订阅由模块持有（start 订阅 / stop 退订），
+      // 响应走统一入口 applySettings（初始化与变更共用）
+      subscribeSettings: onSettingsChanged,
+      onSettingsChange: (ns) => applySettings(ns as Settings),
       onBatchResult: (_i, batch, result) => {
         if (!result.ok || !result.data) return;
         const translations = result.data.translations;
@@ -213,7 +212,8 @@ export default defineContentScript({
         }
       },
     });
-    // #261: 启动编排 —— 未启动时翻译入口拒绝执行
+    // #261/#265: 启动编排 —— 未启动时翻译入口拒绝执行；设置变更
+    // 订阅随 start 建立
     orchestrator.start();
 
     async function doTranslate(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.34",
+  "version": "2.0.36",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/orchestration/orchestrator.ts
+++ b/src/orchestration/orchestrator.ts
@@ -89,6 +89,13 @@ export interface OrchestratorOptions {
     batch: TranslateItem<unknown>[],
     result: TranslateBatchResult,
   ) => void;
+  /**
+   * 设置变更订阅注入（#265）：content 传 storage 的 onSettingsChanged；
+   * 模块在 start 时订阅、stop 时退订。
+   */
+  subscribeSettings?: (fn: (s: unknown) => void) => () => void;
+  /** 设置变更响应（#265）：样式应用与 UI 启停由调用方实现（经注册表）。 */
+  onSettingsChange?: (s: unknown) => void;
 }
 
 /**
@@ -114,14 +121,25 @@ export function createOrchestrator(opts: OrchestratorOptions): TranslationOrches
   // #262: 还原纪元在模块内 —— abort() 递增，在飞翻译据此放弃
   // 尝试、重试与渲染；新翻译快照新纪元，不受旧批次干扰
   let epoch = 0;
+  // #265: 设置变更订阅（start 订阅 / stop 退订）
+  let unsubscribeSettings: (() => void) | null = null;
 
   return {
     start(): void {
       started = true;
+      // #265: 设置变更订阅由模块持有 —— content 不再各自订阅，
+      // 初始化与变更共用同一响应路径
+      if (!unsubscribeSettings && opts.subscribeSettings) {
+        unsubscribeSettings = opts.subscribeSettings((s) => {
+          opts.onSettingsChange?.(s);
+        });
+      }
     },
 
     stop(): void {
       started = false;
+      unsubscribeSettings?.();
+      unsubscribeSettings = null;
     },
 
     abort(): void {


### PR DESCRIPTION
## 问题

初始化的样式应用与设置变更回调各写一份（applyMode/applyStyle/applyCustomCss 两处），变更订阅散在 content——重复的创建 / 变更处理代码。

## 根因

没有统一入口，订阅未收敛。

## 修复

- `applySettings` 统一入口（样式应用 + UI 启停，UI 启停经注册表 ensure）——初始化与设置变更共用一份
- 设置变更订阅由编排模块持有（start 订阅 / stop 退订，subscribeSettings / onSettingsChange 注入），content 不再各自订阅
- 冗余的初始化 ensure 删除

## 验证

- 新增单测 2 项：start 订阅 / stop 退订 / 回调转发、未注入为空操作
- typecheck、全量 554 项单测、pnpm build 通过；本地 e2e core 32 项全绿