### PR TITLE
修复 shadow 内隐藏单元漏翻 (fix #317)

### DIFF
--- a/docs/testing/unit/dom/walker.test.ts
+++ b/docs/testing/unit/dom/walker.test.ts
@@ -261,3 +261,58 @@ describe('collect（#23：不可见单元 → onHidden）', () => {
     }
   });
 });
+
+describe('collect（#317：shadow 内隐藏单元漏翻）', () => {
+  beforeEach(() => {
+    setBody('');
+    mockedCompat.mockReset();
+    mockedCompat.mockReturnValue(null);
+  });
+
+  test('shadow root 内初次不可见的翻译单元被记入 onHidden', () => {
+    setBody('<div id="host"></div>');
+    const host = document.getElementById('host')!;
+    const shadow = host.attachShadow({ mode: 'open' });
+    shadow.innerHTML = '<p id="shadow-hid">shadow hidden text</p>';
+    mockAllBoundingRects();
+    mockBoundingRect(shadow.getElementById('shadow-hid')!, {
+      width: 0,
+      height: 0,
+    });
+
+    const onHidden = vi.fn();
+    const units = collect(document.body, onHidden);
+
+    expect(units).toHaveLength(0);
+    expect(onHidden).toHaveBeenCalledTimes(1);
+    expect(onHidden.mock.calls[0]![0]).toBe(
+      shadow.getElementById('shadow-hid'),
+    );
+  });
+
+  test('多层嵌套 shadow root 内的隐藏单元同样被记录', () => {
+    setBody('<div id="outer"></div>');
+    const outer = document.getElementById('outer')!;
+    const shadow1 = outer.attachShadow({ mode: 'open' });
+    shadow1.innerHTML = '<div id="inner-host"><p id="vis">visible text</p></div>';
+    const innerHost = shadow1.getElementById('inner-host')!;
+    const shadow2 = innerHost.attachShadow({ mode: 'open' });
+    shadow2.innerHTML = '<p id="deep-hid">deep hidden text</p>';
+    mockAllBoundingRects();
+    mockBoundingRect(shadow2.getElementById('deep-hid')!, {
+      width: 0,
+      height: 0,
+    });
+
+    const onHidden = vi.fn();
+    const units = collect(document.body, onHidden);
+
+    // 两层 shadow 内可见单元照常采集
+    expect(units.map((u) => u.id)).toEqual(['vis']);
+    // 第二层 shadow 内的隐藏单元也被记入 onHidden
+    expect(onHidden).toHaveBeenCalledTimes(1);
+    expect(onHidden.mock.calls[0]![0]).toBe(
+      shadow2.getElementById('deep-hid'),
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.39",
+  "version": "2.0.40",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/walker.ts
+++ b/src/dom/walker.ts
@@ -58,8 +58,10 @@ function walk(
       continue;
     }
 
-    // 关键：遇到 shadow host 就递归下沉。TreeWalker 自己不会做这件事
-    if (el.shadowRoot) walk(el.shadowRoot, out, seen);
+    // 关键：遇到 shadow host 就递归下沉。TreeWalker 自己不会做这件事。
+    // #317：onHidden 必须一并传递，否则 shadow 内初次不可见的翻译单元
+    // 不会被注册进可见性观察，展开后永久漏翻。
+    if (el.shadowRoot) walk(el.shadowRoot, out, seen, onHidden);
 
     // Phase 8 域名补丁：在通用判定之前给特定站点插入决策。
     // 补丁的 skip/take 优先于通用规则；null 则交回通用逻辑。


### PR DESCRIPTION
## 问题

shadow root 内初次不可见的翻译单元（如折叠内容）不会被注册进可见性观察，展开后永久漏翻。

## 根因

`collect` 递归下沉 shadowRoot 时漏传 `onHidden` 回调，shadow 内隐藏单元因此无法进入延迟补翻队列。

## 修复

递归调用 `walk(el.shadowRoot, ...)` 时补上 `onHidden` 传递，并新增单层与两层嵌套 shadow 的隐藏单元回归用例。

## 验证

`pnpm typecheck` 通过；`pnpm test` 562 个用例全部通过，其中新增 2 个用例在修复前失败、修复后通过；`pnpm test:e2e:core` 通过。

Closes #317
