### PR TITLE
准入判定迁入编排模块 (fix #311)

### DIFF
--- a/docs/testing/unit/orchestration/orchestrator.test.ts
+++ b/docs/testing/unit/orchestration/orchestrator.test.ts
@@ -13,6 +13,7 @@ import {
 import type { TranslateItem } from '~/src/orchestration/orchestrator';
 import type { TranslateRequest } from '~/src/engines/types';
 import type { Settings } from '~/src/storage/schema';
+import { DEFAULT_SETTINGS } from '~/src/storage/schema';
 
 /** 冲刷微任务 + 一个宏任务，让异步链（send → retry → 回调）完整推进。 */
 async function flush(): Promise<void> {
@@ -282,5 +283,89 @@ describe('设置变更订阅（#265）', () => {
       orch.start();
       orch.stop();
     }).not.toThrow();
+  });
+});
+
+
+describe('准入判定（#311）', () => {
+  const settings = (patch: Partial<Settings>): Settings => ({
+    ...DEFAULT_SETTINGS,
+    ...patch,
+  });
+
+  test('黑名单命中：零请求并返回 blocked', async () => {
+    const send = vi.fn(async () => ({ ok: true, data: { translations: [] } }));
+    const orch = createOrchestrator({
+      send,
+      getSettings: () =>
+        settings({
+          enabled: true,
+          siteList: { mode: 'blacklist', list: ['example.com'] },
+        }),
+      getHostname: () => 'www.example.com',
+    });
+    orch.start();
+    const summary = await orch.translatePage(items(2), 'en', 'zh-CN');
+    expect(send).not.toHaveBeenCalled();
+    expect(summary.admission).toBe('blocked');
+    orch.stop();
+  });
+
+  test('白名单未命中：零请求并返回 blocked', async () => {
+    const send = vi.fn(async () => ({ ok: true, data: { translations: [] } }));
+    const orch = createOrchestrator({
+      send,
+      getSettings: () =>
+        settings({
+          enabled: true,
+          siteList: { mode: 'whitelist', list: ['example.com'] },
+        }),
+      getHostname: () => 'other.example.org',
+    });
+    orch.start();
+    const summary = await orch.translatePage(items(2), 'en', 'zh-CN');
+    expect(send).not.toHaveBeenCalled();
+    expect(summary.admission).toBe('blocked');
+    orch.stop();
+  });
+
+  test('总开关关闭：零请求并返回 disabled', async () => {
+    const send = vi.fn(async () => ({ ok: true, data: { translations: [] } }));
+    const orch = createOrchestrator({
+      send,
+      getSettings: () =>
+        settings({ enabled: false, siteList: { mode: 'blacklist', list: [] } }),
+      getHostname: () => 'example.com',
+    });
+    orch.start();
+    const summary = await orch.translatePage(items(2), 'en', 'zh-CN');
+    expect(send).not.toHaveBeenCalled();
+    expect(summary.admission).toBe('disabled');
+    orch.stop();
+  });
+
+  test('准入放行：正常发送并返回 allowed', async () => {
+    const send = vi.fn(async () => ({ ok: true, data: { translations: [] } }));
+    const orch = createOrchestrator({
+      send,
+      getSettings: () =>
+        settings({ enabled: true, siteList: { mode: 'blacklist', list: [] } }),
+      getHostname: () => 'example.com',
+    });
+    orch.start();
+    const summary = await orch.translatePage(items(2), 'en', 'zh-CN');
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(summary.admission).toBe('allowed');
+    orch.stop();
+  });
+
+  test('未注入设置读取 / 主机名 → 放行（兼容旧装配）', async () => {
+    const send = vi.fn(async () => ({ ok: true, data: { translations: [] } }));
+    const orch = createOrchestrator({ send });
+    orch.start();
+    const summary = await orch.translatePage(items(1), 'en', 'zh-CN');
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(summary.admission).toBe('allowed');
+    orch.stop();
   });
 });

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -219,8 +219,10 @@ export default defineContentScript({
       // #310: 载荷类型收紧为真实 Settings，此处不再需要强制转型
       subscribeSettings: onSettingsChanged,
       onSettingsChange: (ns) => applySettings(ns),
-      // #310: 读取当前设置经注入项提供，模块自身不直接访问存储
+      // #310: 读取当前设置经注入项提供，模块自身不直接访问存储；
+      // #311: 准入判定的当前主机名同样经注入提供
       getSettings,
+      getHostname: () => location.hostname,
       onBatchResult: (_i, batch, result) => {
         if (!result.ok || !result.data) return;
         const translations = result.data.translations;
@@ -254,9 +256,6 @@ export default defineContentScript({
       elements?: Element[],
     ): Promise<string> {
       const ns = getSettings();
-      if (!ns.enabled) return 'disabled';
-      // #153: 站点黑白名单 —— 黑名单命中或白名单未命中 → 整页不发请求
-      if (isSiteBlocked(location.hostname, ns.siteList)) return 'blocked';
 
       let targets: Element[];
       try {
@@ -296,8 +295,14 @@ export default defineContentScript({
 
       // #261/#262: 全页翻译经编排模块执行 —— 批次拆分（15/批）、有界
       // 重试、失效全局短路、epoch 中止、渐进渲染回调都在模块内；
-      // 还原（doRestore → orchestrator.abort()）自动中止在途批次
+      // 还原（doRestore → orchestrator.abort()）自动中止在途批次。
+      // #311: 准入判定（总开关 / 站点名单）也在模块内 —— 拦截时
+      // 零请求，结构化状态说明原因
       const summary = await orchestrator.translatePage(items, ns.from, ns.to);
+
+      // #311: 准入拦截 —— 不发请求、不弹错误提示，返回结构化状态
+      if (summary.admission === 'disabled') return 'disabled';
+      if (summary.admission === 'blocked') return 'blocked';
 
       // #157: 还原发生在翻译进行中 —— 批次被中止不是失败：
       // 不弹“所有引擎均失败”、状态置 aborted（悬浮球回 idle、

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.51",
+  "version": "2.0.52",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/orchestration/orchestrator.ts
+++ b/src/orchestration/orchestrator.ts
@@ -16,6 +16,7 @@ import type {
   FailureCategory,
 } from '~/src/engines/types';
 import type { Settings } from '~/src/storage/schema';
+import { isSiteBlocked } from '~/src/dom/site-filter';
 import { attemptBatchWithRetry } from '~/src/runtime/batch-retry';
 import { sleep as defaultSleep } from '~/src/runtime/sleep';
 
@@ -44,6 +45,8 @@ export interface TranslateBatchResult {
 
 /** 全页翻译的批次结果汇总（#261）：content 据此映射页面状态。 */
 export interface PageTranslateSummary {
+  /** 准入结果（#311）：未通过准入时零请求，调用方据此映射状态与提示。 */
+  admission: Admission;
   /** 是否所有非中止批次均失败。 */
   allFailed: boolean;
   /** 是否有批次被中止（还原 / 导航）。 */
@@ -53,6 +56,14 @@ export interface PageTranslateSummary {
   /** 全失败时的致命原因（失效 / 类别化错误），供 toast 展示。 */
   fatalError: string | null;
 }
+
+/**
+ * 翻译入口准入结果（#311）—— 总开关与站点名单判定：
+ *   - allowed：放行
+ *   - disabled：总开关关闭，不发请求
+ *   - blocked：站点在黑名单中（或白名单未命中），不发请求
+ */
+export type Admission = 'allowed' | 'disabled' | 'blocked';
 
 /** 翻译编排模块 —— 小 interface：启动 / 停止 / 翻译入口（#221）。 */
 export interface TranslationOrchestrator {
@@ -103,6 +114,11 @@ export interface OrchestratorOptions {
    * 准入判定等后续逻辑经此注入读取，装配方注入 storage 的 getSettings。
    */
   getSettings?: () => Settings;
+  /**
+   * 读取当前主机名（#311）：准入判定经此注入取得页面地址，
+   * 模块不直接访问 location。
+   */
+  getHostname?: () => string;
 }
 
 /**
@@ -155,6 +171,20 @@ export function createOrchestrator(opts: OrchestratorOptions): TranslationOrches
 
     async translatePage(items, from, to): Promise<PageTranslateSummary> {
       if (!started) throw new Error('[PT] 编排未启动');
+
+      // #311: 准入判定是翻译入口的前置步骤 —— 总开关关闭或站点被
+      // 名单禁用时零请求，以结构化状态说明拦截原因
+      const admission = admissionFrom(opts);
+      if (admission !== 'allowed') {
+        return {
+          admission,
+          allFailed: false,
+          aborted: false,
+          invalidated: false,
+          fatalError: null,
+        };
+      }
+
       const epochAtStart = epoch;
       // 批次拆分（#245）：与现状一致，每批独立发送
       const batches = splitBatches(items, batchSize);
@@ -225,7 +255,26 @@ export function createOrchestrator(opts: OrchestratorOptions): TranslationOrches
       // #157: 还原恰在最后一批与返回之间发生 —— 也报 aborted
       if (isAborted()) aborted = true;
 
-      return { allFailed, aborted, invalidated, fatalError };
+      return {
+        admission: 'allowed',
+        allFailed,
+        aborted,
+        invalidated,
+        fatalError,
+      };
     },
   };
+}
+
+/**
+ * 准入判定（#311）—— 总开关 + 站点黑白名单，发生在任何请求之前。
+ * 当前主机名经注入提供（getHostname），模块不直接访问页面地址。
+ */
+function admissionFrom(opts: OrchestratorOptions): Admission {
+  const s = opts.getSettings?.();
+  if (!s) return 'allowed';
+  if (!s.enabled) return 'disabled';
+  const host = opts.getHostname?.() ?? '';
+  if (isSiteBlocked(host, s.siteList)) return 'blocked';
+  return 'allowed';
 }


### PR DESCRIPTION
## 问题

「总开关是否开启」「站点是否在名单中被禁用」两条准入规则在内容脚本里，整页翻译入口各自检查，拦截原因没有结构化表达。

## 根因

准入判定不属于内容脚本职责，也没有与翻译入口绑定。

## 修复

准入判定迁入编排模块，成为整页翻译入口的前置步骤：拦截时零请求，`PageTranslateSummary` 新增 `admission` 结构化状态（allowed / disabled / blocked）；当前主机名经 `getHostname` 注入提供，模块不直接访问页面地址；内容脚本删除自建检查，消费模块返回的状态。

## 验证

`pnpm typecheck` 通过；新增 5 个准入单测（黑名单/白名单未命中/总开关关闭零请求、放行正常发送、未注入兼容），`pnpm test` 607 个用例全部通过；既有安全端到端用例（SEC-04/05/06 黑名单白名单零请求）通过；`pnpm test:e2e:core` 34 个用例通过。

Closes #311
