### PR TITLE
gemini 测试连接走探测入口 (fix #323)

### DIFF
--- a/docs/testing/unit/engines/test-connection.test.ts
+++ b/docs/testing/unit/engines/test-connection.test.ts
@@ -110,3 +110,90 @@ describe('testConnection（openai / deepl，#322）', () => {
     expect(result.msg).not.toMatch(/^HTTP /);
   });
 });
+
+describe('testConnection（gemini，#323）', () => {
+  test('模型名填错时报告模型名问题而非 key 问题（修复前失败）', async () => {
+    respond(
+      400,
+      JSON.stringify({
+        error: { code: 400, message: 'models/wrong-model is not found', status: 'NOT_FOUND' },
+      }),
+    );
+    const result = await testConnection('gemini', 'k', 'wrong-model');
+    expect(result.ok).toBe(false);
+    // 不是 key 问题：文案不得以「API key 无效」开头
+    expect(result.msg).not.toMatch(/^API key 无效/);
+    // 报告真实原因：包含模型名信息
+    expect(result.msg).toContain('wrong-model');
+  });
+
+  test('key 确实失效（401）时报告 key 问题', async () => {
+    respond(401);
+    const result = await testConnection('gemini', 'k');
+    expect(result.ok).toBe(false);
+    expect(result.msg).toBe('API key 无效');
+  });
+
+  test('错误体明示认证失败（400）时报告 key 问题', async () => {
+    respond(
+      400,
+      JSON.stringify({
+        error: { code: 400, message: 'API key not valid.', status: 'INVALID_ARGUMENT' },
+      }),
+    );
+    const result = await testConnection('gemini', 'k');
+    expect(result.ok).toBe(false);
+    expect(result.msg).toBe('API key 无效');
+  });
+
+  test('配额耗尽报告为配额问题', async () => {
+    respond(
+      429,
+      JSON.stringify({ error: { code: 429, message: 'quota exceeded', status: 'RESOURCE_EXHAUSTED' } }),
+    );
+    const result = await testConnection('gemini', 'k');
+    expect(result.ok).toBe(false);
+    expect(result.msg).toBe('配额已用尽');
+  });
+
+  test('服务端瞬时故障报告为可重试而非 key 问题', async () => {
+    respond(503);
+    const result = await testConnection('gemini', 'k');
+    expect(result.ok).toBe(false);
+    expect(result.msg).toBe('HTTP 503');
+  });
+
+  test('探测结论与实际翻译对同一响应一致（400 认证体：两者都归 key 无效）', async () => {
+    const body = JSON.stringify({
+      error: { code: 400, message: 'API key not valid.', status: 'INVALID_ARGUMENT' },
+    });
+    // 每次调用新建 Response —— 响应体只能消费一次，探测与翻译各拿一份
+    fetchMock.mockImplementation(async () => new Response(body, { status: 400 }));
+    const probe = await testConnection('gemini', 'k');
+
+    // 同一响应驱动真实翻译路径
+    const { getKey } = await import('~/src/storage/keys');
+    vi.mocked(getKey).mockResolvedValue('k');
+    const { gemini } = await import('~/src/engines/gemini');
+    let translateCategory = '';
+    try {
+      await gemini.translate({ texts: ['a'], from: 'auto', to: 'zh' });
+    } catch (e) {
+      translateCategory = (e as { category: string }).category;
+    }
+    expect(translateCategory).toBe('invalid-key');
+    expect(probe.ok).toBe(false);
+    if (!probe.ok) expect(probe.msg).toBe('API key 无效');
+  });
+
+  test('探测请求带模型名且 key 走请求头不进查询串', async () => {
+    respond(200);
+    await testConnection('gemini', 'k', 'gemini-2.0-flash');
+    const [url, init] = fetchMock.mock.calls[0]! as [string, RequestInit];
+    expect(String(url)).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash',
+    );
+    expect(String(url)).not.toContain('k');
+    expect((init.headers as Record<string, string>)['x-goog-api-key']).toBe('k');
+  });
+});

