### PR TITLE
发布前修正：源码包瘦身与 Firefox manifest 版本说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 对照式网页翻译浏览器扩展。原文与译文并排呈现，让阅读外语内容不必在两个界面之间来回切换。
 
-Chrome / Edge / Firefox，Manifest V3，当前 v2.0。
+Chrome / Edge（Manifest V3）· Firefox（MV2），当前 v2.0。
 
 ## 特性
 

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -91,6 +91,13 @@ export default defineConfig({
       },
     }),
   }),
+  // Firefox 的 AMO 要求随扩展提交源码包，里面只需要能重现构建的东西。
+  // 默认规则会把整个仓库塞进去 —— 文档、商店截图、设计稿，以及
+  // docs/testing/logs/ 下每次跑测试都会重写的覆盖率与报告产物，
+  // 合计约 4.3MB，对复现构建毫无用处，还让审核者多下载 20 倍体积。
+  zip: {
+    excludeSources: ['docs/**', 'store/**', 'design/**'],
+  },
   vite: () => ({
     plugins: [blockTestFiles()],
   }),


### PR DESCRIPTION
两处发布前核对产物时发现的问题。#363 合并时第一个提交还没赶上，一并补进来。

## 源码包排除文档、商店素材与测试产物

Firefox 的 AMO 要求随扩展提交源码包。wxt 默认把整个仓库塞进去，实测 5.1MB 里有 4.3MB 是无关内容：

- `docs/testing/logs/` 下每次跑测试都会重写的覆盖率与 playwright 报告（单个 HTML 就 528KB）
- `store/screenshots/` 商店截图 1.6MB
- `design/` 设计稿

这些对复现构建毫无用处，只让审核者多下载 20 倍体积。加 `zip.excludeSources` 后降到 278KB，`src` / `entrypoints` / `public` / `scripts` / `patches` 与全部构建配置、README、LICENSE 均已核实仍在。

## README 更正 Firefox 的 manifest 版本

README 第 5 行把三个浏览器一并写作 Manifest V3。核对打包产物后发现只有 Chrome 与 Edge 是 mv3，Firefox 产物是 **mv2** —— WXT 对 Firefox 的默认目标，host 权限并入 `permissions`。已改为「Chrome / Edge（Manifest V3）· Firefox（MV2）」。

只动构建配置与文档，不影响扩展产物，版本号不变。