### PR TITLE
导入设置走整体替换语义 (fix #324)

### DIFF
--- a/docs/testing/unit/storage/settings-import.test.ts
+++ b/docs/testing/unit/storage/settings-import.test.ts
@@ -1,0 +1,131 @@
+/**
+ * storage/settings-import.ts — 设置导入整体替换语义（#324）
+ *
+ * 导入此前走逐键合并（patchSettings）：导入不含自定义模型名的配置时
+ * 本机模型名残留，用户以为同步了配置实际打到的还是旧模型。
+ * 本文件断言导入 = 整体替换：
+ * - 不含 models 的配置 → 本机自定义模型名被清除（修复前失败）
+ * - 含 models 的配置 → 模型名与文件一致
+ * - 其余嵌套项（siteList / hotkeys）与模型名同语义
+ * - 既有校验不回归：未知字段丢弃、并发钳制、CSS 校验、密钥剔除
+ * - 无效 JSON → 配置保持不变
+ */
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { resetStorage } from '~/docs/testing/setup';
+import { DEFAULT_SETTINGS } from '~/src/storage/schema';
+
+beforeEach(() => {
+  resetStorage();
+  vi.resetModules();
+});
+
+/** 加载模块并返回（每次 resetModules 后重新取）。 */
+async function load() {
+  return import('~/src/storage/settings-import');
+}
+
+describe('导入整体替换语义（#324）', () => {
+  test('导入不含 models 的配置后，本机自定义模型名被清除（修复前失败）', async () => {
+    const settingsMod = await import('~/src/storage/settings');
+    await settingsMod.settingsReady();
+    await settingsMod.patchSettings({ models: { openai: 'gpt-custom' } });
+    expect(settingsMod.getSettings().models.openai).toBe('gpt-custom');
+
+    const { importSettings } = await load();
+    // 配置里没有任何 models 字段
+    const result = await importSettings(
+      JSON.stringify({ displayMode: 'translation-only' }),
+    );
+    expect(result.ok).toBe(true);
+    expect(settingsMod.getSettings().displayMode).toBe('translation-only');
+    // 模型名被清除（整体替换，缺省回落默认 {}）
+    expect(settingsMod.getSettings().models).toEqual({});
+  });
+
+  test('导入含自定义模型名的配置后，模型名与文件一致', async () => {
+    const settingsMod = await import('~/src/storage/settings');
+    await settingsMod.settingsReady();
+    await settingsMod.patchSettings({ models: { openai: 'old-model' } });
+
+    const { importSettings } = await load();
+    const result = await importSettings(
+      JSON.stringify({ models: { gemini: 'gemini-new' } }),
+    );
+    expect(result.ok).toBe(true);
+    expect(settingsMod.getSettings().models).toEqual({ gemini: 'gemini-new' });
+  });
+
+  test('其余嵌套配置项（siteList / hotkeys）与模型名同语义', async () => {
+    const settingsMod = await import('~/src/storage/settings');
+    await settingsMod.settingsReady();
+    await settingsMod.patchSettings({
+      siteList: { mode: 'blacklist', list: ['old.example.com'] },
+      hotkeys: { 'toggle-translate': 'Alt+P' },
+    });
+
+    const { importSettings } = await load();
+    const result = await importSettings(
+      JSON.stringify({
+        siteList: { mode: 'blacklist', list: ['new.example.com'] },
+      }),
+    );
+    expect(result.ok).toBe(true);
+    // siteList 整体覆盖为导入值
+    expect(settingsMod.getSettings().siteList.list).toEqual([
+      'new.example.com',
+    ]);
+    // hotkeys 未出现在导入文件 → 回落到默认（不残留本机自定义）
+    expect(settingsMod.getSettings().hotkeys).toEqual(DEFAULT_SETTINGS.hotkeys);
+  });
+
+  test('未知字段被丢弃、密钥字段被剔除', async () => {
+    const { parseImport } = await load();
+    const parsed = parseImport(
+      JSON.stringify({
+        displayMode: 'translation-only',
+        unknownField: 'garbage',
+        apiKeys: { openai: 'sk-secret' },
+      }),
+    );
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) {
+      const s = parsed.settings as unknown as Record<string, unknown>;
+      expect(s.displayMode).toBe('translation-only');
+      expect('unknownField' in s).toBe(false);
+      expect('apiKeys' in s).toBe(false);
+    }
+  });
+
+  test('并发数被钳制到合法范围（#172）', async () => {
+    const { parseImport } = await load();
+    const parsed = parseImport(JSON.stringify({ maxConcurrency: 0 }));
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) expect(parsed.settings.maxConcurrency).toBe(1);
+  });
+
+  test('自定义 CSS 被校验：非法 CSS 导入失败且配置保持不变', async () => {
+    const settingsMod = await import('~/src/storage/settings');
+    await settingsMod.settingsReady();
+    await settingsMod.patchSettings({ displayMode: 'translation-only' });
+
+    const { importSettings } = await load();
+    const result = await importSettings(
+      JSON.stringify({ customCss: '@import url(http://evil.example/x.css);' }),
+    );
+    expect(result.ok).toBe(false);
+    // 配置未被改动
+    expect(settingsMod.getSettings().displayMode).toBe('translation-only');
+  });
+
+  test('导入格式无效的 JSON 时配置保持不变', async () => {
+    const settingsMod = await import('~/src/storage/settings');
+    await settingsMod.settingsReady();
+    await settingsMod.patchSettings({ displayMode: 'translation-only' });
+
+    const { importSettings } = await load();
+    expect((await importSettings('{not json')).ok).toBe(false);
+    expect((await importSettings('[]')).ok).toBe(false);
+    expect((await importSettings('"str"')).ok).toBe(false);
+    expect(settingsMod.getSettings().displayMode).toBe('translation-only');
+  });
+});

