### PR TITLE
划词翻译走编排入口 (fix #315)

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -21,7 +21,6 @@ import { startObserver, type ObserverHandle } from '~/src/dom/observer';
 import { walkShadowTree } from '~/src/dom/shadow-walk';
 import { render, unrender, applyMode, applyStyle } from '~/src/dom/renderer';
 import { unsplitPre } from '~/src/dom/pre-split';
-import { isSiteBlocked } from '~/src/dom/site-filter';
 import { applyCustomCss } from '~/src/styles/custom';
 import { createBall, setBallState } from '~/src/ui/floating-ball';
 import { createParaBtn } from '~/src/ui/paragraph-btn';
@@ -518,32 +517,31 @@ export default defineContentScript({
     async function translateSelection(text: string): Promise<void> {
       // 跨行划词时选区文本天然带 \n，入口归一化
       text = normalizeText(text);
+
+      // #315: 划词翻译走编排模块的单文本入口 —— 与逐段翻译共用
+      // 同一份准入判定与失败提示语义，不再直连消息通道
       const ns = getSettings();
-      if (!ns.enabled) return;
-      // #153: 站点名单拦截划词翻译
-      if (isSiteBlocked(location.hostname, ns.siteList)) {
-        toast(tf('toastSiteBlocked', '该站点已在站点名单中被禁用翻译'), 'error');
+      const result = await orchestrator.translateText(text, ns.from, ns.to);
+
+      // 准入拦截：与逐段 / 整页翻译一致的提示
+      if (result.admission === 'blocked') {
+        if (isMainFrame)
+          toast(tf('toastSiteBlocked', '该站点已在站点名单中被禁用翻译'), 'error');
         return;
       }
+      if (result.admission !== 'allowed') return;
 
-      const resp = await translateViaBackground({
-        texts: [text],
-        from: ns.from,
-        to: ns.to,
-      });
-
-      if (!resp?.ok) {
-        // #247: 按类型化类别给出提示分支 —— key 无效 / 配额失效展示
-        // 真实原因；瞬时故障保持现有泛化文案
-        if (resp.category === 'invalid-key' || resp.category === 'quota') {
-          toast(resp.error, 'error');
+      if (!result.ok) {
+        // #313: key 无效 / 配额展示真实原因，瞬时故障展示泛化文案
+        if (result.display?.showRealReason && result.error) {
+          toast(result.error, 'error');
         } else {
           toast(tf('toastTranslateFail', '翻译失败'), 'error');
         }
         return;
       }
 
-      toast(resp.data.translations[0]!);
+      toast(result.translation!);
     }
 
     // ── 监听 popup / background 消息 ──

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.55",
+  "version": "2.0.56",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## 问题

划词翻译直连消息通道，准入检查与失败分支与逐段翻译此前逐字相同。

## 根因

划词翻译没有切换到编排模块的单文本入口。

## 修复

划词翻译改走与逐段翻译同一个 `translateText` 单文本入口：准入与失败提示行为完全一致（站点被屏蔽 toast、key 无效 / 配额真实原因、瞬时泛化文案），删除自持的准入检查与失败分支；选区文本的入口归一化行为不变。

## 验证

`pnpm typecheck` 通过；`pnpm test` 618 个用例全部通过；`pnpm test:e2e:core` 34 个用例通过；`pnpm build` 正常。

Closes #315
