### PR TITLE
整页路径准入去重与 content 收尾 (fix #316)

### DIFF
--- a/docs/testing/unit/orchestration/orchestrator.test.ts
+++ b/docs/testing/unit/orchestration/orchestrator.test.ts
@@ -588,3 +588,37 @@ describe('失败提示语义映射（#313）', () => {
     });
   });
 });
+
+describe('跨三条路径的失败提示契约（#316）', () => {
+  // 三条翻译路径（整页 / 逐段 / 划词）最终都消费编排模块的
+  // display 决策；本契约断言两个模块入口对同一失败类别产出同一决策，
+  // 内容脚本侧只是渲染该决策（#313 边界：模块不触碰 UI）。
+  const CATEGORIES = ['invalid-key', 'quota', 'transient'] as const;
+
+  for (const category of CATEGORIES) {
+    test(`失败类别 ${category}：整页入口与单文本入口产出同一提示决策`, async () => {
+      const send = vi.fn(async () => ({
+        ok: false,
+        category,
+        error: '引擎给出的原因',
+        retryable: true,
+      }));
+      const orch = createOrchestrator({ send });
+      orch.start();
+
+      const page = await orch.translatePage(items(2), 'en', 'zh-CN');
+      const single = await orch.translateText('Hello', 'en', 'zh-CN');
+
+      expect(page.display).toEqual(single.display);
+      if (category === 'transient') {
+        expect(page.display).toEqual({ showRealReason: false });
+      } else {
+        expect(page.display).toEqual({
+          showRealReason: true,
+          reason: '引擎给出的原因',
+        });
+      }
+      orch.stop();
+    });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-translation",
-  "version": "2.0.56",
+  "version": "2.0.57",
   "description": "对照式网页翻译浏览器扩展",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## 问题

内容脚本残留被编排模块接管的准入检查，消息通道的调用方不唯一；三条翻译路径的失败提示决策没有契约保障。

## 根因

逐段与划词切换编排入口（#314/#315）后收尾工作缺失。

## 修复

确认 content 不再直连消息通道（`translateViaBackground` 仅作为编排模块的 send 注入）、无重复的总开关或站点名单检查；新增跨路径契约测试：同一失败类别在整页与单文本入口产出同一提示决策，内容脚本只渲染模块给出的决策。

## 验证

`pnpm typecheck` 通过；新增 3 个跨路径契约用例（invalid-key / quota / transient），`pnpm test` 621 个用例全部通过；`pnpm build` 正常。

Closes #316