--- a/entrypoints/options/sections/advanced.ts
+++ b/entrypoints/options/sections/advanced.ts
@@ -1,13 +1,13 @@
 // Phase 7 — 高级分区：并发数、缓存管理、设置导入/导出。
 
-import { DEFAULT_SETTINGS, clampConcurrency } from '~/src/storage/schema';
-import { validateCustomCss } from '~/src/styles/custom';
+import { DEFAULT_SETTINGS } from '~/src/storage/schema';
 import {
   getSettings,
   patchSettings,
   replaceSettings,
   onSettingsChanged,
 } from '~/src/storage/settings';
+import { importSettings as applyImport } from '~/src/storage/settings-import';
 import { cacheClear } from '~/src/storage/cache';
 import { removeKey } from '~/src/storage/keys';
 import { tf } from '~/src/i18n';
@@ -34,34 +34,13 @@ async function exportSettings(): Promise<string> {
 }
 
 async function importSettings(json: string): Promise<void> {
-  try {
-    const data = JSON.parse(json);
-    // 白名单校验：只允许已知 Setting 字段
-    const allowed = Object.keys(DEFAULT_SETTINGS);
-    const sanitized: Record<string, unknown> = {};
-    for (const key of allowed) {
-      if (key in data) sanitized[key] = data[key];
-    }
-    // #172: 值校验 —— 导入文件可绕过 UI 下拉，maxConcurrency 必须钳制，
-    // 否则 0/负数会让 Google 闸门永久饿死、全部翻译挂起
-    if (typeof sanitized.maxConcurrency === 'number') {
-      sanitized.maxConcurrency = clampConcurrency(sanitized.maxConcurrency);
-    }
-    // #168: 导入同样走统一校验器 —— 否则 @import/url() 等可通过导入
-    // 绕过表单校验，运行时注入被拒后旧样式还被清掉
-    if (typeof sanitized.customCss === 'string') {
-      const cssResult = validateCustomCss(sanitized.customCss);
-      if (!cssResult.ok) {
-        showToast(tf('toastImportFail', `导入失败：${cssResult.msg}`));
-        return;
-      }
-    }
-    // 显式移除任何密钥相关字段
-    delete sanitized.apiKeys;
-    await patchSettings(sanitized as any);
+  // #324: 导入走整体替换语义（与恢复默认一致）—— 解析校验在
+  // settings-import 模块，失败时配置保持不变
+  const result = await applyImport(json);
+  if (result.ok) {
     showToast(tf('toastImported', '设置已导入'));
-  } catch {
-    showToast(tf('toastImportFail', '导入失败：JSON 格式无效'));
+  } else {
+    showToast(tf('toastImportFail', `导入失败：${result.reason}`));
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.46",
+  "version": "2.0.47",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/storage/settings-import.ts
+++ b/src/storage/settings-import.ts
@@ -1,0 +1,76 @@
+// 设置导入 —— 整体替换语义（#324）。
+//
+// 导入此前走 patchSettings（逐键合并）：导入一份不含自定义模型名的
+// 配置时，本机原有的模型名会残留 —— 用户以为同步了配置，实际翻译
+// 打到的还是旧模型。本模块把导入改为与恢复默认一致的整体替换：
+//   1. 白名单字段 + 既有校验（并发钳制 / 自定义 CSS 校验 / 剔除密钥）
+//   2. 缺省或 null 的字段回落到默认值
+//   3. 嵌套键（models / siteList / hotkeys）整体覆盖 —— 策略声明表
+//      NESTED_KEYS 仍是唯一声明处，本模块不硬编码任何键名
+// 解析与构建是纯函数（parseImport），可独立单测；写盘只经 replaceSettings。
+
+import type { Settings } from './schema';
+import { DEFAULT_SETTINGS, clampConcurrency } from './schema';
+import { validateCustomCss } from '~/src/styles/custom';
+import { replaceSettings } from './settings';
+
+export type ImportResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+/**
+ * 解析并校验导入 JSON，构建完整替换对象（纯函数，不写存储）。
+ * 返回 ok=false 时调用方不应写盘。
+ */
+export function parseImport(
+  json: string,
+): { ok: true; settings: Settings } | { ok: false; reason: string } {
+  let data: unknown;
+  try {
+    data = JSON.parse(json);
+  } catch {
+    return { ok: false, reason: 'JSON 格式无效' };
+  }
+  // 非对象（数组 / 基本类型）视为无效 —— 整体替换语义下绝不能
+  // 把合法但形状错误的 JSON 解析成「空配置」把本机设置冲掉
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    return { ok: false, reason: 'JSON 格式无效' };
+  }
+
+  const rec = data as Record<string, unknown>;
+  // 白名单校验：只允许已知 Setting 字段，未知字段被丢弃；
+  // null 值视为缺省（整体替换语义下回落默认，不污染配置）
+  const allowed = Object.keys(DEFAULT_SETTINGS);
+  const next: Record<string, unknown> = {};
+  for (const key of allowed) {
+    if (key in rec && rec[key] !== null) next[key] = rec[key];
+  }
+  // #172: 值校验 —— 导入文件可绕过 UI 下拉，maxConcurrency 必须钳制，
+  // 否则 0/负数会让 Google 闸门永久饿死、全部翻译挂起
+  if (typeof next.maxConcurrency === 'number') {
+    next.maxConcurrency = clampConcurrency(next.maxConcurrency);
+  }
+  // #168: 导入同样走统一校验器 —— 否则 @import/url() 等可通过导入
+  // 绕过表单校验，运行时注入被拒后旧样式还被清掉
+  if (typeof next.customCss === 'string') {
+    const cssResult = validateCustomCss(next.customCss);
+    if (!cssResult.ok) return { ok: false, reason: cssResult.msg };
+  }
+  // 显式移除任何密钥相关字段
+  delete next.apiKeys;
+
+  // #324: 整体替换语义 —— 缺省字段回落到默认值；嵌套键整体覆盖
+  // （导入不含自定义模型名的配置时本机模型名被清除，不残留）。
+  // 嵌套键策略只声明在 NESTED_KEYS 一处，由 replaceSettings 消费；
+  // 这里只做整对象替换，不硬编码任何键名
+  const complete = { ...DEFAULT_SETTINGS, ...next } as Settings;
+  return { ok: true, settings: complete };
+}
+
+/** 导入设置：解析校验 → 整体替换写盘。 */
+export async function importSettings(json: string): Promise<ImportResult> {
+  const parsed = parseImport(json);
+  if (!parsed.ok) return parsed;
+  await replaceSettings(parsed.settings);
+  return { ok: true };
+}


### PR DESCRIPTION
## 问题

导入不含自定义模型名的配置后，本机原有的模型名残留——用户以为同步了配置，实际翻译打到的还是旧模型。

## 根因

导入走逐键合并语义（patchSettings），嵌套对象只覆盖提供的键，兄弟键（本机模型名）保留。

## 修复

导入改为整体替换语义（与恢复默认一致）：缺省字段回落默认值、嵌套键整体覆盖；未知字段丢弃、并发钳制、CSS 校验、密钥剔除等既有校验不变；无效 JSON 配置保持不变。解析与构建收敛到 `src/storage/settings-import.ts`，可独立单测。

## 验证

`pnpm typecheck` 通过；新增 7 个导入单测（含修复前失败的本机模型名清除用例），`pnpm test` 593 个用例全部通过；`pnpm build` 正常。

Closes #324
