### PR TITLE
失败类别到提示语义的映射迁入 (fix #313)

### DIFF
--- a/docs/testing/unit/orchestration/orchestrator.test.ts
+++ b/docs/testing/unit/orchestration/orchestrator.test.ts
@@ -8,6 +8,7 @@ import { describe, test, expect, vi } from 'vitest';
 import {
   createOrchestrator,
   splitBatches,
+  displayDecision,
   FULL_PAGE_BATCH_SIZE,
 } from '~/src/orchestration/orchestrator';
 import type { TranslateItem } from '~/src/orchestration/orchestrator';
@@ -470,5 +471,120 @@ describe('单文本翻译入口（#312）', () => {
     expect(result.category).toBe('aborted');
     expect(result.translation).toBeUndefined();
     orch.stop();
+  });
+});
+
+describe('失败提示语义映射（#313）', () => {
+  test('单文本：key 无效 → 展示真实原因并携带引擎原因文本', async () => {
+    const send = vi.fn(async () => ({
+      ok: false,
+      category: 'invalid-key',
+      error: 'API key 无效',
+      retryable: false,
+    }));
+    const orch = createOrchestrator({ send });
+    orch.start();
+
+    const result = await orch.translateText('Hello', 'en', 'zh-CN');
+
+    expect(result.ok).toBe(false);
+    expect(result.display).toEqual({
+      showRealReason: true,
+      reason: 'API key 无效',
+    });
+    orch.stop();
+  });
+
+  test('单文本：配额耗尽 → 展示真实原因并携带引擎原因文本', async () => {
+    const send = vi.fn(async () => ({
+      ok: false,
+      category: 'quota',
+      error: '配额已用尽',
+      retryable: false,
+      invalidated: true,
+    }));
+    const orch = createOrchestrator({ send });
+    orch.start();
+
+    const result = await orch.translateText('Hello', 'en', 'zh-CN');
+
+    expect(result.ok).toBe(false);
+    expect(result.display).toEqual({
+      showRealReason: true,
+      reason: '配额已用尽',
+    });
+    orch.stop();
+  });
+
+  test('单文本：瞬时故障 → 泛化文案', async () => {
+    const send = vi.fn(async () => ({
+      ok: false,
+      category: 'transient',
+      error: 'HTTP 503',
+      retryable: true,
+    }));
+    const orch = createOrchestrator({ send });
+    orch.start();
+
+    const result = await orch.translateText('Hello', 'en', 'zh-CN');
+
+    expect(result.ok).toBe(false);
+    expect(result.display).toEqual({ showRealReason: false });
+    orch.stop();
+  });
+
+  test('整页：全部引擎 key 无效 → 汇总展示真实原因', async () => {
+    const send = vi.fn(async () => ({
+      ok: false,
+      category: 'invalid-key',
+      error: 'API key 无效',
+      retryable: false,
+    }));
+    const orch = createOrchestrator({ send });
+    orch.start();
+
+    const summary = await orch.translatePage(items(2), 'en', 'zh-CN');
+
+    expect(summary.allFailed).toBe(true);
+    expect(summary.display).toEqual({
+      showRealReason: true,
+      reason: 'API key 无效',
+    });
+    orch.stop();
+  });
+
+  test('整页：瞬时故障 → 泛化文案', async () => {
+    const send = vi.fn(async () => ({
+      ok: false,
+      category: 'transient',
+      error: 'HTTP 503',
+      retryable: true,
+    }));
+    const orch = createOrchestrator({ send });
+    orch.start();
+
+    const summary = await orch.translatePage(items(2), 'en', 'zh-CN');
+
+    expect(summary.allFailed).toBe(true);
+    expect(summary.display).toEqual({ showRealReason: false });
+    orch.stop();
+  });
+
+  test('整页与单文本共用同一份映射（displayDecision 模块级单测）', () => {
+    // 同一份映射函数被两个入口共用（#313）
+    expect(displayDecision('invalid-key', 'API key 无效')).toEqual({
+      showRealReason: true,
+      reason: 'API key 无效',
+    });
+    expect(displayDecision('quota', '配额已用尽')).toEqual({
+      showRealReason: true,
+      reason: '配额已用尽',
+    });
+    expect(displayDecision('transient', 'HTTP 503')).toEqual({
+      showRealReason: false,
+    });
+    expect(displayDecision(undefined, undefined)).toEqual({
+      showRealReason: false,
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.53",
+  "version": "2.0.54",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",

--- a/src/orchestration/orchestrator.ts
+++ b/src/orchestration/orchestrator.ts
@@ -55,6 +55,8 @@ export interface PageTranslateSummary {
   invalidated: boolean;
   /** 全失败时的致命原因（失效 / 类别化错误），供 toast 展示。 */
   fatalError: string | null;
+  /** 提示语义（#313）：全失败时展示真实原因还是泛化文案。 */
+  display: FailureDisplay;
 }
 
 /**
@@ -73,10 +75,38 @@ export interface SingleTextResult {
   ok: boolean;
   /** 译文（成功时）—— 引擎结果逐字透传，模块不改写。 */
   translation?: string;
-  /** 失败类别（失败时，#313 据此决定提示语义）。 */
+  /** 失败类别（失败时）。 */
   category?: FailureCategory;
-  /** 失败原因文本（key 无效 / 配额等展示真实原因用）。 */
+  /** 失败原因文本（引擎给出的真实原因）。 */
   error?: string;
+  /** 提示语义（#313）：失败时展示真实原因还是泛化文案。 */
+  display?: FailureDisplay;
+}
+
+/**
+ * 失败提示语义（#313）——「展示引擎给出的真实原因，还是展示泛化文案」
+ * 的决定由失败类别映射，在模块内构造一次，整页与单文本入口共用。
+ * 模块不触碰任何 UI，提示的渲染仍由调用方完成。
+ */
+export interface FailureDisplay {
+  /** true：展示真实原因（key 无效 / 配额耗尽）；false：展示泛化文案（瞬时）。 */
+  showRealReason: boolean;
+  /** 引擎给出的原因文本（showRealReason=true 时）。 */
+  reason?: string;
+}
+
+/**
+ * 失败类别 → 提示语义映射（#313）。
+ * key 无效 / 配额耗尽 → 展示真实原因；瞬时故障 → 泛化文案。
+ */
+export function displayDecision(
+  category: FailureCategory | undefined,
+  error: string | undefined,
+): FailureDisplay {
+  if (category === 'invalid-key' || category === 'quota') {
+    return { showRealReason: true, reason: error };
+  }
+  return { showRealReason: false };
 }
 
 /** 翻译编排模块 —— 小 interface：启动 / 停止 / 翻译入口（#221）。 */
@@ -206,6 +236,7 @@ export function createOrchestrator(opts: OrchestratorOptions): TranslationOrches
           aborted: false,
           invalidated: false,
           fatalError: null,
+          display: { showRealReason: false },
         };
       }
 
@@ -218,6 +249,8 @@ export function createOrchestrator(opts: OrchestratorOptions): TranslationOrches
       // #111/#247: 失效 / 类别化致命原因 —— 全失败时优先展示
       let invalidated = false;
       let fatalError: string | null = null;
+      // #313: 真实原因提示决策（key 无效 / 配额 → 展示真实原因）
+      let realReason: string | null = null;
 
       // #262: 中止谓词 —— 还原（abort 递增纪元）或他批已判失效
       const isAborted = (): boolean =>
@@ -262,12 +295,12 @@ export function createOrchestrator(opts: OrchestratorOptions): TranslationOrches
               invalidated = true;
               fatalError = result.error;
             }
-            // #247: 类别化致命原因 —— key 无效 / 配额失效展示真实原因
-            if (
-              result.category === 'invalid-key' ||
-              result.category === 'quota'
-            ) {
+            // #313: 提示语义映射（整页与单文本共用同一份）——
+            // key 无效 / 配额耗尽展示真实原因，瞬时故障展示泛化文案
+            const decision = displayDecision(result.category, result.error);
+            if (decision.showRealReason) {
               fatalError = result.error;
+              realReason = decision.reason ?? result.error ?? null;
             }
           }
 
@@ -285,6 +318,11 @@ export function createOrchestrator(opts: OrchestratorOptions): TranslationOrches
         aborted,
         invalidated,
         fatalError,
+        // #313: 全失败时是否展示真实原因（失效原因也算真实原因）
+        display:
+          realReason || (invalidated ? fatalError : null)
+            ? { showRealReason: true, reason: realReason ?? fatalError ?? undefined }
+            : { showRealReason: false },
       };
     },
 
@@ -321,6 +359,8 @@ export function createOrchestrator(opts: OrchestratorOptions): TranslationOrches
         ok: false,
         category: result.category,
         error: result.error,
+        // #313: 失败提示语义由类别映射（与整页入口同一份）
+        display: displayDecision(result.category, result.error),
       };
     },
   };


### PR DESCRIPTION
## 问题

「展示引擎给出的真实原因，还是展示泛化文案」的决定在内容脚本的逐段翻译与划词翻译两条路径里各写一遍。

## 根因

失败类别的提示语义映射没有收敛到编排模块。

## 修复

新增 `displayDecision` 映射（key 无效 / 配额耗尽 → 展示真实原因并携带引擎原因文本；瞬时故障 → 泛化文案），整页入口与单文本入口共用同一份；`SingleTextResult` 与 `PageTranslateSummary` 携带 `display` 结构化决策，模块不调用任何 UI 函数。

## 验证

`pnpm typecheck` 通过；新增 6 个提示语义单测（单文本/整页的 key 无效、配额、瞬时，及 displayDecision 模块级用例），`pnpm test` 618 个用例全部通过；`pnpm build` 正常。

Closes #313
