### PR TITLE
google-web 走公共判定与契约扩展 (fix #266)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.37",
+  "version": "2.0.38",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/google-web.ts
+++ b/src/engines/google-web.ts
@@ -5,6 +5,7 @@
 import { fetchWithTimeout } from './fetch-timeout';
 import { engineGate } from './engine-gate';
 import { EngineError } from './types';
+import { classifyStatus } from './shared';
 import type { TranslateEngine } from './types';
 
 const ENDPOINT = 'https://translate.googleapis.com/translate_a/single';
@@ -26,8 +27,9 @@ async function fetchOne(
 
   const resp = await fetchWithTimeout('google-web', `${ENDPOINT}?${qs}`);
   if (!resp.ok) {
-    // #251: 类型化类别 —— 免 key 引擎一律瞬时（可重试）
-    throw new EngineError('google-web', true, `HTTP ${resp.status}`, 'transient');
+    // #266: 分类走公共判定 —— 免 key 引擎一律瞬时（可重试）
+    const category = classifyStatus('google-web', resp, true);
+    throw new EngineError('google-web', true, `HTTP ${resp.status}`, category);
   }
 
   const data = await resp.json();
@@ -69,7 +71,8 @@ export const googleWeb: TranslateEngine = {
 
     // 全部失败 → 抛出让 router 整体切换到下一个引擎
     if (failedIndices.length === texts.length) {
-      throw new EngineError('google-web', true, `全部 ${texts.length} 条翻译失败`, 'transient');
+      const category = classifyStatus('google-web', { status: 500 }, true);
+      throw new EngineError('google-web', true, `全部 ${texts.length} 条翻译失败`, category);
     }
 
     return {


### PR DESCRIPTION
## 问题

google-web 的分类硬编码在适配器里，与公共判定（#239）并存——判定口径存在第二份。

## 根因

适配器未切换到公共模块。

## 修复

google-web 非 2xx 与全部失败分支改走 `classifyStatus`（免 key 引擎一律瞬时）；契约套件（#264）已覆盖五家引擎 × 状态码矩阵，扩展后全绿——五家经公共模块口径一致。

## 验证

- google-web HTTP 单测全绿（transient 断言不变），契约套件 5 项全绿
- typecheck 与全量 552 项单测通过