### PR TITLE
引擎连通性探测入口 (fix #321)

### DIFF
--- a/docs/testing/unit/engines/probe-contract.test.ts
+++ b/docs/testing/unit/engines/probe-contract.test.ts
@@ -1,0 +1,172 @@
+/**
+ * engines — 探测入口与翻译路径同分类契约测试（#321）
+ *
+ * 探测入口（probeConnection）走与翻译路径同一份状态分类（#239），
+ * 契约：同一响应（状态码 + 错误体）× 同一引擎 → 两类路径产出同一失败类别。
+ *
+ * 表驱动覆盖 401 / 403 / 429 / 5xx 矩阵，以及 Gemini 的读错误体特例
+ * （400 + 错误体明示认证失败 → key 无效；400 + 模型名错误 → 瞬时）。
+ */
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import type { ProbeSpec } from '~/src/engines/shared';
+import { EngineError } from '~/src/engines/types';
+
+vi.mock('~/src/storage/keys', () => ({
+  getKey: vi.fn(),
+}));
+
+vi.mock('~/src/storage/settings', () => ({
+  getSettings: vi.fn(() => ({ maxConcurrency: 6, models: {} })),
+  onSettingsChanged: vi.fn(() => () => {}),
+}));
+
+const KEYED = ['openai', 'deepl', 'gemini'] as const;
+
+/** 引擎 id → 适配器导出的探测规格名。 */
+const PROBE_EXPORT: Record<string, string> = {
+  openai: 'openaiProbe',
+  deepl: 'deeplProbe',
+  gemini: 'geminiProbe',
+};
+
+/** keyed 类引擎的公共口径（#239）。 */
+const KEYED_EXPECTED: Record<number, string> = {
+  401: 'invalid-key',
+  403: 'invalid-key',
+  429: 'quota',
+  500: 'transient',
+  503: 'transient',
+};
+
+const STATUS_MATRIX = [401, 403, 429, 500, 503];
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** 驱动真实适配器走一遍 translate，返回失败类别（与 #264 同口径）。 */
+async function translateCategoryFor(
+  engineId: string,
+  status: number,
+  body?: string,
+): Promise<string> {
+  vi.resetModules();
+  const { getKey } = await import('~/src/storage/keys');
+  vi.mocked(getKey).mockResolvedValue('k');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(input);
+      if (url.includes('edge.microsoft.com/translate/auth')) {
+        return new Response('jwt-token', { status: 200 });
+      }
+      return new Response(body ?? 'err', { status });
+    }),
+  );
+  const { openai } = await import('~/src/engines/openai');
+  const { deepl } = await import('~/src/engines/deepl');
+  const { gemini } = await import('~/src/engines/gemini');
+  const engine = { openai, deepl, gemini }[engineId]!;
+  try {
+    await engine.translate({ texts: ['a'], from: 'auto', to: 'zh' });
+    return 'no-error';
+  } catch (e) {
+    return (e as EngineError).category;
+  }
+}
+
+/** 驱动探测入口，返回失败类别（或 'ok'）。 */
+async function probeCategoryFor(
+  engineId: string,
+  status: number,
+  body?: string,
+): Promise<string> {
+  vi.resetModules();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response(body ?? 'err', { status })),
+  );
+  const { probeConnection } = await import('~/src/engines/shared');
+  const mod = (await import(`~/src/engines/${engineId}`)) as Record<
+    string,
+    ProbeSpec
+  >;
+  const spec = mod[PROBE_EXPORT[engineId]!]!;
+  const result = await probeConnection(spec, { key: 'k' });
+  return result.ok ? 'ok' : result.category;
+}
+
+describe('探测入口 × 翻译路径 同分类契约（#321）', () => {
+  for (const status of STATUS_MATRIX) {
+    test(`状态码 ${status}：三家自带 key 引擎的探测与翻译路径分类一致`, async () => {
+      for (const id of KEYED) {
+        const translate = await translateCategoryFor(id, status);
+        const probe = await probeCategoryFor(id, status);
+        expect(translate, `${id} 翻译路径在 ${status} 上的分类`).toBe(
+          KEYED_EXPECTED[status],
+        );
+        expect(probe, `${id} 探测入口在 ${status} 上的分类`).toBe(
+          KEYED_EXPECTED[status],
+        );
+      }
+    });
+  }
+
+  test('gemini 400 + 错误体明示认证失败：探测与翻译路径都归为 key 无效', async () => {
+    const body = JSON.stringify({
+      error: { code: 400, message: 'API key not valid.', status: 'INVALID_ARGUMENT' },
+    });
+    const translate = await translateCategoryFor('gemini', 400, body);
+    const probe = await probeCategoryFor('gemini', 400, body);
+    expect(translate).toBe('invalid-key');
+    expect(probe).toBe('invalid-key');
+  });
+
+  test('gemini 400 + 模型名错误错误体：探测与翻译路径都归为瞬时', async () => {
+    const body = JSON.stringify({
+      error: { code: 400, message: 'models/wrong-model is not found', status: 'NOT_FOUND' },
+    });
+    const translate = await translateCategoryFor('gemini', 400, body);
+    const probe = await probeCategoryFor('gemini', 400, body);
+    expect(translate).toBe('transient');
+    expect(probe).toBe('transient');
+  });
+});
+
+describe('探测入口契约（#321）', () => {
+  test('凭据以请求头传递，不进查询串', async () => {
+    vi.resetModules();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { probeConnection } = await import('~/src/engines/shared');
+    const { openaiProbe } = await import('~/src/engines/openai');
+
+    const result = await probeConnection(openaiProbe, { key: 'sk-test' });
+
+    expect(result).toEqual({ ok: true, message: '连接成功' });
+    const [url, init] = fetchMock.mock.calls[0]! as [string, RequestInit];
+    expect(url).not.toContain('sk-test');
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      'Bearer sk-test',
+    );
+  });
+
+  test('网络 / 超时归为瞬时，不产生任何存储写入', async () => {
+    vi.resetModules();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new TypeError('Failed to fetch')),
+    );
+    const { probeConnection } = await import('~/src/engines/shared');
+    const { deeplProbe } = await import('~/src/engines/deepl');
+
+    const result = await probeConnection(deeplProbe, { key: 'k' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.category).toBe('transient');
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.43",
+  "version": "2.0.44",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/deepl.ts
+++ b/src/engines/deepl.ts
@@ -7,6 +7,7 @@ import { fetchWithTimeout } from './fetch-timeout';
 import { engineGate } from './engine-gate';
 import { EngineError } from './types';
 import { classifyStatus } from './shared';
+import type { ProbeSpec } from './shared';
 import type { TranslateEngine } from './types';
 
 // #159: 引擎级并发闸门 —— 整页翻译批次并发 → translate() 并发调用
@@ -18,6 +19,15 @@ function endpointFor(key: string): string {
     ? 'https://api-free.deepl.com/v2/translate'
     : 'https://api.deepl.com/v2/translate';
 }
+
+/** 连通性探测规格（#321）：GET /v2/usage，免费版与专业版端点区分不变。 */
+export const deeplProbe: ProbeSpec = {
+  engineId: 'deepl',
+  buildRequest: ({ key }) => ({
+    url: endpointFor(key).replace('/v2/translate', '/v2/usage'),
+    headers: { Authorization: `DeepL-Auth-Key ${key}` },
+  }),
+};
 
 export const deepl: TranslateEngine = {
   id: 'deepl',

--- a/src/engines/gemini.ts
+++ b/src/engines/gemini.ts
@@ -7,9 +7,14 @@ import { DEFAULT_MODELS } from '~/src/storage/schema';
 import { fetchWithTimeout } from './fetch-timeout';
 import { engineGate } from './engine-gate';
 import { EngineError } from './types';
-import { classifyStatus, buildNumberedPrompt } from './shared';
-import { parseNumbered } from './openai';
+import {
+  classifyStatus,
+  buildNumberedPrompt,
+  type ProbeResult,
+  type ProbeSpec,
+} from './shared';
 import type { TranslateEngine } from './types';
+import { parseNumbered } from './openai';
 
 // #159: 引擎级并发闸门 —— 整页翻译批次并发 → translate() 并发调用
 const getGate = engineGate();
@@ -63,6 +68,43 @@ async function classifyError(resp: Response): Promise<EngineError> {
   const detail = message ? `：${message}` : '';
   return new EngineError('gemini', true, `HTTP ${resp.status}${detail}`, 'transient');
 }
+
+/** 连通性探测规格（#321）：GET /v1beta/models/{model}，凭据走请求头。 */
+export const geminiProbe: ProbeSpec = {
+  engineId: 'gemini',
+  buildRequest: ({ key, model }) => ({
+    url:
+      'https://generativelanguage.googleapis.com/v1beta/models/' +
+      (model ?? DEFAULT_MODELS.gemini),
+    headers: { 'x-goog-api-key': key },
+  }),
+  // 引擎特例（#321/#257 保留在适配器内）：Gemini 的 400 覆盖多种情况，
+  // 只有错误体明示认证失败才是 key 问题；模型名错误 / 内容过长等其余
+  // 情况交回公共状态码分类（瞬时）。
+  classifyError: async (resp): Promise<ProbeResult | null> => {
+    let status = '';
+    let message = '';
+    try {
+      const body = (await resp.json()) as {
+        error?: { status?: string; message?: string };
+      };
+      status = body.error?.status ?? '';
+      message = body.error?.message ?? '';
+    } catch {
+      // 非 JSON 错误体，交回公共状态码分类
+      return null;
+    }
+    const isAuthByBody =
+      status === 'UNAUTHENTICATED' ||
+      status === 'PERMISSION_DENIED' ||
+      /API key/i.test(message) ||
+      /API_KEY_INVALID/i.test(message);
+    if (isAuthByBody) {
+      return { ok: false, category: 'invalid-key', message: 'API key 无效' };
+    }
+    return null;
+  },
+};
 
 export const gemini: TranslateEngine = {
   id: 'gemini',

--- a/src/engines/openai.ts
+++ b/src/engines/openai.ts
@@ -9,12 +9,22 @@ import { fetchWithTimeout } from './fetch-timeout';
 import { engineGate } from './engine-gate';
 import { EngineError } from './types';
 import { classifyStatus, buildNumberedPrompt } from './shared';
+import type { ProbeSpec } from './shared';
 import type { TranslateEngine } from './types';
 
 const DEFAULT_ENDPOINT = 'https://api.openai.com/v1/chat/completions';
 
 // #159: 引擎级并发闸门 —— 整页翻译批次并发 → translate() 并发调用
 const getGate = engineGate();
+
+/** 连通性探测规格（#321）：GET /v1/models，凭据走请求头。 */
+export const openaiProbe: ProbeSpec = {
+  engineId: 'openai',
+  buildRequest: ({ key }) => ({
+    url: 'https://api.openai.com/v1/models',
+    headers: { Authorization: `Bearer ${key}` },
+  }),
+};
 
 /**
  * 解析 LLM 编号输出为译文数组。

--- a/src/engines/shared.ts
+++ b/src/engines/shared.ts
@@ -10,6 +10,7 @@
 
 import type { FailureCategory } from './types';
 import { normalizeText } from '~/src/dom/normalize';
+import { fetchWithTimeout } from './fetch-timeout';
 
 /** 自带 key 的引擎 —— 401/403 才可能意味着「key 无效」。 */
 const KEYED_ENGINES: ReadonlySet<string> = new Set(['openai', 'deepl', 'gemini']);
@@ -63,4 +64,85 @@ export function buildNumberedPrompt(
     `将以下编号文本翻译成${to}${from === 'auto' ? '' : `（源语言：${from}）`}。` +
     `严格保持编号与行数一致，只输出译文，不要解释。\n\n${numbered}`
   );
+}
+
+// ── 连通性探测入口（#321）──
+
+/**
+ * 连通性探测结果 —— 与翻译路径同一份状态分类（#321）。
+ * ok=false 时携带失败类别与展示文案，调用方按类别决定提示语义。
+ */
+export type ProbeResult =
+  | { ok: true; message: string }
+  | { ok: false; category: FailureCategory; message: string };
+
+/**
+ * 适配器提供的探测规格（#321）：端点、凭据传递方式与特例分类。
+ * 公共骨架只做「构造请求 → 发送 → 公共状态分类」，引擎特例
+ * （需要读错误响应体才能定类别的那家）由适配器在 classifyError
+ * 中提供，不复制进公共模块。
+ */
+export interface ProbeSpec {
+  engineId: string;
+  /**
+   * 构造最小探测请求。凭据一律走请求头，不进查询串 ——
+   * URL 会进浏览器网络日志、DevTools 记录与任何中间层的访问日志。
+   * model 仅在引擎有模型概念时传入（openai / gemini）。
+   */
+  buildRequest(ctx: { key: string; model?: string }): {
+    url: string;
+    headers: Record<string, string>;
+    method?: 'GET' | 'POST';
+    body?: string;
+  };
+  /**
+   * 特例分类：适配器读取错误响应体后才能定类别时提供（如 Gemini）。
+   * 返回 null 表示无特例意见，交回公共状态码分类（#239）。
+   */
+  classifyError?: (resp: Response) => Promise<ProbeResult | null>;
+}
+
+/** 公共分类的展示文案 —— 与翻译路径的错误文案同口径（#321）。 */
+function probeMessage(category: FailureCategory, status: number): string {
+  if (category === 'invalid-key') return 'API key 无效';
+  if (category === 'quota') return '配额已用尽';
+  return `HTTP ${status}`;
+}
+
+/**
+ * 连通性探测入口（#321）：接受引擎标识与待测 key（+ 可选模型名），
+ * 走与翻译路径同一份状态分类，返回同构的类型化结果。
+ * 纯查询：不产生任何存储写入，key 由调用方显式传入。
+ */
+export async function probeConnection(
+  spec: ProbeSpec,
+  ctx: { key: string; model?: string },
+): Promise<ProbeResult> {
+  const { url, headers, method = 'GET', body } = spec.buildRequest(ctx);
+
+  let resp: Response;
+  try {
+    resp = await fetchWithTimeout(spec.engineId, url, {
+      method,
+      headers,
+      ...(body ? { body } : {}),
+    });
+  } catch (e) {
+    // 网络 / 超时 → 瞬时（与翻译路径同一口径）
+    return {
+      ok: false,
+      category: 'transient',
+      message: e instanceof Error ? e.message : String(e),
+    };
+  }
+
+  if (resp.ok) return { ok: true, message: '连接成功' };
+
+  // 适配器特例优先（读错误体定类别）；无特例则走公共状态码分类
+  if (spec.classifyError) {
+    const special = await spec.classifyError(resp);
+    if (special) return special;
+  }
+  const category = classifyStatus(spec.engineId, resp, true);
+  return { ok: false, category, message: probeMessage(category, resp.status) };
 }


### PR DESCRIPTION
## 问题

设置页各引擎的测试连接自行判断 HTTP 状态码，OpenAI 只认 401、DeepL 只认 403，另一状态码被显示成裸 HTTP 错误码。

## 根因

缺少统一的连通性探测入口，状态分类逻辑没有与翻译路径共用。

## 修复

在引擎公共模块新增 `probeConnection` 入口：接受引擎标识与待测 key（+ 可选模型名），走与翻译路径同一份 `classifyStatus` 分类，返回同构类型化结果；各适配器导出探测规格（端点、凭据走请求头），Gemini 读错误体特例保留在适配器内；入口为纯查询，不产生任何存储写入。

## 验证

`pnpm typecheck` 通过；新增探测契约测试 9 个（状态码矩阵 × 三引擎的探测/翻译同分类、Gemini 错误体特例、凭据不进查询串、网络错误归瞬时），`pnpm test` 571 个用例全部通过。

Closes #321
