### PR TITLE
采集调用方切换到句柄登记 (fix #332)

### DIFF
--- a/docs/testing/unit/dom/observer.test.ts
+++ b/docs/testing/unit/dom/observer.test.ts
@@ -234,32 +234,21 @@ describe('可见性追踪弱引用与停止清理（#330）', () => {
     return import('~/src/dom/observer');
   }
 
-  test('隐藏单元登记走弱引用（WeakRef），集合不持有强引用', async () => {
-    const RealWeakRef = globalThis.WeakRef;
-    const spy = vi
-      .spyOn(globalThis, 'WeakRef')
-      .mockImplementation((target: WeakKey) => new RealWeakRef(target));
-    try {
-      const { registerHidden } = await load();
-      const el = document.createElement('p');
-      registerHidden(el);
-      expect(spy).toHaveBeenCalledWith(el);
-    } finally {
-      spy.mockRestore();
-    }
-  });
-
-  test('IO 启动前登记的隐藏单元在启动时被补挂观察（首轮翻译期间登记不丢失）', async () => {
-    const { registerHidden, startObserver } = await load();
-    const el = document.createElement('p');
-    registerHidden(el);
-
+  test('句柄创建后补挂启动前登记的隐藏单元（首轮翻译期间登记不丢失，#332）', async () => {
+    const { startObserver } = await load();
+    // 模拟 content 的登记缓冲：句柄创建（观察器启动）前采集到的
+    // 隐藏单元，在创建后经 handle.registerHidden 补挂
+    const buffered = [
+      document.createElement('p'),
+      document.createElement('p'),
+    ];
     const handle = startObserver(() => {});
-    expect(CapturingIO.instances[0]!.observed).toContain(el);
+    for (const el of buffered) handle.registerHidden(el);
+    expect(CapturingIO.instances[0]!.observed).toEqual(buffered);
     handle.stop();
   });
 
-  test('句柄登记（IO 启动后）被直接观察', async () => {
+  test('句柄登记被直接观察', async () => {
     const { startObserver } = await load();
     const handle = startObserver(() => {});
     const el = document.createElement('p');
@@ -269,11 +258,10 @@ describe('可见性追踪弱引用与停止清理（#330）', () => {
   });
 
   test('观察器停止后，旧周期登记的隐藏单元不泄漏到新一轮观察', async () => {
-    const { registerHidden, startObserver } = await load();
-    const old = document.createElement('p');
-    registerHidden(old);
-
+    const { startObserver } = await load();
     const handle1 = startObserver(() => {});
+    const old = document.createElement('p');
+    handle1.registerHidden(old);
     expect(CapturingIO.instances[0]!.observed).toContain(old);
     handle1.stop();
 

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -17,7 +17,7 @@ import {
   hasBlockTextChildren,
   restorePreserves,
 } from '~/src/dom/text';
-import { startObserver, registerHidden } from '~/src/dom/observer';
+import { startObserver, type ObserverHandle } from '~/src/dom/observer';
 import { walkShadowTree } from '~/src/dom/shadow-walk';
 import { render, unrender, applyMode, applyStyle } from '~/src/dom/renderer';
 import { unsplitPre } from '~/src/dom/pre-split';
@@ -131,15 +131,45 @@ export default defineContentScript({
     // ── 增量补翻 observer ──
     // #255: observer 经注册表启停 —— 整页翻译完成时启动，还原时停止；
     // 启停幂等，不再手写 stopObserving 判空
+    //
+    // #331/#332: 隐藏单元登记能力从观察器句柄取得（模块顶层不再导出
+    // 登记函数）。整页翻译的 collect 先于观察器启动（翻译成功后
+    // ensure('observer', true)），期间的登记进 preStartHidden 缓冲
+    // （WeakRef，#330 弱引用语义），句柄创建时补挂 —— 首轮翻译期间
+    // 采集到的隐藏单元因此不丢失。
+    const preStartHidden = new Set<WeakRef<Element>>();
+    let observerHandle: ObserverHandle | null = null;
+
+    /** 整页翻译 collect 的隐藏单元回调：句柄存在则直登，否则进缓冲。 */
+    function registerHiddenForObserver(el: Element): void {
+      if (observerHandle) {
+        observerHandle.registerHidden(el);
+        return;
+      }
+      preStartHidden.add(new WeakRef(el));
+    }
+
     registry.register('observer', {
-      create: () =>
-        startObserver((els) => {
+      create: () => {
+        const handle = startObserver((els) => {
           doTranslate(els).catch((e) =>
             console.error('[PT] 增量补翻失败:', e),
           );
-        }),
+        });
+        observerHandle = handle;
+        // 补挂启动前登记的隐藏单元（死亡引用直接丢弃）
+        for (const ref of preStartHidden) {
+          const el = ref.deref();
+          if (el) handle.registerHidden(el);
+        }
+        preStartHidden.clear();
+        return handle;
+      },
       // #331: startObserver 返回句柄，stop 经句柄执行（幂等）
-      stop: (handle) => handle.stop(),
+      stop: (handle) => {
+        handle.stop();
+        observerHandle = null;
+      },
     });
 
     // ── 设置变更统一入口（#265）──
@@ -227,7 +257,7 @@ export default defineContentScript({
 
       let targets: Element[];
       try {
-        targets = elements ?? collect(document.body, registerHidden);
+        targets = elements ?? collect(document.body, registerHiddenForObserver);
       } catch (e) {
         throw new Error(
           `[collect] ${e instanceof Error ? e.message : String(e)}`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.49",
+  "version": "2.0.50",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/dom/observer.ts
+++ b/src/dom/observer.ts
@@ -86,26 +86,6 @@ export interface ObserverHandle {
 }
 
 /**
- * 启动前登记缓冲（#331）—— 模块级 registerHidden 的语义收敛为
- * 「观察器尚未启动时的登记缓冲」：首轮整页翻译期间采集到的隐藏
- * 单元（collect 在观察器启动前执行）先入此缓冲，观察器启动时
- * 消费并补挂观察（关键语义点：采集期间的登记不丢失）。
- * 元素以 WeakRef 持有（#330：离开 DOM 后仅剩弱引用）。
- */
-let preStartHidden: Set<WeakRef<Element>> | null = null;
-
-/**
- * 模块级隐藏单元登记（#331）—— 仅作启动前缓冲。
- * 观察器运行期间的登记一律走句柄（handle.registerHidden）；
- * 本函数由采集调用方（整页翻译的 collect）传入，观察器启动时
- * 由 startObserver 消费。
- */
-export function registerHidden(el: Element): void {
-  preStartHidden ??= new Set();
-  preStartHidden.add(new WeakRef(el));
-}
-
-/**
  * 启动增量补翻观察器，返回句柄（#331）。
  * 句柄提供停止与隐藏单元登记两项能力；隐藏单元集合、可见性观察
  * 实例、补翻回调三份状态全部随句柄创建与销毁，不再跨用例共享。
@@ -279,18 +259,9 @@ export function startObserver(
         threshold: 0,
       },
     );
-    // 消费启动前登记缓冲（#331 关键语义点：首轮整页翻译期间采集到
-    // 的隐藏单元在此补挂观察，采集期间的登记不丢失；死亡引用丢弃）
-    if (preStartHidden) {
-      for (const ref of preStartHidden) {
-        const el = ref.deref();
-        if (el && !hiddenSeen.has(el)) {
-          hiddenSeen.add(el);
-          io.observe(el);
-        }
-      }
-      preStartHidden = null;
-    }
+    // 启动前登记的缓冲由采集调用方（content）持有，句柄创建后经
+    // handle.registerHidden 补挂（#332）—— 首轮整页翻译期间采集
+    // 到的隐藏单元因此不丢失，此处不再有模块级登记
   }
 
   // #23：启动 IntersectionObserver，监听初次采集时因 display:none 被跳过的元素


### PR DESCRIPTION
## 问题

采集调用方（content）从模块顶层导入隐藏单元登记函数，登记能力与观察器实例脱钩。

## 根因

句柄化（#331）后登记能力属于观察器句柄，但整页翻译的 collect 先于观察器启动，调用方仍走模块级全局函数。

## 修复

模块顶层不再导出登记函数；content 自持启动前登记缓冲（WeakRef），观察器句柄创建时补挂——首轮翻译期间采集的隐藏单元不丢失；采集模块 interface 与生命周期注册表接线不变。

## 验证

`pnpm typecheck` 通过；观察器单测更新为纯句柄语义（补挂、停止清理、多句柄互不可见），`pnpm test` 602 个用例全部通过；`pnpm test:e2e:core` 34 个用例通过；`pnpm build` 正常。

Closes #332
