### PR TITLE
编排模块注入设置类型收紧 (fix #310)

### DIFF
--- a/docs/testing/unit/orchestration/orchestrator.test.ts
+++ b/docs/testing/unit/orchestration/orchestrator.test.ts
@@ -12,6 +12,7 @@ import {
 } from '~/src/orchestration/orchestrator';
 import type { TranslateItem } from '~/src/orchestration/orchestrator';
 import type { TranslateRequest } from '~/src/engines/types';
+import type { Settings } from '~/src/storage/schema';
 
 /** 冲刷微任务 + 一个宏任务，让异步链（send → retry → 回调）完整推进。 */
 async function flush(): Promise<void> {
@@ -247,9 +248,10 @@ describe('epoch 中止语义（#262）', () => {
 
 describe('设置变更订阅（#265）', () => {
   test('start 订阅设置变更、stop 退订；回调转发 onSettingsChange', async () => {
-    let handler: ((s: unknown) => void) | null = null;
+    // #310: 订阅回调类型收紧为真实 Settings（断言与行为不变）
+    let handler: ((s: Settings) => void) | null = null;
     let unsubscribed = false;
-    const seen: unknown[] = [];
+    const seen: Settings[] = [];
     const send = vi.fn(async () => ({ ok: true, data: { translations: [] } }));
 
     const orch = createOrchestrator({
@@ -266,7 +268,7 @@ describe('设置变更订阅（#265）', () => {
     orch.start();
     expect(handler).not.toBeNull();
 
-    handler!({ style: 'bold' });
+    handler!({ style: 'bold' } as Settings);
     expect(seen).toEqual([{ style: 'bold' }]);
 
     orch.stop();

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -215,9 +215,12 @@ export default defineContentScript({
     const orchestrator = createOrchestrator({
       send: translateViaBackground,
       // #265: 设置变更订阅由模块持有（start 订阅 / stop 退订），
-      // 响应走统一入口 applySettings（初始化与变更共用）
+      // 响应走统一入口 applySettings（初始化与变更共用）。
+      // #310: 载荷类型收紧为真实 Settings，此处不再需要强制转型
       subscribeSettings: onSettingsChanged,
-      onSettingsChange: (ns) => applySettings(ns as Settings),
+      onSettingsChange: (ns) => applySettings(ns),
+      // #310: 读取当前设置经注入项提供，模块自身不直接访问存储
+      getSettings,
       onBatchResult: (_i, batch, result) => {
         if (!result.ok || !result.data) return;
         const translations = result.data.translations;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.50",
+  "version": "2.0.51",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/orchestration/orchestrator.ts
+++ b/src/orchestration/orchestrator.ts
@@ -15,6 +15,7 @@ import type {
   TranslateResponse,
   FailureCategory,
 } from '~/src/engines/types';
+import type { Settings } from '~/src/storage/schema';
 import { attemptBatchWithRetry } from '~/src/runtime/batch-retry';
 import { sleep as defaultSleep } from '~/src/runtime/sleep';
 
@@ -92,10 +93,16 @@ export interface OrchestratorOptions {
   /**
    * 设置变更订阅注入（#265）：content 传 storage 的 onSettingsChanged；
    * 模块在 start 时订阅、stop 时退订。
+   * #310：回调携带真实设置类型，装配方不再需要强制转型。
    */
-  subscribeSettings?: (fn: (s: unknown) => void) => () => void;
+  subscribeSettings?: (fn: (s: Settings) => void) => () => void;
   /** 设置变更响应（#265）：样式应用与 UI 启停由调用方实现（经注册表）。 */
-  onSettingsChange?: (s: unknown) => void;
+  onSettingsChange?: (s: Settings) => void;
+  /**
+   * 读取当前设置（#310）：模块自身不直接访问存储 ——
+   * 准入判定等后续逻辑经此注入读取，装配方注入 storage 的 getSettings。
+   */
+  getSettings?: () => Settings;
 }
 
 /**


### PR DESCRIPTION
## 问题

编排模块的设置变更订阅与响应载荷类型标为 unknown，装配方要强制转型才能使用。

## 根因

注入项类型未收敛到真实设置类型，模块内部也没有读取当前设置的途径。

## 修复

订阅与响应注入项收紧为真实 `Settings` 类型，装配方不再需要强制转型；新增「读取当前设置」注入项（`getSettings`），模块自身不直接访问存储，为准入判定迁入做准备。

## 验证

`pnpm typecheck` 通过；编排单测 15 个全部通过（既有用例仅类型注解随接口收紧，断言与行为不变），`pnpm test` 602 个用例全部通过；`pnpm build` 正常。

Closes #310
