### PR TITLE
观察器句柄化与状态内聚 (fix #331)

### DIFF
--- a/docs/testing/unit/dom/observer.test.ts
+++ b/docs/testing/unit/dom/observer.test.ts
@@ -37,7 +37,7 @@ describe('startObserver 采集去重（#158）', () => {
     const restore = mockAllBoundingRects();
     try {
       const seen: Element[] = [];
-      const stop = startObserver((els) => seen.push(...els));
+      const handle = startObserver((els) => seen.push(...els));
 
       // 分步 append：容器与子元素落在同一 300ms 防抖窗口
       const container = document.createElement('div');
@@ -52,7 +52,7 @@ describe('startObserver 采集去重（#158）', () => {
       expect(seen).toHaveLength(1);
       expect(seen[0]).toBe(p);
 
-      stop();
+      handle.stop();
     } finally {
       restore();
     }
@@ -62,7 +62,7 @@ describe('startObserver 采集去重（#158）', () => {
     const restore = mockAllBoundingRects();
     try {
       const seen: Element[] = [];
-      const stop = startObserver((els) => seen.push(...els));
+      const handle = startObserver((els) => seen.push(...els));
 
       const p = document.createElement('p');
       p.textContent = 'original text';
@@ -74,7 +74,7 @@ describe('startObserver 采集去重（#158）', () => {
       await vi.advanceTimersByTimeAsync(300);
 
       expect(seen).toContain(p);
-      stop();
+      handle.stop();
     } finally {
       restore();
     }
@@ -84,7 +84,7 @@ describe('startObserver 采集去重（#158）', () => {
     const restore = mockAllBoundingRects();
     try {
       const seen: Element[] = [];
-      const stop = startObserver((els) => seen.push(...els));
+      const handle = startObserver((els) => seen.push(...els));
 
       const p = document.createElement('p');
       p.textContent = '原文';
@@ -103,7 +103,7 @@ describe('startObserver 采集去重（#158）', () => {
       await vi.advanceTimersByTimeAsync(300);
       expect(seen).toHaveLength(0);
 
-      stop();
+      handle.stop();
     } finally {
       restore();
     }
@@ -113,7 +113,7 @@ describe('startObserver 采集去重（#158）', () => {
     const restore = mockAllBoundingRects();
     try {
       const seen: Element[] = [];
-      const stop = startObserver((els) => seen.push(...els));
+      const handle = startObserver((els) => seen.push(...els));
 
       const p = document.createElement('p');
       p.textContent = '旧原文';
@@ -135,7 +135,7 @@ describe('startObserver 采集去重（#158）', () => {
       // 单元被还原（data-pt 清除）并重新采集
       expect(p.getAttribute('data-pt')).toBeNull();
       expect(seen).toContain(p);
-      stop();
+      handle.stop();
     } finally {
       restore();
     }
@@ -145,7 +145,7 @@ describe('startObserver 采集去重（#158）', () => {
     const restore = mockAllBoundingRects();
     try {
       const seen: Element[] = [];
-      const stop = startObserver((els) => seen.push(...els));
+      const handle = startObserver((els) => seen.push(...els));
 
       // host 先入 DOM，随后才 attachShadow（模拟延迟初始化的 Web Component）
       const host = document.createElement('div');
@@ -158,7 +158,7 @@ describe('startObserver 采集去重（#158）', () => {
       await vi.advanceTimersByTimeAsync(300);
 
       expect(seen).toContain(p);
-      stop();
+      handle.stop();
     } finally {
       restore();
     }
@@ -168,7 +168,7 @@ describe('startObserver 采集去重（#158）', () => {
     const restore = mockAllBoundingRects();
     try {
       const seen: Element[] = [];
-      const stop = startObserver((els) => seen.push(...els));
+      const handle = startObserver((els) => seen.push(...els));
 
       // 超长纯文本 pre（> MAX_TEXT），段落间空行分隔 → splitPre 切出多个 .pt-chunk
       const para = (i: number) =>
@@ -191,7 +191,7 @@ describe('startObserver 采集去重（#158）', () => {
         expect(seen.filter((x) => x === el)).toHaveLength(1);
       }
 
-      stop();
+      handle.stop();
     } finally {
       restore();
     }
@@ -249,23 +249,23 @@ describe('可见性追踪弱引用与停止清理（#330）', () => {
     }
   });
 
-  test('IO 启动前登记的隐藏单元在启动时被补挂观察', async () => {
+  test('IO 启动前登记的隐藏单元在启动时被补挂观察（首轮翻译期间登记不丢失）', async () => {
     const { registerHidden, startObserver } = await load();
     const el = document.createElement('p');
     registerHidden(el);
 
-    const stop = startObserver(() => {});
+    const handle = startObserver(() => {});
     expect(CapturingIO.instances[0]!.observed).toContain(el);
-    stop();
+    handle.stop();
   });
 
-  test('IO 启动后登记的隐藏单元被直接观察', async () => {
-    const { registerHidden, startObserver } = await load();
-    const stop = startObserver(() => {});
+  test('句柄登记（IO 启动后）被直接观察', async () => {
+    const { startObserver } = await load();
+    const handle = startObserver(() => {});
     const el = document.createElement('p');
-    registerHidden(el);
+    handle.registerHidden(el);
     expect(CapturingIO.instances[0]!.observed).toContain(el);
-    stop();
+    handle.stop();
   });
 
   test('观察器停止后，旧周期登记的隐藏单元不泄漏到新一轮观察', async () => {
@@ -273,23 +273,140 @@ describe('可见性追踪弱引用与停止清理（#330）', () => {
     const old = document.createElement('p');
     registerHidden(old);
 
-    const stop1 = startObserver(() => {});
+    const handle1 = startObserver(() => {});
     expect(CapturingIO.instances[0]!.observed).toContain(old);
-    stop1();
+    handle1.stop();
 
     // 新一轮：旧单元不再被观察，新一轮登记照常工作
-    const stop2 = startObserver(() => {});
+    const handle2 = startObserver(() => {});
     expect(CapturingIO.instances[1]!.observed).not.toContain(old);
     const fresh = document.createElement('p');
-    registerHidden(fresh);
+    handle2.registerHidden(fresh);
     expect(CapturingIO.instances[1]!.observed).toContain(fresh);
-    stop2();
+    handle2.stop();
   });
 
-  test('停止之后再登记隐藏单元：不抛异常，进入新一轮待观察队列', async () => {
-    const { registerHidden, startObserver } = await load();
-    const stop = startObserver(() => {});
-    stop();
-    expect(() => registerHidden(document.createElement('p'))).not.toThrow();
+  test('停止之后句柄登记不产生效果且不抛异常', async () => {
+    const { startObserver } = await load();
+    const handle = startObserver(() => {});
+    const before = CapturingIO.instances[0]!.observed.length;
+    handle.stop();
+    expect(() => handle.registerHidden(document.createElement('p'))).not.toThrow();
+    expect(CapturingIO.instances[0]!.observed).toHaveLength(before);
+  });
+});
+
+describe('观察器句柄化（#331）', () => {
+  class CapturingIO {
+    static instances: CapturingIO[] = [];
+    observed: Element[] = [];
+    callback: (entries: { isIntersecting: boolean; target: Element }[]) => void;
+
+    constructor(cb: (entries: { isIntersecting: boolean; target: Element }[]) => void) {
+      this.callback = cb;
+      CapturingIO.instances.push(this);
+    }
+
+    observe(el: Element): void {
+      this.observed.push(el);
+    }
+
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    vi.resetModules();
+    CapturingIO.instances = [];
+    vi.stubGlobal('IntersectionObserver', CapturingIO);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+  });
+
+  async function load() {
+    return import('~/src/dom/observer');
+  }
+
+  test('句柄提供停止与隐藏单元登记两项能力', async () => {
+    const { startObserver } = await load();
+    const handle = startObserver(() => {});
+    expect(typeof handle.stop).toBe('function');
+    expect(typeof handle.registerHidden).toBe('function');
+    handle.stop();
+  });
+
+  test('停止之后产生 DOM 变更，补翻回调不再被调用', async () => {
+    vi.useFakeTimers();
+    const restore = mockAllBoundingRects();
+    try {
+      const { startObserver } = await load();
+      const seen: Element[] = [];
+      const handle = startObserver((els) => seen.push(...els));
+
+      const p = document.createElement('p');
+      p.textContent = 'first';
+      document.body.appendChild(p);
+      await vi.advanceTimersByTimeAsync(300);
+      expect(seen).toContain(p);
+
+      handle.stop();
+      const p2 = document.createElement('p');
+      p2.textContent = 'second';
+      document.body.appendChild(p2);
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(seen).not.toContain(p2);
+    } finally {
+      vi.useRealTimers();
+      restore();
+    }
+  });
+
+  test('停止是幂等的：连续调用两次不抛异常、无副作用', async () => {
+    const { startObserver } = await load();
+    const handle = startObserver(() => {});
+    expect(() => {
+      handle.stop();
+      handle.stop();
+    }).not.toThrow();
+  });
+
+  test('连续「启动 → 停止 → 启动」后行为与首次一致，前一轮隐藏单元不泄漏', async () => {
+    const { startObserver } = await load();
+    const seen: Element[] = [];
+    const handle1 = startObserver((els) => seen.push(...els));
+    const el1 = document.createElement('p');
+    handle1.registerHidden(el1);
+    expect(CapturingIO.instances[0]!.observed).toContain(el1);
+    handle1.stop();
+
+    const handle2 = startObserver((els) => seen.push(...els));
+    // 前一轮的隐藏单元不进入新一轮观察
+    expect(CapturingIO.instances[1]!.observed).not.toContain(el1);
+    // 新一轮登记照常被观察
+    const el2 = document.createElement('p');
+    handle2.registerHidden(el2);
+    expect(CapturingIO.instances[1]!.observed).toContain(el2);
+    handle2.stop();
+  });
+
+  test('单测不依赖跨用例共享的模块级状态：各句柄状态互不可见', async () => {
+    const { startObserver } = await load();
+    const a = startObserver(() => {});
+    const b = startObserver(() => {});
+    const ea = document.createElement('p');
+    const eb = document.createElement('p');
+    a.registerHidden(ea);
+    b.registerHidden(eb);
+    // 各自的登记只进各自的观察实例
+    expect(CapturingIO.instances[0]!.observed).toContain(ea);
+    expect(CapturingIO.instances[0]!.observed).not.toContain(eb);
+    expect(CapturingIO.instances[1]!.observed).toContain(eb);
+    expect(CapturingIO.instances[1]!.observed).not.toContain(ea);
+    a.stop();
+    b.stop();
   });
 });

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -138,7 +138,8 @@ export default defineContentScript({
             console.error('[PT] 增量补翻失败:', e),
           );
         }),
-      stop: (stopObserving) => stopObserving(),
+      // #331: startObserver 返回句柄，stop 经句柄执行（幂等）
+      stop: (handle) => handle.stop(),
     });
 
     // ── 设置变更统一入口（#265）──

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.48",
+  "version": "2.0.49",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/observer.ts
+++ b/src/dom/observer.ts
@@ -74,76 +74,53 @@ function observeShadowRoots(
 // ── #23 可见性追踪 ──
 
 /**
- * 隐藏单元登记（#330 内存修复）。
- *
- * 待观察的隐藏单元此前是模块级强引用 Set：观察器未启动或元素从未
- * 进入视口时只增不减，长时间停留的单页应用会持续持有已离开 DOM 的
- * 元素。现在：
- *   - hiddenSeen：WeakSet 去重（弱引用，不阻碍回收）
- *   - pendingHidden：IO 启动前登记的待观察队列，元素以 WeakRef 持有
- *     （离开 DOM 后仅剩弱引用，可被回收）；IO 启动时惰性清理死亡引用
- *   - IO 启动后登记的元素直接 observe，不进队列
- * 观察器停止时三者全部清空（#330：相关状态随停止清理）。
+ * 观察器句柄（#331）—— 启动观察器返回的能力集合：
+ *   - stop()：停止全部观察（幂等），随后隐藏单元登记不产生效果
+ *   - registerHidden()：登记因不可见而被跳过的翻译单元
+ * 隐藏单元集合、可见性观察实例、补翻回调三份状态全部随句柄创建与
+ * 销毁，不再跨用例共享模块级状态。
  */
-let hiddenSeen = new WeakSet<Element>();
-let pendingHidden: Set<WeakRef<Element>> | null = null;
-let io: IntersectionObserver | null = null;
-let onVisibleCb: ((els: Element[]) => void) | null = null;
+export interface ObserverHandle {
+  stop(): void;
+  registerHidden(el: Element): void;
+}
 
 /**
- * 注册因不可见而被跳过的翻译单元。
- * 由 walker 的 onHidden 回调调用，也可在 IO 启动后直接挂载观察。
+ * 启动前登记缓冲（#331）—— 模块级 registerHidden 的语义收敛为
+ * 「观察器尚未启动时的登记缓冲」：首轮整页翻译期间采集到的隐藏
+ * 单元（collect 在观察器启动前执行）先入此缓冲，观察器启动时
+ * 消费并补挂观察（关键语义点：采集期间的登记不丢失）。
+ * 元素以 WeakRef 持有（#330：离开 DOM 后仅剩弱引用）。
+ */
+let preStartHidden: Set<WeakRef<Element>> | null = null;
+
+/**
+ * 模块级隐藏单元登记（#331）—— 仅作启动前缓冲。
+ * 观察器运行期间的登记一律走句柄（handle.registerHidden）；
+ * 本函数由采集调用方（整页翻译的 collect）传入，观察器启动时
+ * 由 startObserver 消费。
  */
 export function registerHidden(el: Element): void {
-  if (hiddenSeen.has(el)) return;
-  hiddenSeen.add(el);
-  if (io) {
-    io.observe(el);
-  } else {
-    // IO 尚未启动：进待观察队列（弱引用，IO 启动时补挂）
-    pendingHidden ??= new Set();
-    pendingHidden.add(new WeakRef(el));
-  }
+  preStartHidden ??= new Set();
+  preStartHidden.add(new WeakRef(el));
 }
 
-function startWatching(onNewNodes: (els: Element[]) => void): void {
-  if (io) return; // 已经启动
-  onVisibleCb = onNewNodes;
-  io = new IntersectionObserver(
-    (entries) => {
-      const newlyVisible: Element[] = [];
-      for (const entry of entries) {
-        if (entry.isIntersecting) {
-          io!.unobserve(entry.target);
-          hiddenSeen.delete(entry.target as Element);
-          // 元素变为可见，重新采集其子树中的翻译单元
-          newlyVisible.push(...collect(entry.target, registerHidden));
-        }
-      }
-      if (newlyVisible.length && onVisibleCb) {
-        onVisibleCb(newlyVisible);
-      }
-    },
-    {
-      // 提前 300px 触发，让即将滚入视口的内容提前翻译
-      rootMargin: '300px',
-      threshold: 0,
-    },
-  );
-  // 观察所有已注册的隐藏元素（弱引用队列：死亡引用直接丢弃）
-  if (pendingHidden) {
-    for (const ref of pendingHidden) {
-      const el = ref.deref();
-      if (el) io.observe(el);
-    }
-    pendingHidden.clear();
-  }
-}
-
-/** 启动 MutationObserver，对新增节点触发补翻回调。 */
+/**
+ * 启动增量补翻观察器，返回句柄（#331）。
+ * 句柄提供停止与隐藏单元登记两项能力；隐藏单元集合、可见性观察
+ * 实例、补翻回调三份状态全部随句柄创建与销毁，不再跨用例共享。
+ */
 export function startObserver(
   onNewNodes: (els: Element[]) => void,
-): () => void {
+): ObserverHandle {
+  // ── 随句柄创建的状态（#331）──
+  /** 隐藏单元去重（弱引用，#330）。 */
+  let hiddenSeen = new WeakSet<Element>();
+  let io: IntersectionObserver | null = null;
+  let onVisibleCb: ((els: Element[]) => void) | null = null;
+  /** 已停止：登记与回调全部失效（幂等停止的守卫）。 */
+  let stopped = false;
+
   let pending: Node[] = [];
   let timer: number | undefined;
   // 所有活跃的 observer 列表（主文档 + 各 shadow root）
@@ -176,7 +153,7 @@ export function startObserver(
     // 兜底去重：compat take、shadow 边界等极端路径下保证每单元只回调一次
     const found = [
       ...new Set(
-        roots.flatMap((n) => collect(n as Element, registerHidden)),
+        roots.flatMap((n) => collect(n as Element, registerHiddenInstance)),
       ),
     ];
 
@@ -267,21 +244,76 @@ export function startObserver(
     },
   });
 
-  // #23：启动 IntersectionObserver，监听初次采集时因 display:none 被跳过的元素
-  startWatching(onNewNodes);
+  // ── 可见性追踪（随句柄创建，#331）──
 
-  return () => {
-    unwatch();
-    for (const mo of observers) mo.disconnect();
-    if (timer) clearTimeout(timer);
-    if (io) {
-      io.disconnect();
-      io = null;
+  /** 句柄的隐藏单元登记：停止后不产生效果且不抛异常（#331）。 */
+  function registerHiddenInstance(el: Element): void {
+    if (stopped) return;
+    if (hiddenSeen.has(el)) return;
+    hiddenSeen.add(el);
+    if (io) io.observe(el);
+  }
+
+  function startWatching(): void {
+    if (io) return; // 已经启动
+    onVisibleCb = onNewNodes;
+    io = new IntersectionObserver(
+      (entries) => {
+        const newlyVisible: Element[] = [];
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            io!.unobserve(entry.target);
+            hiddenSeen.delete(entry.target as Element);
+            // 元素变为可见，重新采集其子树中的翻译单元
+            // （隐藏后代经本句柄登记，仍被本实例观察）
+            newlyVisible.push(...collect(entry.target, registerHiddenInstance));
+          }
+        }
+        if (newlyVisible.length && onVisibleCb) {
+          onVisibleCb(newlyVisible);
+        }
+      },
+      {
+        // 提前 300px 触发，让即将滚入视口的内容提前翻译
+        rootMargin: '300px',
+        threshold: 0,
+      },
+    );
+    // 消费启动前登记缓冲（#331 关键语义点：首轮整页翻译期间采集到
+    // 的隐藏单元在此补挂观察，采集期间的登记不丢失；死亡引用丢弃）
+    if (preStartHidden) {
+      for (const ref of preStartHidden) {
+        const el = ref.deref();
+        if (el && !hiddenSeen.has(el)) {
+          hiddenSeen.add(el);
+          io.observe(el);
+        }
+      }
+      preStartHidden = null;
     }
-    // #330：停止时清空全部可见性追踪状态 —— 隐藏单元登记、
-    // 待观察队列不再跨启动周期残留
-    pendingHidden = null;
-    hiddenSeen = new WeakSet();
-    onVisibleCb = null;
+  }
+
+  // #23：启动 IntersectionObserver，监听初次采集时因 display:none 被跳过的元素
+  startWatching();
+
+  return {
+    stop(): void {
+      // #331: 停止幂等 —— 连续调用两次不抛异常、无副作用
+      if (stopped) return;
+      stopped = true;
+      unwatch();
+      for (const mo of observers) mo.disconnect();
+      if (timer) clearTimeout(timer);
+      if (io) {
+        io.disconnect();
+        io = null;
+      }
+      // #330/#331：停止时清空全部可见性追踪状态 —— 隐藏单元登记、
+      // 补翻回调随句柄销毁，不再跨启动周期残留
+      hiddenSeen = new WeakSet();
+      onVisibleCb = null;
+    },
+
+    registerHidden: registerHiddenInstance,
   };
 }


### PR DESCRIPTION
## 问题

观察器返回「一个停止函数」，隐藏单元集合、IO 实例、补翻回调都是模块级状态，跨用例共享且生命周期与观察器脱钩。

## 根因

启动观察器的返回面太薄，状态无处附着，只能挂在模块顶层。

## 修复

启动观察器返回句柄（停止 + 隐藏单元登记两项能力），三份状态随句柄创建与销毁；停止幂等、停止后登记不产生效果；模块级登记收敛为「启动前缓冲」，首轮整页翻译期间采集到的隐藏单元在观察器启动后被补挂观察，登记不丢失。

## 验证

`pnpm typecheck` 通过；观察器单测改为经句柄访问（不再依赖共享模块级状态），新增 6 个句柄用例（能力面、停止后不再补翻、停止后登记无效果、停止幂等、启停循环不泄漏、多句柄互不可见），`pnpm test` 603 个用例全部通过；`pnpm test:e2e:core` 34 个用例通过。

Closes #331
