### PR TITLE
单文本翻译入口 (fix #312)

### DIFF
--- a/docs/testing/unit/orchestration/orchestrator.test.ts
+++ b/docs/testing/unit/orchestration/orchestrator.test.ts
@@ -369,3 +369,106 @@ describe('准入判定（#311）', () => {
     orch.stop();
   });
 });
+
+describe('单文本翻译入口（#312）', () => {
+  const settings = (patch: Partial<Settings>): Settings => ({
+    ...DEFAULT_SETTINGS,
+    ...patch,
+  });
+
+  test('成功时返回译文，且译文未被改写（逐字透传）', async () => {
+    const send = vi.fn(async () => ({
+      ok: true,
+      data: { translations: ['  你好，世界！  '] },
+    }));
+    const orch = createOrchestrator({ send });
+    orch.start();
+
+    const result = await orch.translateText('Hello, World!', 'en', 'zh-CN');
+
+    expect(result.ok).toBe(true);
+    expect(result.translation).toBe('  你好，世界！  ');
+    expect(send).toHaveBeenCalledWith({
+      texts: ['Hello, World!'],
+      from: 'en',
+      to: 'zh-CN',
+    });
+    orch.stop();
+  });
+
+  test('站点被屏蔽：零请求并返回 blocked', async () => {
+    const send = vi.fn(async () => ({ ok: true, data: { translations: [] } }));
+    const orch = createOrchestrator({
+      send,
+      getSettings: () =>
+        settings({
+          enabled: true,
+          siteList: { mode: 'blacklist', list: ['example.com'] },
+        }),
+      getHostname: () => 'example.com',
+    });
+    orch.start();
+
+    const result = await orch.translateText('Hello', 'en', 'zh-CN');
+
+    expect(send).not.toHaveBeenCalled();
+    expect(result.admission).toBe('blocked');
+    expect(result.ok).toBe(false);
+    orch.stop();
+  });
+
+  test('总开关关闭：零请求并返回 disabled', async () => {
+    const send = vi.fn(async () => ({ ok: true, data: { translations: [] } }));
+    const orch = createOrchestrator({
+      send,
+      getSettings: () =>
+        settings({ enabled: false, siteList: { mode: 'blacklist', list: [] } }),
+      getHostname: () => 'example.com',
+    });
+    orch.start();
+
+    const result = await orch.translateText('Hello', 'en', 'zh-CN');
+
+    expect(send).not.toHaveBeenCalled();
+    expect(result.admission).toBe('disabled');
+    expect(result.ok).toBe(false);
+    orch.stop();
+  });
+
+  test('失败时携带类别与原因', async () => {
+    const send = vi.fn(async () => ({
+      ok: false,
+      category: 'invalid-key',
+      error: 'API key 无效',
+      retryable: false,
+    }));
+    const orch = createOrchestrator({ send });
+    orch.start();
+
+    const result = await orch.translateText('Hello', 'en', 'zh-CN');
+
+    expect(result.ok).toBe(false);
+    expect(result.category).toBe('invalid-key');
+    expect(result.error).toBe('API key 无效');
+    orch.stop();
+  });
+
+  test('在飞期间被中止（还原递增纪元）→ 不返回译文', async () => {
+    let resolveSend!: (v: unknown) => void;
+    const send = vi.fn(
+      () => new Promise((r) => (resolveSend = r)),
+    );
+    const orch = createOrchestrator({ send });
+    orch.start();
+
+    const pending = orch.translateText('Hello', 'en', 'zh-CN');
+    orch.abort(); // 还原：递增纪元
+    resolveSend({ ok: true, data: { translations: ['你好'] } });
+
+    const result = await pending;
+    expect(result.ok).toBe(false);
+    expect(result.category).toBe('aborted');
+    expect(result.translation).toBeUndefined();
+    orch.stop();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.52",
+  "version": "2.0.53",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/orchestration/orchestrator.ts
+++ b/src/orchestration/orchestrator.ts
@@ -65,6 +65,20 @@ export interface PageTranslateSummary {
  */
 export type Admission = 'allowed' | 'disabled' | 'blocked';
 
+/** 单文本翻译结果（#312）—— 逐段翻译 / 划词翻译共用。 */
+export interface SingleTextResult {
+  /** 准入结果：未通过准入时零请求。 */
+  admission: Admission;
+  /** 是否成功。 */
+  ok: boolean;
+  /** 译文（成功时）—— 引擎结果逐字透传，模块不改写。 */
+  translation?: string;
+  /** 失败类别（失败时，#313 据此决定提示语义）。 */
+  category?: FailureCategory;
+  /** 失败原因文本（key 无效 / 配额等展示真实原因用）。 */
+  error?: string;
+}
+
 /** 翻译编排模块 —— 小 interface：启动 / 停止 / 翻译入口（#221）。 */
 export interface TranslationOrchestrator {
   /** 启动编排（设置变更响应等初始化）。 */
@@ -86,6 +100,16 @@ export interface TranslationOrchestrator {
     from: string,
     to: string,
   ): Promise<PageTranslateSummary>;
+  /**
+   * 单文本翻译入口（#312）—— 供逐段翻译与划词翻译使用。
+   * 复用整页入口的准入判定（#311）：站点被屏蔽、总开关关闭均零请求；
+   * 成功时返回译文（引擎结果逐字透传，模块不改写）。
+   */
+  translateText(
+    text: string,
+    from: string,
+    to: string,
+  ): Promise<SingleTextResult>;
 }
 
 export interface OrchestratorOptions {
@@ -261,6 +285,42 @@ export function createOrchestrator(opts: OrchestratorOptions): TranslationOrches
         aborted,
         invalidated,
         fatalError,
+      };
+    },
+
+    async translateText(text, from, to): Promise<SingleTextResult> {
+      if (!started) throw new Error('[PT] 编排未启动');
+
+      // #311: 与整页入口同一份准入判定 —— 拦截时零请求
+      const admission = admissionFrom(opts);
+      if (admission !== 'allowed') return { admission, ok: false };
+
+      // 单文本单请求，与整页入口共用注入的消息层（#312）
+      const epochAtStart = epoch;
+      const result = (await opts.send({
+        texts: [text],
+        from,
+        to,
+      })) as TranslateBatchResult;
+
+      // 在飞期间被中止（还原递增纪元）—— 不返回译文
+      if (epoch !== epochAtStart) {
+        return { admission, ok: false, category: 'aborted' };
+      }
+
+      if (result.ok) {
+        // 译文逐字透传引擎结果，模块不改写（#312）
+        return {
+          admission,
+          ok: true,
+          translation: result.data?.translations?.[0],
+        };
+      }
+      return {
+        admission,
+        ok: false,
+        category: result.category,
+        error: result.error,
       };
     },
   };


### PR DESCRIPTION
## 问题

逐段翻译与划词翻译直连消息通道，准入判定与失败处理各写一份。

## 根因

缺少供单文本路径使用的编排入口，无法复用整页入口的准入与消息层。

## 修复

编排模块新增 `translateText` 单文本入口：复用整页入口的准入判定（站点被屏蔽、总开关关闭均零请求并返回结构化状态），成功时逐字透传引擎译文（模块不改写），失败时携带类别与原因；经注入的假消息层可完整测试，无需 DOM 环境；整页入口行为不变。

## 验证

`pnpm typecheck` 通过；新增 5 个单文本入口单测（成功透传、屏蔽/禁用零请求、失败类别与原因、在飞中止不返回译文），`pnpm test` 612 个用例全部通过；`pnpm build` 正常。

Closes #312
