### PR TITLE
openai 与 deepl 测试连接走探测入口 (fix #322)

### DIFF
--- a/docs/testing/unit/engines/test-connection.test.ts
+++ b/docs/testing/unit/engines/test-connection.test.ts
@@ -1,0 +1,112 @@
+/**
+ * engines/test-connection.ts — 设置页测试连接单测（#322）
+ *
+ * openai / deepl 的测试连接统一走探测入口后：
+ * - 401 与 403 在两家引擎上都被报告为 key 问题（此前 openai 只查 401、
+ *   deepl 只查 403，另一个状态码被显示成裸 HTTP 错误码）
+ * - 429 被报告为配额问题
+ * - 成功 / 其余非 2xx 保持既有文案形态
+ * - DeepL 免费版（:fx）与专业版端点区分不变
+ */
+import { describe, test, expect, vi, afterEach, beforeEach } from 'vitest';
+import { testConnection } from '~/src/engines/test-connection';
+
+vi.mock('~/src/storage/keys', () => ({
+  getKey: vi.fn(),
+}));
+
+vi.mock('~/src/storage/settings', () => ({
+  getSettings: vi.fn(() => ({ maxConcurrency: 6, models: {} })),
+  onSettingsChanged: vi.fn(() => () => {}),
+}));
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn(async () => new Response('ok', { status: 200 }));
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** 让下一个探测请求返回指定状态码。 */
+function respond(status: number, body?: string): void {
+  fetchMock.mockResolvedValue(new Response(body ?? 'err', { status }));
+}
+
+describe('testConnection（openai / deepl，#322）', () => {
+  test('openai 401 与 403 都报告为 key 问题', async () => {
+    for (const status of [401, 403]) {
+      respond(status);
+      const result = await testConnection('openai', 'sk-test');
+      expect(result.ok).toBe(false);
+      expect(result.msg).toBe('API key 无效');
+    }
+  });
+
+  test('deepl 401 与 403 都报告为 key 问题', async () => {
+    for (const status of [401, 403]) {
+      respond(status);
+      const result = await testConnection('deepl', 'k');
+      expect(result.ok).toBe(false);
+      expect(result.msg).toBe('API key 无效');
+    }
+  });
+
+  test('openai 与 deepl 的 429 都报告为配额问题', async () => {
+    for (const engine of ['openai', 'deepl'] as const) {
+      respond(429);
+      const result = await testConnection(engine, 'k');
+      expect(result.ok).toBe(false);
+      expect(result.msg).toBe('配额已用尽');
+    }
+  });
+
+  test('5xx 报告为裸 HTTP 错误码（瞬时）', async () => {
+    respond(503);
+    const result = await testConnection('openai', 'sk-test');
+    expect(result.ok).toBe(false);
+    expect(result.msg).toBe('HTTP 503');
+  });
+
+  test('连接成功返回 ok 且文案为连接成功', async () => {
+    respond(200);
+    const result = await testConnection('openai', 'sk-test');
+    expect(result.ok).toBe(true);
+    expect(result.msg).toBe('连接成功');
+  });
+
+  test('凭据以请求头传递，不进查询串', async () => {
+    respond(200);
+    await testConnection('openai', 'sk-test');
+    const [url, init] = fetchMock.mock.calls[0]! as [string, RequestInit];
+    expect(String(url)).not.toContain('sk-test');
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      'Bearer sk-test',
+    );
+  });
+
+  test('DeepL 免费版 key（:fx 结尾）走 free 端点，专业版走正式端点', async () => {
+    respond(200);
+    await testConnection('deepl', 'k:fx');
+    expect(String(fetchMock.mock.calls[0]![0])).toBe(
+      'https://api-free.deepl.com/v2/usage',
+    );
+
+    respond(200);
+    await testConnection('deepl', 'k');
+    expect(String(fetchMock.mock.calls[1]![0])).toBe(
+      'https://api.deepl.com/v2/usage',
+    );
+  });
+
+  test('网络错误报告为瞬时故障', async () => {
+    fetchMock.mockRejectedValue(new TypeError('Failed to fetch'));
+    const result = await testConnection('deepl', 'k');
+    expect(result.ok).toBe(false);
+    expect(result.msg).not.toBe('API key 无效');
+    expect(result.msg).not.toMatch(/^HTTP /);
+  });
+});

--- a/entrypoints/options/sections/engines.ts
+++ b/entrypoints/options/sections/engines.ts
@@ -8,6 +8,7 @@ import {
   onSettingsChanged,
 } from '~/src/storage/settings';
 import { getKey, setKey, removeKey } from '~/src/storage/keys';
+import { testConnection } from '~/src/engines/test-connection';
 import { tf } from '~/src/i18n';
 import { showToast } from '../main';
 
@@ -38,56 +39,33 @@ const BYOK_FALLBACK_DESC: Record<string, string> = {
 };
 
 // ---- Test connection ----
+//
+// #322：openai / deepl 的测试连接统一走探测入口（src/engines/test-connection.ts），
+// 状态分类与翻译路径同一份口径 —— 401/403 → key 问题、429 → 配额、
+// 其余非 2xx → 瞬时。gemini 仍走旧路径，见 #323。
 
