### PR TITLE
隐藏单元集合改弱引用并随停止清理 (fix #330)

### DIFF
--- a/docs/testing/unit/dom/observer.test.ts
+++ b/docs/testing/unit/dom/observer.test.ts
@@ -197,3 +197,99 @@ describe('startObserver 采集去重（#158）', () => {
     }
   });
 });
+
+describe('可见性追踪弱引用与停止清理（#330）', () => {
+  /** 记录 observe 目标与实例序号的 IO 桩。 */
+  class CapturingIO {
+    static instances: CapturingIO[] = [];
+    observed: Element[] = [];
+    callback: (entries: { isIntersecting: boolean; target: Element }[]) => void;
+
+    constructor(cb: (entries: { isIntersecting: boolean; target: Element }[]) => void) {
+      this.callback = cb;
+      CapturingIO.instances.push(this);
+    }
+
+    observe(el: Element): void {
+      this.observed.push(el);
+    }
+
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    vi.resetModules();
+    CapturingIO.instances = [];
+    vi.stubGlobal('IntersectionObserver', CapturingIO);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+  });
+
+  async function load() {
+    return import('~/src/dom/observer');
+  }
+
+  test('隐藏单元登记走弱引用（WeakRef），集合不持有强引用', async () => {
+    const RealWeakRef = globalThis.WeakRef;
+    const spy = vi
+      .spyOn(globalThis, 'WeakRef')
+      .mockImplementation((target: object) => new RealWeakRef(target));
+    try {
+      const { registerHidden } = await load();
+      const el = document.createElement('p');
+      registerHidden(el);
+      expect(spy).toHaveBeenCalledWith(el);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test('IO 启动前登记的隐藏单元在启动时被补挂观察', async () => {
+    const { registerHidden, startObserver } = await load();
+    const el = document.createElement('p');
+    registerHidden(el);
+
+    const stop = startObserver(() => {});
+    expect(CapturingIO.instances[0]!.observed).toContain(el);
+    stop();
+  });
+
+  test('IO 启动后登记的隐藏单元被直接观察', async () => {
+    const { registerHidden, startObserver } = await load();
+    const stop = startObserver(() => {});
+    const el = document.createElement('p');
+    registerHidden(el);
+    expect(CapturingIO.instances[0]!.observed).toContain(el);
+    stop();
+  });
+
+  test('观察器停止后，旧周期登记的隐藏单元不泄漏到新一轮观察', async () => {
+    const { registerHidden, startObserver } = await load();
+    const old = document.createElement('p');
+    registerHidden(old);
+
+    const stop1 = startObserver(() => {});
+    expect(CapturingIO.instances[0]!.observed).toContain(old);
+    stop1();
+
+    // 新一轮：旧单元不再被观察，新一轮登记照常工作
+    const stop2 = startObserver(() => {});
+    expect(CapturingIO.instances[1]!.observed).not.toContain(old);
+    const fresh = document.createElement('p');
+    registerHidden(fresh);
+    expect(CapturingIO.instances[1]!.observed).toContain(fresh);
+    stop2();
+  });
+
+  test('停止之后再登记隐藏单元：不抛异常，进入新一轮待观察队列', async () => {
+    const { registerHidden, startObserver } = await load();
+    const stop = startObserver(() => {});
+    stop();
+    expect(() => registerHidden(document.createElement('p'))).not.toThrow();
+  });
+});

--- a/docs/testing/unit/dom/observer.test.ts
+++ b/docs/testing/unit/dom/observer.test.ts
@@ -238,7 +238,7 @@ describe('可见性追踪弱引用与停止清理（#330）', () => {
     const RealWeakRef = globalThis.WeakRef;
     const spy = vi
       .spyOn(globalThis, 'WeakRef')
-      .mockImplementation((target: object) => new RealWeakRef(target));
+      .mockImplementation((target: WeakKey) => new RealWeakRef(target));
     try {
       const { registerHidden } = await load();
       const el = document.createElement('p');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.47",
+  "version": "2.0.48",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/observer.ts
+++ b/src/dom/observer.ts
@@ -73,8 +73,20 @@ function observeShadowRoots(
 
 // ── #23 可见性追踪 ──
 
-/** 初次采集时因 display:none 被跳过的翻译单元 */
-const hiddenTargets = new Set<Element>();
+/**
+ * 隐藏单元登记（#330 内存修复）。
+ *
+ * 待观察的隐藏单元此前是模块级强引用 Set：观察器未启动或元素从未
+ * 进入视口时只增不减，长时间停留的单页应用会持续持有已离开 DOM 的
+ * 元素。现在：
+ *   - hiddenSeen：WeakSet 去重（弱引用，不阻碍回收）
+ *   - pendingHidden：IO 启动前登记的待观察队列，元素以 WeakRef 持有
+ *     （离开 DOM 后仅剩弱引用，可被回收）；IO 启动时惰性清理死亡引用
+ *   - IO 启动后登记的元素直接 observe，不进队列
+ * 观察器停止时三者全部清空（#330：相关状态随停止清理）。
+ */
+let hiddenSeen = new WeakSet<Element>();
+let pendingHidden: Set<WeakRef<Element>> | null = null;
 let io: IntersectionObserver | null = null;
 let onVisibleCb: ((els: Element[]) => void) | null = null;
 
@@ -83,8 +95,15 @@ let onVisibleCb: ((els: Element[]) => void) | null = null;
  * 由 walker 的 onHidden 回调调用，也可在 IO 启动后直接挂载观察。
  */
 export function registerHidden(el: Element): void {
-  hiddenTargets.add(el);
-  if (io) io.observe(el);
+  if (hiddenSeen.has(el)) return;
+  hiddenSeen.add(el);
+  if (io) {
+    io.observe(el);
+  } else {
+    // IO 尚未启动：进待观察队列（弱引用，IO 启动时补挂）
+    pendingHidden ??= new Set();
+    pendingHidden.add(new WeakRef(el));
+  }
 }
 
 function startWatching(onNewNodes: (els: Element[]) => void): void {
@@ -96,7 +115,7 @@ function startWatching(onNewNodes: (els: Element[]) => void): void {
       for (const entry of entries) {
         if (entry.isIntersecting) {
           io!.unobserve(entry.target);
-          hiddenTargets.delete(entry.target as Element);
+          hiddenSeen.delete(entry.target as Element);
           // 元素变为可见，重新采集其子树中的翻译单元
           newlyVisible.push(...collect(entry.target, registerHidden));
         }
@@ -111,9 +130,13 @@ function startWatching(onNewNodes: (els: Element[]) => void): void {
       threshold: 0,
     },
   );
-  // 观察所有已注册的隐藏元素
-  for (const el of hiddenTargets) {
-    io.observe(el);
+  // 观察所有已注册的隐藏元素（弱引用队列：死亡引用直接丢弃）
+  if (pendingHidden) {
+    for (const ref of pendingHidden) {
+      const el = ref.deref();
+      if (el) io.observe(el);
+    }
+    pendingHidden.clear();
   }
 }
 
@@ -255,7 +278,10 @@ export function startObserver(
       io.disconnect();
       io = null;
     }
-    hiddenTargets.clear();
+    // #330：停止时清空全部可见性追踪状态 —— 隐藏单元登记、
+    // 待观察队列不再跨启动周期残留
+    pendingHidden = null;
+    hiddenSeen = new WeakSet();
     onVisibleCb = null;
   };
 }


### PR DESCRIPTION
## 问题

待观察的隐藏单元集合是模块级强引用，观察器从未启动或元素从未进入视口时只增不减，长时间停留的单页应用会持续持有已离开 DOM 的元素，无法回收。

## 根因

`Set<Element>` 强引用登记集合没有清理路径，元素生命周期与观察状态脱钩。

## 修复

去重改用 WeakSet（弱引用），IO 启动前登记的待观察队列改用 WeakRef（离开 DOM 后仅剩弱引用，可被回收，IO 启动时惰性清理）；观察器停止时清空全部可见性追踪状态。补翻行为、视口余量与可见性特例不变。

## 验证

`pnpm typecheck` 通过；新增 5 个观察器单测（WeakRef 结构、启动前后登记、停止清理不泄漏、停止后再登记不抛异常），`pnpm test` 598 个用例全部通过；`pnpm test:e2e:core` 34 个用例通过。

Closes #330