--- a/entrypoints/options/sections/engines.ts
+++ b/entrypoints/options/sections/engines.ts
@@ -40,35 +40,22 @@ const BYOK_FALLBACK_DESC: Record<string, string> = {
 
 // ---- Test connection ----
 //
-// #322：openai / deepl 的测试连接统一走探测入口（src/engines/test-connection.ts），
-// 状态分类与翻译路径同一份口径 —— 401/403 → key 问题、429 → 配额、
-// 其余非 2xx → 瞬时。gemini 仍走旧路径，见 #323。
+// #322/#323：三家 BYOK 引擎的测试连接统一走探测入口
+// （src/engines/test-connection.ts），状态分类与翻译路径同一份口径
+// —— 401/403 → key 问题、429 → 配额、其余非 2xx → 瞬时（带真实原因）。
 
 async function runTest(
   engine: EngineId,
   key: string,
 ): Promise<{ ok: boolean; msg: string }> {
-  if (engine === 'openai' || engine === 'deepl') {
-    return testConnection(engine, key);
+  // 仅三家 BYOK 引擎有测试连接按钮；其余引擎走到这里视为不可达
+  if (engine !== 'openai' && engine !== 'deepl' && engine !== 'gemini') {
+    return { ok: false, msg: `HTTP 0` };
   }
-  // gemini 旧路径（#323 接入探测入口）
-  try {
-    const model = getSettings().models?.gemini ?? 'gemini-2.0-flash';
-    // key 走请求头而非 query —— URL 会进浏览器网络日志与各级访问日志，请求头不会
-    const resp = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/${model}`,
-      { headers: { 'x-goog-api-key': key } },
-    );
-    if (resp.ok) return { ok: true, msg: tf('testOk', '连接成功') };
-    const data = await resp.json().catch(() => null);
-    const errMsg = data?.error?.message ?? `HTTP ${resp.status}`;
-    return {
-      ok: false,
-      msg: `${tf('keyInvalid', 'API key 无效')}：${errMsg}`,
-    };
-  } catch (e) {
-    return { ok: false, msg: tf('netError', `网络错误：${e}`, String(e)) };
-  }
+  // gemini 的探测需要模型名（#323：模型名填错时报模型名问题而非 key 问题）
+  const model =
+    engine === 'gemini' ? getSettings().models?.gemini ?? undefined : undefined;
+  return testConnection(engine, key, model);
 }
 
 // ---- Drag & drop ----

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.45",
+  "version": "2.0.46",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/engines/gemini.ts
+++ b/src/engines/gemini.ts
@@ -80,7 +80,8 @@ export const geminiProbe: ProbeSpec = {
   }),
   // 引擎特例（#321/#257 保留在适配器内）：Gemini 的 400 覆盖多种情况，
   // 只有错误体明示认证失败才是 key 问题；模型名错误 / 内容过长等其余
-  // 情况交回公共状态码分类（瞬时）。
+  // 情况报告真实原因（#323 —— 此前任意非 2xx 一律报「API key 无效」，
+  // 模型名填错的用户被误导去重新申请 key）。
   classifyError: async (resp): Promise<ProbeResult | null> => {
     let status = '';
     let message = '';
@@ -102,7 +103,17 @@ export const geminiProbe: ProbeSpec = {
     if (isAuthByBody) {
       return { ok: false, category: 'invalid-key', message: 'API key 无效' };
     }
-    return null;
+    // 模型名错误 / 内容过长 / 安全拦截 / 5xx 等：与翻译路径同一分类
+    const category = classifyStatus('gemini', resp, true);
+    if (category === 'quota') {
+      return { ok: false, category: 'quota', message: '配额已用尽' };
+    }
+    const detail = message ? `：${message}` : '';
+    return {
+      ok: false,
+      category: 'transient',
+      message: `HTTP ${resp.status}${detail}`,
+    };
   },
 };
 

--- a/src/engines/test-connection.ts
+++ b/src/engines/test-connection.ts
@@ -1,17 +1,19 @@
-// 设置页测试连接 —— 统一走探测入口（#322）。
+// 设置页测试连接 —— 统一走探测入口（#322/#323）。
 //
 // 此前 openai 只查 401、deepl 只查 403，另一状态码会被显示成裸的
-// HTTP 错误码；这里把两家引擎的测试连接收敛到公共探测入口
-// probeConnection（#321），状态分类与翻译路径同一份口径：
-// 401/403 → key 问题、429 → 配额、其余非 2xx → 瞬时。
+// HTTP 错误码；gemini 任意非 2xx 一律报「API key 无效」，模型名填错
+// 的用户被误导去重新申请 key。这里把三家引擎的测试连接收敛到公共
+// 探测入口 probeConnection（#321），状态分类与翻译路径同一份口径：
+// 401/403 → key 问题、429 → 配额、其余非 2xx → 瞬时（带真实原因）。
 // 本模块不持有任何 UI 依赖，可独立单测。
 
 import { probeConnection } from './shared';
 import { openaiProbe } from './openai';
 import { deeplProbe } from './deepl';
+import { geminiProbe } from './gemini';
 
-/** 已接入探测入口的自带 key 引擎（gemini 见 #323）。 */
-export type TestableKeyedEngine = 'openai' | 'deepl';
+/** 已接入探测入口的自带 key 引擎。 */
+export type TestableKeyedEngine = 'openai' | 'deepl' | 'gemini';
 
 /** 测试连接结果 —— ok 与展示文案（文案已按失败类别区分）。 */
 export interface TestConnectionResult {
@@ -23,8 +25,14 @@ export interface TestConnectionResult {
 export async function testConnection(
   engine: TestableKeyedEngine,
   key: string,
+  model?: string,
 ): Promise<TestConnectionResult> {
-  const spec = engine === 'openai' ? openaiProbe : deeplProbe;
-  const result = await probeConnection(spec, { key });
+  const spec =
+    engine === 'openai'
+      ? openaiProbe
+      : engine === 'deepl'
+        ? deeplProbe
+        : geminiProbe;
+  const result = await probeConnection(spec, { key, model });
   return { ok: result.ok, msg: result.message };
 }


### PR DESCRIPTION
## 问题

Gemini 测试连接对任意非 2xx 响应一律报告「API key 无效」，模型名填错的用户被误导去重新申请 key，问题当然不会消失。

## 根因

设置页的 gemini 测试连接自建判定，没有区分失败类别，也没有携带服务端真实原因。

## 修复

gemini 测试连接改走公共探测入口：模型名错误等瞬时故障报告真实原因（`HTTP 400：models/xxx is not found`），key 失效、配额耗尽、服务端瞬时各归其类，探测结论与实际翻译对同一 key 的结论一致。

## 验证

`pnpm typecheck` 通过；新增 7 个 gemini 测试连接单测（含修复前失败的模型名用例），`pnpm test` 586 个用例全部通过；`pnpm build` 正常。

Closes #323
