### PR TITLE
采集跳过决策整理为显式决策表 (fix #319)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.41",
+  "version": "2.0.42",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/walker.ts
+++ b/src/dom/walker.ts
@@ -6,10 +6,87 @@
 //
 // Phase 8 接入域名级采集补丁（src/dom/compat.ts），
 // 在通用规则判定之前给特定站点插入决策。
+//
+// #319：采集跳过决策表。每个跳过分支明确标注语义：
+//   - 整棵子树拒绝（reject-subtree）：不再访问该元素任何后代（含 shadowRoot）
+//   - 跳过自身继续子树（skip-self）：元素不入列，但子元素照常访问
+//
+// 判定顺序（不可颠倒）：
+//   1. 便宜的标签查表 —— pt-ui / SKIP_SET 在 acceptNode 里执行，
+//      FILTER_REJECT 让 TreeWalker 整体跳过子树（#319 分支 R1/R2）
+//   2. 逐元素判定（decideCollect）—— compat 补丁 → pre 切块 →
+//      翻译单元查表 → 非文本内容 → 非视觉跳过 → 可见性
+//      其中 shouldSkipNonVisual 要拼 outerHTML / 算 textContent、
+//      isVisible 取 getBoundingClientRect，都强制同步布局，必须排在
+//      便宜判定之后
 
-import { SKIP_SET, shouldSkipNonVisual, isVisible, isTranslationUnit, hasNonTextContent } from './classify';
+import {
+  SKIP_SET,
+  shouldSkipNonVisual,
+  isVisible,
+  isTranslationUnit,
+  hasNonTextContent,
+} from './classify';
 import { applyCompat } from './compat';
 import { splitPre } from './pre-split';
+
+/** 逐元素采集决策（#319 决策表）。 */
+type CollectDecision =
+  | { kind: 'take'; el: Element } // 域名补丁改指：直接收为单元，继续遍历
+  | { kind: 'collect' } // 采集当前元素
+  | { kind: 'skip-self' } // 跳过自身，继续访问子元素
+  | { kind: 'hidden'; el: Element }; // 不可见：记入 onHidden，跳过自身
+
+/**
+ * 便宜的标签查表 —— 整棵子树拒绝（#319 R1/R2）。
+ * 放在 acceptNode 里而非逐元素判定：FILTER_REJECT 让 TreeWalker
+ * 不进入被拒子树的 light DOM，也避免先访问子元素再逐层拒绝。
+ */
+function rejectSubtree(el: Element): boolean {
+  // R1 整棵子树拒绝：扩展自身 UI —— 且不下沉其 shadowRoot
+  if ((el as HTMLElement).dataset?.ptUi === '1') return true;
+  // R2 整棵子树拒绝：SKIP_SET（button/code/script 等）
+  if (SKIP_SET.has(el.tagName.toLowerCase())) return true;
+  return false;
+}
+
+/**
+ * 逐元素采集决策（#319 决策表）—— 判定顺序：
+ * 便宜的标签查表（翻译单元判定首步）在前，强制同步布局的
+ * shouldSkipNonVisual / isVisible 在后。
+ */
+function decideCollect(el: Element, seen: Set<Element>): CollectDecision {
+  // D1 域名补丁（skip 优先于通用判定）：跳过自身继续子树
+  const patched = applyCompat(el);
+  if (patched && 'skip' in patched) return { kind: 'skip-self' };
+  // D2 域名补丁（take）：改指收为单元，继续遍历
+  if (patched && 'take' in patched) return { kind: 'take', el: patched.take };
+
+  // D3 #65：超大纯文本 pre（如 GitHub README 的 .plain > pre）按空行切块，
+  // 块是独立翻译单元。切分是纯文本结构操作，无站点相关性；
+  // 代码块判定（isCodeBlockPre）是唯一站点相关部分（#64）。
+  // 切块在单元判定之前：pre 自身不是单元也要切，切出的 .pt-chunk 才入列。
+  if (el.tagName === 'PRE') splitPre(el as HTMLPreElement);
+
+  // D4 已采集去重 / 翻译单元查表（首步只是一次标签查表）：
+  // 非单元或已入列（compat take 收过）—— 跳过自身继续子树
+  if (seen.has(el) || !isTranslationUnit(el)) return { kind: 'skip-self' };
+
+  // D5 #50：含媒体/交互控件的容器不能整体翻译（render 会拒绝），
+  // 跳过自身继续子树 —— 其纯文本后代（不含非文本内容）仍可采集
+  if (hasNonTextContent(el)) return { kind: 'skip-self' };
+
+  // D6 非视觉跳过：notranslate / 已翻译单元自身（.pt-origin 内不重复翻）/
+  // 扩展 UI / 非正文区 / 文本长度。跳过自身继续子树 —— 已翻译单元内
+  // 新增的段落（原文容器之外）仍被采集（#179）
+  if (shouldSkipNonVisual(el)) return { kind: 'skip-self' };
+
+  // D7 #23：不可见翻译单元记入延迟队列，等 IntersectionObserver 补翻。
+  // 跳过自身继续子树
+  if (!isVisible(el)) return { kind: 'hidden', el };
+
+  return { kind: 'collect' };
+}
 
 /**
  * 采集可翻译节点。
@@ -33,16 +110,10 @@ function walk(
 ): void {
   const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, {
     acceptNode(node) {
-      const el = node as Element;
-
-      // 扩展自身 UI：整棵子树拒绝，且不下沉其 shadowRoot
-      if ((el as HTMLElement).dataset?.ptUi === '1')
-        return NodeFilter.FILTER_REJECT;
-
-      if (SKIP_SET.has(el.tagName.toLowerCase()))
-        return NodeFilter.FILTER_REJECT;
-
-      return NodeFilter.FILTER_ACCEPT;
+      // 便宜标签查表：整棵子树拒绝（#319 R1/R2）
+      return rejectSubtree(node as Element)
+        ? NodeFilter.FILTER_REJECT
+        : NodeFilter.FILTER_ACCEPT;
     },
   });
 
@@ -52,7 +123,7 @@ function walk(
 
     // TreeWalker.currentNode 初值是 root 本身，acceptNode 不作用于根节点。
     // 递归进入 shadowRoot 时 root 是 ShadowRoot（DocumentFragment，无 tagName），
-    // 必须跳过，否则 shouldSkip() 里 el.tagName.toLowerCase() 抛 TypeError。
+    // 必须跳过，否则 el.tagName.toLowerCase() 抛 TypeError。
     if (el.nodeType !== Node.ELEMENT_NODE) {
       node = walker.nextNode();
       continue;
@@ -63,58 +134,32 @@ function walk(
     // 不会被注册进可见性观察，展开后永久漏翻。
     if (el.shadowRoot) walk(el.shadowRoot, out, seen, onHidden);
 
-    // Phase 8 域名补丁：在通用判定之前给特定站点插入决策。
-    // 补丁的 skip/take 优先于通用规则；null 则交回通用逻辑。
-    //
+    // 逐元素判定（决策表见 decideCollect）：
     // Web Components（<relative-time>、<clipboard-copy> 等）上访问
     // textContent / outerHTML / closest() 可能抛出 DOMException，
-    // 用 try-catch 包裹整段逐元素判定，失败时安全跳过当前节点，
+    // 用 try-catch 包裹整段判定，失败时按「跳过自身继续子树」处理，
     // 宁可漏翻单个可疑节点也不要整页崩溃（#54）。
     try {
-      const patched = applyCompat(el);
-      if (patched && 'skip' in patched) {
-        node = walker.nextNode();
-        continue;
-      }
-      if (patched && 'take' in patched) {
-        if (!seen.has(el)) {
+      const decision = decideCollect(el, seen);
+      switch (decision.kind) {
+        case 'take':
+          if (!seen.has(decision.el)) {
+            seen.add(decision.el);
+            out.push(decision.el);
+          }
+          break;
+        case 'collect':
           seen.add(el);
-          out.push(patched.take);
-        }
-        node = walker.nextNode();
-        continue;
-      }
-
-      // #65：超大纯文本 pre（如 GitHub README 的 .plain > pre）按空行切块，
-      // 块是独立翻译单元。切分是纯文本结构操作，无站点相关性；
-      // 代码块判定（isCodeBlockPre）是唯一站点相关部分（#64）。
-      if (el.tagName === 'PRE') splitPre(el as HTMLPreElement);
-
-      // 判定顺序不能反：isTranslationUnit() 首步只是一次标签查表，而
-      // shouldSkipNonVisual() 要拼 outerHTML、算 textContent。先便宜后昂贵。
-      if (!seen.has(el) && isTranslationUnit(el)) {
-        // #50：含媒体/交互控件的容器不能整体翻译（render 会拒绝），
-        // 跳过但不影响子树 —— walker 依旧会访问其子元素，
-        // 它们可能是不含非文本内容的纯文本翻译单元。
-        if (hasNonTextContent(el)) {
-          node = walker.nextNode();
-          continue;
-        }
-        if (shouldSkipNonVisual(el)) {
-          node = walker.nextNode();
-          continue;
-        }
-        // #23：不可见的翻译单元记入延迟队列，等 IntersectionObserver 补翻
-        if (!isVisible(el)) {
-          onHidden?.(el);
-          node = walker.nextNode();
-          continue;
-        }
-        seen.add(el);
-        out.push(el);
+          out.push(el);
+          break;
+        case 'hidden':
+          onHidden?.(decision.el);
+          break;
+        case 'skip-self':
+          break;
       }
     } catch {
-      // Web Components 等节点上 DOM 属性访问可能抛异常，安全跳过
+      // 跳过自身继续子树（#54）
     }
     node = walker.nextNode();
   }


### PR DESCRIPTION
## 问题

采集器的跳过分支混用「整棵子树拒绝」与「跳过自身继续子树」两种语义，且没有标注，迁移到统一遍历模块时无法逐条核对映射关系。

## 根因

跳过逻辑散落在 acceptNode 与主循环里，分支语义靠读代码推断。

## 修复

抽出 `rejectSubtree`（整棵子树拒绝：pt-ui、SKIP_SET）与 `decideCollect`（逐元素决策表：compat 补丁、pre 切块、单元查表、非文本内容、非视觉跳过、可见性），每个分支标注语义，判定顺序保持「先便宜查表、后强制布局」不变。

## 验证

`pnpm typecheck` 通过；`pnpm test` 562 个用例全部通过（采集相关测试文件未修改）；`pnpm test:e2e:core` 34 个用例通过。

Closes #319