-async function testConnection(
+async function runTest(
   engine: EngineId,
   key: string,
 ): Promise<{ ok: boolean; msg: string }> {
+  if (engine === 'openai' || engine === 'deepl') {
+    return testConnection(engine, key);
+  }
+  // gemini 旧路径（#323 接入探测入口）
   try {
-    if (engine === 'openai') {
-      const resp = await fetch('https://api.openai.com/v1/models', {
-        headers: { Authorization: `Bearer ${key}` },
-      });
-      if (resp.ok) return { ok: true, msg: tf('testOk', '连接成功') };
-      if (resp.status === 401)
-        return { ok: false, msg: tf('keyInvalid', 'API key 无效') };
-      return { ok: false, msg: `HTTP ${resp.status}` };
-    }
-    if (engine === 'deepl') {
-      const endpoint = key.endsWith(':fx')
-        ? 'https://api-free.deepl.com/v2/usage'
-        : 'https://api.deepl.com/v2/usage';
-      const resp = await fetch(endpoint, {
-        headers: { Authorization: `DeepL-Auth-Key ${key}` },
-      });
-      if (resp.ok) {
-        const data = await resp.json();
-        const count = String(data.character_count ?? '?');
-        return {
-          ok: true,
-          msg: tf('testOkUsage', `连接成功（已用 ${count} 字符）`, count),
-        };
-      }
-      if (resp.status === 403)
-        return { ok: false, msg: tf('keyInvalid', 'API key 无效') };
-      return { ok: false, msg: `HTTP ${resp.status}` };
-    }
-    if (engine === 'gemini') {
-      const model = getSettings().models?.gemini ?? 'gemini-2.0-flash';
-      // key 走请求头而非 query —— URL 会进浏览器网络日志与各级访问日志，请求头不会
-      const resp = await fetch(
-        `https://generativelanguage.googleapis.com/v1beta/models/${model}`,
-        { headers: { 'x-goog-api-key': key } },
-      );
-      if (resp.ok) return { ok: true, msg: tf('testOk', '连接成功') };
-      const data = await resp.json().catch(() => null);
-      const errMsg = data?.error?.message ?? `HTTP ${resp.status}`;
-      return {
-        ok: false,
-        msg: `${tf('keyInvalid', 'API key 无效')}：${errMsg}`,
-      };
-    }
-    return { ok: false, msg: `HTTP 0` };
+    const model = getSettings().models?.gemini ?? 'gemini-2.0-flash';
+    // key 走请求头而非 query —— URL 会进浏览器网络日志与各级访问日志，请求头不会
+    const resp = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/${model}`,
+      { headers: { 'x-goog-api-key': key } },
+    );
+    if (resp.ok) return { ok: true, msg: tf('testOk', '连接成功') };
+    const data = await resp.json().catch(() => null);
+    const errMsg = data?.error?.message ?? `HTTP ${resp.status}`;
+    return {
+      ok: false,
+      msg: `${tf('keyInvalid', 'API key 无效')}：${errMsg}`,
+    };
   } catch (e) {
     return { ok: false, msg: tf('netError', `网络错误：${e}`, String(e)) };
   }
@@ -273,7 +251,7 @@ export function initEngines(): void {
         }
         resultEl.className = 'pt-key-result';
         resultEl.textContent = tf('testing', '测试中…');
-        const result = await testConnection(id, key);
+        const result = await runTest(id, key);
         resultEl.className = `pt-key-result ${result.ok ? 'pt-success' : 'pt-fail'}`;
         resultEl.textContent = result.msg;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.44",
+  "version": "2.0.45",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/test-connection.ts
+++ b/src/engines/test-connection.ts
@@ -1,0 +1,30 @@
+// 设置页测试连接 —— 统一走探测入口（#322）。
+//
+// 此前 openai 只查 401、deepl 只查 403，另一状态码会被显示成裸的
+// HTTP 错误码；这里把两家引擎的测试连接收敛到公共探测入口
+// probeConnection（#321），状态分类与翻译路径同一份口径：
+// 401/403 → key 问题、429 → 配额、其余非 2xx → 瞬时。
+// 本模块不持有任何 UI 依赖，可独立单测。
+
+import { probeConnection } from './shared';
+import { openaiProbe } from './openai';
+import { deeplProbe } from './deepl';
+
+/** 已接入探测入口的自带 key 引擎（gemini 见 #323）。 */
+export type TestableKeyedEngine = 'openai' | 'deepl';
+
+/** 测试连接结果 —— ok 与展示文案（文案已按失败类别区分）。 */
+export interface TestConnectionResult {
+  ok: boolean;
+  msg: string;
+}
+
+/** 测试连接：构造最小请求 → 探测入口分类 → 返回结果（不写存储）。 */
+export async function testConnection(
+  engine: TestableKeyedEngine,
+  key: string,
+): Promise<TestConnectionResult> {
+  const spec = engine === 'openai' ? openaiProbe : deeplProbe;
+  const result = await probeConnection(spec, { key });
+  return { ok: result.ok, msg: result.message };
+}


### PR DESCRIPTION
## 问题

OpenAI 测试连接只查 401、DeepL 只查 403，另一个状态码被显示成裸 HTTP 错误码。

## 根因

两家引擎的测试连接各自自建状态码判定，没有走统一分类。

## 修复

openai / deepl 测试连接改走公共探测入口（#321）：401 与 403 均报告为 key 问题、429 报告为配额问题；删除设置页自建的状态码判定，DeepL 免费版/专业版端点区分保留在探测规格中。

## 验证

`pnpm typecheck` 通过；新增 8 个测试连接单测（401/403/429/5xx/成功/凭据头传递/free 端点/网络错误），`pnpm test` 579 个用例全部通过；`pnpm build` 正常。

Closes #322
