### PR TITLE
shadow 折叠内容补翻端到端夹具 (fix #318)

### DIFF
--- a/docs/testing/e2e/core.spec.ts
+++ b/docs/testing/e2e/core.spec.ts
@@ -303,6 +303,45 @@ test.describe('Fixture: shadow', () => {
   });
 });
 
+test.describe('Fixture: shadow-collapse', () => {
+  test('@core TC-E2E-59: shadow 内折叠内容展开后自动补翻（#318 回归）', async ({
+    page, mockGoogle, seedSettings, gotoFixture,
+  }) => {
+    await seedSettings({});
+    await mockGoogle();
+    await gotoFixture('shadow-collapse');
+
+    await translateAndWait(page);
+
+    // 整页翻译后：折叠区内内容仍隐藏，尚未翻译
+    const before = await page.evaluate(() => {
+      const host = document.getElementById('host');
+      return host?.shadowRoot?.getElementById('hidden-content')?.getAttribute('data-pt') ?? null;
+    });
+    expect(before).toBeNull();
+
+    // 展开折叠区（移除 display:none —— 纯属性级操作，不产生 childList
+    // 记录，只能靠 IntersectionObserver 的隐藏单元注册链路触发补翻）
+    await page.evaluate(() => {
+      const host = document.getElementById('host');
+      const wrap = host?.shadowRoot?.getElementById('collapsible') as HTMLElement;
+      wrap.style.display = 'block';
+    });
+
+    // 自动补翻：shadow 内折叠内容出现译文标记
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const host = document.getElementById('host');
+            return host?.shadowRoot?.getElementById('hidden-content')?.getAttribute('data-pt') ?? null;
+          }),
+        { timeout: 15_000 },
+      )
+      .toBe('done');
+  });
+});
+
 test.describe('Fixture: nested', () => {
   test('@core TC-E2E-21: 嵌套元素不产生重复文本', async ({
     page, mockGoogle, seedSettings, gotoFixture,

--- a/docs/testing/e2e/fixtures.ts
+++ b/docs/testing/e2e/fixtures.ts
@@ -20,6 +20,7 @@ export const FIXTURES = [
   'basic',
   'auto-mutate',
   'shadow',
+  'shadow-collapse',
   'custom-elements',
   'iframe',
   'infinite',

--- a/docs/testing/e2e/fixtures/shadow-collapse.html
+++ b/docs/testing/e2e/fixtures/shadow-collapse.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Shadow Collapse — Hidden Content Re-translation</title>
+</head>
+<body>
+  <h1>Shadow Collapse Test Page</h1>
+  <p>This paragraph is in the light DOM and should be translated normally.</p>
+
+  <div id="host"></div>
+
+  <script>
+    // shadow root 内含一个初始隐藏的折叠区：初次整页翻译时其内容
+    // 不可见（0x0 rect），展开（移除 display:none，纯属性级操作）
+    // 后应被自动补翻（#317/#318 完整链路）
+    const host = document.getElementById('host');
+    const root = host.attachShadow({ mode: 'open' });
+    root.innerHTML =
+      '<p>Visible shadow paragraph.</p>' +
+      '<div id="collapsible" style="display:none">' +
+      '<p id="hidden-content">Initially hidden shadow content that needs translation.</p>' +
+      '</div>';
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.40",
+  "version": "2.0.41",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## 问题

shadow 内折叠内容展开后补翻的完整链路没有端到端覆盖，回归只能靠单测验证前半段。

## 根因

缺少一条覆盖「采集 → 隐藏单元注册 → IntersectionObserver → 展开触发补翻」全链路的夹具用例。

## 修复

新增 `shadow-collapse` 夹具页（shadow root 内含初始 display:none 的翻译单元），并新增 @core 用例 TC-E2E-59：整页翻译后移除 display:none，断言内容被自动补翻。

## 验证

该用例在 #317 修复前的 walker 下失败、修复后通过；`pnpm typecheck`、`pnpm test`（562 个）、`pnpm test:e2e:core`（34 个）全部通过。

Closes #318
