### PR TITLE
修复未翻译状态下自动出现译文 (fix #302)

### DIFF
--- a/docs/testing/e2e/core.spec.ts
+++ b/docs/testing/e2e/core.spec.ts
@@ -381,6 +381,23 @@ test.describe('Fixture: infinite', () => {
   });
 });
 
+test.describe('Fixture: auto-mutate', () => {
+  test('@core 无用户操作时不出现译文 —— 内容脚本启动时不得自动启动 observer', async ({
+    page, mockGoogle, seedSettings, gotoFixture,
+  }) => {
+    await seedSettings({});
+    await mockGoogle();
+    await gotoFixture('auto-mutate');
+
+    // 页面自身在 500ms 后自动插入段落（模拟 SPA 变更），
+    // 等待其落地 + observer 防抖窗口（300ms）+ 传输余量
+    await page.waitForTimeout(2500);
+
+    // 未点击任何翻译入口 —— 页面任何位置都不应出现译文标记
+    expect(await page.locator('[data-pt="done"]').count()).toBe(0);
+  });
+});
+
 test.describe('Fixture: spa', () => {
   test('@core TC-E2E-23: 路由切换后新内容可被发现', async ({
     page, mockGoogle, seedSettings, gotoFixture,

--- a/docs/testing/e2e/fixtures.ts
+++ b/docs/testing/e2e/fixtures.ts
@@ -18,6 +18,7 @@ const FIXTURES_BASE = 'http://localhost:4173';
 /** 所有 fixture 页面的文件名 */
 export const FIXTURES = [
   'basic',
+  'auto-mutate',
   'shadow',
   'custom-elements',
   'iframe',

--- a/docs/testing/e2e/fixtures/auto-mutate.html
+++ b/docs/testing/e2e/fixtures/auto-mutate.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Auto Mutate</title></head>
+<body>
+  <h1>Static heading that should NOT be translated without user action.</h1>
+  <p>Static paragraph one. This page must show no translations unless the user toggles.</p>
+  <script>
+    // 模拟 SPA：加载后 500ms 自动插入新段落（无任何用户操作）
+    setTimeout(() => {
+      const p = document.createElement('p');
+      p.id = 'late-paragraph';
+      p.textContent = 'Late appended paragraph — SPA mutation without user action.';
+      document.body.appendChild(p);
+    }, 500);
+  </script>
+</body>
+</html>

--- a/docs/testing/unit/ui/lifecycle-registry.test.ts
+++ b/docs/testing/unit/ui/lifecycle-registry.test.ts
@@ -1,8 +1,13 @@
 /**
  * ui/lifecycle-registry.ts — UI 生命周期注册表 单元测试（#235）
  *
- * 用假 create/stop 断言：启停成对、重复注册幂等、停止后不重复执行、
- * ensure 设置变更钩子幂等、dispose 全量停止。
+ * 用假 create/stop 断言：声明与实例化分离（register 不 create，
+ * 首次 ensure(true) 才创建）、启停成对、重复注册幂等、停止后不重复
+ * 执行、ensure 设置变更钩子幂等、dispose 全量停止。
+ *
+ * #267：register 声明即创建的语义会让副作用类生命周期（增量补翻
+ * observer 挂 MutationObserver）在内容脚本初始化时误启动 —— 本测试
+ * 钉死「register 后 create 未被调用」的契约。
  */
 import { describe, test, expect, vi } from 'vitest';
 import { createLifecycleRegistry } from '~/src/ui/lifecycle-registry';
@@ -23,15 +28,32 @@ function fakeLifecycle(id: string, log: string[]) {
   };
 }
 
-describe('register — 启停成对', () => {
-  test('register 立即 create，返回的停止函数触发对应 stop', () => {
+describe('register — 声明与实例化分离', () => {
+  test('register 不立即 create（#267 回归）；首次 ensure(true) 才创建', () => {
+    const log: string[] = [];
+    const lc = fakeLifecycle('observer', log);
+    const registry = createLifecycleRegistry();
+
+    registry.register('observer', lc);
+    // 声明后未启动 —— 副作用类生命周期不得因声明而误启动
+    expect(lc.create).not.toHaveBeenCalled();
+    expect(registry.isRunning('observer')).toBe(false);
+
+    registry.ensure('observer', true);
+    expect(lc.create).toHaveBeenCalledTimes(1);
+    expect(registry.isRunning('observer')).toBe(true);
+  });
+
+  test('register 返回的停止函数：停止实例并移除声明', () => {
     const log: string[] = [];
     const lc = fakeLifecycle('ball', log);
     const registry = createLifecycleRegistry();
 
     const stop = registry.register('ball', lc);
-    expect(lc.create).toHaveBeenCalledTimes(1);
-    expect(registry.isRunning('ball')).toBe(true);
+    expect(lc.create).not.toHaveBeenCalled();
+
+    registry.ensure('ball', true);
+    expect(log).toEqual(['create:ball']);
 
     stop();
     expect(log).toEqual(['create:ball', 'stop:ball']);
@@ -39,6 +61,9 @@ describe('register — 启停成对', () => {
     // 停止函数幂等：再次调用不重复执行 stop
     stop();
     expect(lc.stop).toHaveBeenCalledTimes(1);
+    // 声明已移除：ensure 不再复活
+    registry.ensure('ball', true);
+    expect(registry.isRunning('ball')).toBe(false);
   });
 
   test('unregister 停止并移除，未注册 id 为空操作', () => {
@@ -47,6 +72,7 @@ describe('register — 启停成对', () => {
     const registry = createLifecycleRegistry();
 
     registry.register('ball', lc);
+    registry.ensure('ball', true);
     registry.unregister('ball');
     expect(log).toEqual(['create:ball', 'stop:ball']);
     registry.unregister('ball'); // 空操作，不抛
@@ -62,13 +88,16 @@ describe('register — 重复注册幂等', () => {
     const registry = createLifecycleRegistry();
 
     registry.register('ball', lc1);
+    registry.ensure('ball', true);
     expect(registry.isRunning('ball')).toBe(true);
 
     registry.register('ball', lc2);
-    expect(log).toEqual(['create:a1', 'stop:a1', 'create:a2']);
-    expect(registry.isRunning('ball')).toBe(true);
+    expect(log).toEqual(['create:a1', 'stop:a1']);
+    expect(registry.isRunning('ball')).toBe(false); // 声明被替换，未重新创建
 
-    // 旧实例不会被二次停止
+    // 新声明经 ensure 启动 —— 旧实例不会被二次停止
+    registry.ensure('ball', true);
+    expect(log).toEqual(['create:a1', 'stop:a1', 'create:a2']);
     registry.unregister('ball');
     expect(log).toEqual(['create:a1', 'stop:a1', 'create:a2', 'stop:a2']);
   });
@@ -83,7 +112,7 @@ describe('ensure — 设置变更驱动的启停钩子', () => {
 
     registry.ensure('ball', true);
     registry.ensure('ball', true);
-    expect(lc.create).toHaveBeenCalledTimes(1); // 注册时一次，ensure 不再重复
+    expect(lc.create).toHaveBeenCalledTimes(1);
     expect(registry.isRunning('ball')).toBe(true);
   });
 
@@ -92,6 +121,14 @@ describe('ensure — 设置变更驱动的启停钩子', () => {
     const lc = fakeLifecycle('ball', log);
     const registry = createLifecycleRegistry();
     registry.register('ball', lc);
+
+    registry.ensure('ball', false);
+    expect(log).toEqual([]); // 未启动过 —— 停止为空操作
+    expect(registry.isRunning('ball')).toBe(false);
+
+    registry.ensure('ball', true);
+    expect(log).toEqual(['create:ball']);
+    expect(registry.isRunning('ball')).toBe(true);
 
     registry.ensure('ball', false);
     expect(log).toEqual(['create:ball', 'stop:ball']);
@@ -104,7 +141,6 @@ describe('ensure — 设置变更驱动的启停钩子', () => {
     // 重新启用 → 重新创建（启停成对）
     registry.ensure('ball', true);
     expect(log).toEqual(['create:ball', 'stop:ball', 'create:ball']);
-    expect(registry.isRunning('ball')).toBe(true);
   });
 
   test('未注册的 id：ensure 为空操作', () => {
@@ -121,6 +157,8 @@ describe('dispose', () => {
     const registry = createLifecycleRegistry();
     registry.register('ball', fakeLifecycle('ball', log));
     registry.register('para-btn', fakeLifecycle('para-btn', log));
+    registry.ensure('ball', true);
+    registry.ensure('para-btn', true);
 
     registry.dispose();
     expect(log).toEqual(['create:ball', 'create:para-btn', 'stop:ball', 'stop:para-btn']);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.38",
+  "version": "2.0.39",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/ui/lifecycle-registry.ts
+++ b/src/ui/lifecycle-registry.ts
@@ -51,10 +51,13 @@ export function createLifecycleRegistry(): LifecycleRegistry {
 
   const registry: LifecycleRegistry = {
     register<T>(id: string, lifecycle: RegistryLifecycle<T>): () => void {
-      // 重复注册幂等：旧实例先停止，同一 id 至多一个实例在跑
+      // 重复注册幂等：同一 id 至多一个实例在跑（旧实例先停止）
       stopInstance(id);
       decls.set(id, lifecycle as RegistryLifecycle<unknown>);
-      instances.set(id, lifecycle.create());
+      // 声明与实例化分离：实例由首次 ensure(true) 驱动创建 ——
+      // register 不立即 create。副作用类生命周期（如增量补翻 observer
+      // 挂 MutationObserver）若「声明即启动」，会在内容脚本初始化时
+      // 误启动，SPA 页面自身变更即触发自动翻译（在线直播页复现）。
       return () => registry.unregister(id);
     },
 


### PR DESCRIPTION
## 问题

未点击任何翻译入口，SPA 页面（如哔哩哔哩直播页）即出现译文——中文文本以「原文+灰色译文」双行呈现（zh→zh 译文逐字相同），数字行保持单行，悬浮球仍显示空闲「译」。

## 根因

生命周期注册表（#235）的 register 实现为「声明即创建」——注册时立即调用 create()。content 入口（#255）按此注册 observer，startObserver 在内容脚本初始化时就被执行，MutationObserver 已在监听 document.body；SPA 页面加载后的自身 DOM 变更命中 mutation 队列，防抖后 collect → doTranslate 直接渲染译文，绕过 toggle 流程——悬浮球状态只由 toggle 更新故保持空闲态；zh→zh 逐字译文形成双行重复，数字行被 isMainlyNumeric 跳过。静态 fixture 页面加载后无变更，observer 永不自触发，e2e 全绿掩盖了回归。

## 修复

注册表改为「声明与实例化分离」——register 只声明生命周期（重复注册幂等），实例创建推迟到首次 ensure(true)；副作用类生命周期不再因声明而误启动，悬浮球/段落按钮也不再注册时闪建再停。

## 验证

- 新增回归 e2e（加载后 500ms 自动插入段落的 fixture + 断言无用户操作时 [data-pt=done] 为 0）：修复前 3 次重试全部失败（收到 1 个译文标记），修复后通过
- 全量单测 560 项、e2e core 33 项（含还原在飞/快捷键/observer 增量回归）、e2e extended 9 项全绿